### PR TITLE
feat(testing): Initial tests

### DIFF
--- a/system/shadowdark.mjs
+++ b/system/shadowdark.mjs
@@ -9,6 +9,8 @@ import * as dice from "./src/dice/_module.mjs";
 import * as documents from "./src/documents/_module.mjs";
 import * as sheets from "./src/sheets/_module.mjs";
 
+import "./src/testing/index.mjs";
+
 /* -------------------------------------------- */
 /*  Define Module Structure                     */
 /* -------------------------------------------- */

--- a/system/src/documents/__tests__/documents-actor.test.mjs
+++ b/system/src/documents/__tests__/documents-actor.test.mjs
@@ -1,7 +1,6 @@
 /**
  * @file Contains tests for actor documents
  */
-
 import ActorSD from "../ActorSD.mjs";
 import { cleanUpActorsByKey } from "../../testing/testUtils.mjs";
 
@@ -11,15 +10,15 @@ export const options = {
 };
 
 const createMockActor = async type => {
-	ActorSD.create({
+	return ActorSD.create({
 		name: `Test Actor ${key}`,
 		type,
 	});
 };
 
-export default ({ describe, it, after, expect }) => {
-	after(async () => {
-		await cleanUpActorsByKey(key);
+export default ({ describe, it, after, before, expect }) => {
+	after(() => {
+		cleanUpActorsByKey(key);
 	});
 
 	describe("Actor creation", () => {
@@ -61,12 +60,16 @@ export default ({ describe, it, after, expect }) => {
 			20: 4,
 		};
 
+		before(async () => {
+			await createMockActor("Player");
+		});
+
 		Object.keys(modifiers).forEach(value => {
 			let modifier = modifiers[value];
 			describe(`${value} as value generates correct modifier`, () => {
 				abilities.forEach(ability => {
 					it(`for ${ability}`, async () => {
-						const actor = await await createMockActor("Player");
+						const actor = await game.actors.getName(`Test Actor ${key}`);
 						const updateData = {};
 						updateData[`system.abilities.${ability}.value`] = value;
 						await actor.update(updateData);
@@ -77,8 +80,8 @@ export default ({ describe, it, after, expect }) => {
 			});
 		});
 
-		after(async () => {
-			await cleanUpActorsByKey(key);
+		after(() => {
+			cleanUpActorsByKey(key);
 		});
 	});
 

--- a/system/src/documents/__tests__/documents-actor.test.mjs
+++ b/system/src/documents/__tests__/documents-actor.test.mjs
@@ -1,0 +1,89 @@
+/**
+ * @file Contains tests for actor documents
+ */
+
+import ActorSD from "../ActorSD.mjs";
+import { cleanUpActorsByKey } from "../../testing/testUtils.mjs";
+
+export const key = "shadowdark.documents.actor";
+export const options = {
+	displayName: "ShadowDark: Documents: Actor",
+};
+
+const createMockActor = async type => {
+	ActorSD.create({
+		name: `Test Actor ${key}`,
+		type,
+	});
+};
+
+export default ({ describe, it, after, before, expect }) => {
+	after(async () => {
+		await cleanUpActorsByKey(key);
+	});
+
+	describe("Actor creation", () => {
+		it("can create Player actor", async () => {
+			const actor = await createMockActor("Player");
+			expect(actor).is.not.undefined;
+			await actor.delete();
+		});
+
+		it("can create NPC actor", async () => {
+			const actor = await createMockActor("NPC");
+			expect(actor).is.not.undefined;
+			await actor.delete();
+		});
+	});
+
+	describe("abilityModifier(ability)", () => {
+		before(async () => {
+			await createMockActor("Player");
+		});
+
+		const abilities = ["str", "dex", "con", "int", "wis", "cha"];
+		const modifiers = {
+			1: -4,
+			2: -4,
+			3: -4,
+			4: -3,
+			5: -3,
+			6: -2,
+			7: -2,
+			8: -1,
+			9: -1,
+			10: 0,
+			11: 0,
+			12: 1,
+			13: 1,
+			14: 2,
+			15: 2,
+			16: 3,
+			17: 3,
+			18: 4,
+			19: 4,
+			20: 4,
+		};
+
+		Object.keys(modifiers).forEach(value => {
+			let modifier = modifiers[value];
+			describe(`${value} as value generates correct modifier`, () => {
+				abilities.forEach(ability => {
+					it(`for ${ability}`, async () => {
+						const actor = await game.actors.getName(`Test Actor ${key}`);
+						const updateData = {};
+						updateData[`system.abilities.${ability}.value`] = value;
+						await actor.update(updateData);
+
+						expect(actor.abilityModifier(ability)).equal(modifier);
+					});
+				});
+			});
+		});
+
+		after(async () => {
+			const actor = await game.actors.getName(`Test Actor ${key}`);
+			await actor.delete();
+		});
+	});
+};

--- a/system/src/documents/__tests__/documents-actor.test.mjs
+++ b/system/src/documents/__tests__/documents-actor.test.mjs
@@ -17,7 +17,7 @@ const createMockActor = async type => {
 	});
 };
 
-export default ({ describe, it, after, before, expect }) => {
+export default ({ describe, it, after, expect }) => {
 	after(async () => {
 		await cleanUpActorsByKey(key);
 	});
@@ -37,10 +37,6 @@ export default ({ describe, it, after, before, expect }) => {
 	});
 
 	describe("abilityModifier(ability)", () => {
-		before(async () => {
-			await createMockActor("Player");
-		});
-
 		const abilities = ["str", "dex", "con", "int", "wis", "cha"];
 		const modifiers = {
 			1: -4,
@@ -70,7 +66,7 @@ export default ({ describe, it, after, before, expect }) => {
 			describe(`${value} as value generates correct modifier`, () => {
 				abilities.forEach(ability => {
 					it(`for ${ability}`, async () => {
-						const actor = await game.actors.getName(`Test Actor ${key}`);
+						const actor = await await createMockActor("Player");
 						const updateData = {};
 						updateData[`system.abilities.${ability}.value`] = value;
 						await actor.update(updateData);
@@ -82,8 +78,33 @@ export default ({ describe, it, after, before, expect }) => {
 		});
 
 		after(async () => {
-			const actor = await game.actors.getName(`Test Actor ${key}`);
+			await cleanUpActorsByKey(key);
+		});
+	});
+
+	describe("numGearSlots()", () => {
+		it("returns default gearslots for NPC", async () => {
+			const actor = await createMockActor("NPC");
+			expect(actor.numGearSlots()).equal(CONFIG.SHADOWDARK.DEFAULTS.GEAR_SLOTS);
+			await actor.delete();
+		});
+
+		it("returns default gearslots for Player actor with lower str", async () => {
+			const actor = await createMockActor("Player");
+			await actor.update({"system.abilities.str.value": 3});
+			expect(actor.numGearSlots()).equal(CONFIG.SHADOWDARK.DEFAULTS.GEAR_SLOTS);
+			await actor.delete();
+		});
+
+		it("returns str gearslots when higher than default gearslots", async () => {
+			const actor = await createMockActor("Player");
+			await actor.update({
+				"system.abilities.str.value": CONFIG.SHADOWDARK.DEFAULTS.GEAR_SLOTS + 1,
+			});
+			expect(actor.numGearSlots()).equal(CONFIG.SHADOWDARK.DEFAULTS.GEAR_SLOTS + 1);
 			await actor.delete();
 		});
 	});
+
+	describe("rollAbility(abilityId, options={})", () => {});
 };

--- a/system/src/documents/__tests__/documents-actor.test.mjs
+++ b/system/src/documents/__tests__/documents-actor.test.mjs
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-expressions */
 /**
  * @file Contains tests for actor documents
  */

--- a/system/src/documents/__tests__/documents-item.test.mjs
+++ b/system/src/documents/__tests__/documents-item.test.mjs
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-expressions */
 /**
  * @file Contains tests for item documents
  */
@@ -34,7 +35,7 @@ export default ({ describe, it, after, expect }) => {
 	describe("_preCreate(data, options, user)", () => {
 		it("Gem type item has slots correctly configured", async () => {
 			const item = await createMockItem("Gem");
-			expect(item.system.slots.free_cary).equal(0);
+			expect(item.system.slots.free_carry).equal(0);
 			expect(CONFIG.SHADOWDARK.INVENTORY.GEMS_PER_SLOT).is.not.null;
 			expect(item.system.slots.per_slot).equal(CONFIG.SHADOWDARK.INVENTORY.GEMS_PER_SLOT);
 			expect(item.system.slots.slots_used).equal(1);

--- a/system/src/documents/__tests__/documents-item.test.mjs
+++ b/system/src/documents/__tests__/documents-item.test.mjs
@@ -1,0 +1,43 @@
+/**
+ * @file Contains tests for item documents
+ */
+import ItemSD from "../ItemSD.mjs";
+import { cleanUpItemsByKey } from "../../testing/testUtils.mjs";
+
+export const key = "shadowdark.documents.item";
+export const options = {
+	displayName: "ShadowDark: Documents: Item",
+};
+
+const createMockItem = async type => {
+	return ItemSD.create({
+		name: `Test Item ${key}: ${type}`,
+		type,
+	});
+};
+
+export default ({ describe, it, after, expect }) => {
+	after(() => {
+		cleanUpItemsByKey(key);
+	});
+
+	describe("Item creation", () => {
+		it("can create Gem item", async () => {
+			const item = await createMockItem("Gem");
+			expect(item).is.not.undefined;
+			await item.delete();
+		});
+
+		// @todo: Write creation tests for the rest of the items
+	});
+
+	describe("_preCreate(data, options, user)", () => {
+		it("Gem type item has slots correctly configured", async () => {
+			const item = await createMockItem("Gem");
+			expect(item.system.slots.free_cary).equal(0);
+			expect(CONFIG.SHADOWDARK.INVENTORY.GEMS_PER_SLOT).is.not.null;
+			expect(item.system.slots.per_slot).equal(CONFIG.SHADOWDARK.INVENTORY.GEMS_PER_SLOT);
+			expect(item.system.slots.slots_used).equal(1);
+		});
+	});
+};

--- a/system/src/testing/index.mjs
+++ b/system/src/testing/index.mjs
@@ -6,12 +6,21 @@ import documentsActorTests, {
 	key as documentsActorKey,
 	options as documentsActorOptions,
 } from "../documents/__tests__/documents-actor.test.mjs";
-
+import documentsItemsTests, {
+	key as documentsItemsKey,
+	options as documentsItemsOptions,
+} from "../documents/__tests__/documents-item.test.mjs";
 
 Hooks.on("quenchReady", async quench => {
+	// Document tests
 	quench.registerBatch(
 		documentsActorKey,
 		documentsActorTests,
 		documentsActorOptions
+	);
+	quench.registerBatch(
+		documentsItemsKey,
+		documentsItemsTests,
+		documentsItemsOptions
 	);
 });

--- a/system/src/testing/index.mjs
+++ b/system/src/testing/index.mjs
@@ -1,0 +1,17 @@
+/**
+ * @file Orchestration for our Quench tests
+ */
+
+import documentsActorTests, {
+	key as documentsActorKey,
+	options as documentsActorOptions,
+} from "../documents/__tests__/documents-actor.test.mjs";
+
+
+Hooks.on("quenchReady", async quench => {
+	quench.registerBatch(
+		documentsActorKey,
+		documentsActorTests,
+		documentsActorOptions
+	);
+});

--- a/system/src/testing/testUtils.mjs
+++ b/system/src/testing/testUtils.mjs
@@ -11,8 +11,14 @@ const delay = ms =>
 
 export const waitForInput = () => delay(inputDelay);
 
-export const cleanUpActorsByKey = async key => {
+export const cleanUpActorsByKey = key => {
 	game.actors
 		?.filter(a => a.name === `Test Actor ${key}`)
-		.forEach(async a => await a.delete());
+		.forEach(a => a.delete());
+};
+
+export const cleanUpItemsByKey = key => {
+	game.items
+		?.filter(i => i.name.includes(`Test Item ${key}:`))
+		.forEach(i => i.delete());
 };

--- a/system/src/testing/testUtils.mjs
+++ b/system/src/testing/testUtils.mjs
@@ -1,0 +1,18 @@
+/**
+ * @file Utilities for our Quench tests
+ */
+
+const inputDelay = 120;
+
+const delay = ms =>
+	new Promise(resolve => {
+		setTimeout(resolve, ms);
+	});
+
+export const waitForInput = () => delay(inputDelay);
+
+export const cleanUpActorsByKey = async key => {
+	game.actors
+		?.filter(a => a.name === `Test Actor ${key}`)
+		.forEach(async a => await a.delete());
+};


### PR DESCRIPTION
I've written tests similar to Old-School Essentials here, utilizing the Quench module. (https://github.com/Ethaks/FVTT-Quench).

If this type of testing is relevant, I'd gladly spend more time writing tests for Shadowdark too.

Added tests for `Actor` documents, and `Item` documents.