### PR TITLE
chore(test): more document tests

### DIFF
--- a/system/src/documents/__tests__/documents-actor.test.mjs
+++ b/system/src/documents/__tests__/documents-actor.test.mjs
@@ -3,7 +3,7 @@
  * @file Contains tests for actor documents
  */
 import ActorSD from "../ActorSD.mjs";
-import { 
+import {
 	cleanUpActorsByKey,
 	abilities,
 	waitForInput,
@@ -36,6 +36,210 @@ export default ({ describe, it, after, before, expect }) => {
 		it("can create NPC actor", async () => {
 			const actor = await createMockActor("NPC");
 			expect(actor).is.not.undefined;
+			await actor.delete();
+		});
+	});
+
+	describe("Player actor has expected information", () => {
+		let actor = {};
+
+		before(async () => {
+			actor = await createMockActor("Player");
+		});
+
+		/* Shared Details */
+		it("has attributes", () => {
+			expect(actor.system.attributes).is.not.undefined;
+		});
+		it("has attributes.ac", () => {
+			expect(actor.system.attributes.ac).is.not.undefined;
+		});
+		it("has attributes.ac.value", () => {
+			expect(actor.system.attributes.ac.value).is.not.undefined;
+		});
+		it("has attributes.hp", () => {
+			expect(actor.system.attributes.hp).is.not.undefined;
+		});
+		it("has attributes.hp.max", () => {
+			expect(actor.system.attributes.hp.max).is.not.undefined;
+		});
+		it("has attributes.hp.value", () => {
+			expect(actor.system.attributes.hp.value).is.not.undefined;
+		});
+		it("has alignment", () => {
+			expect(actor.system.alignment).is.not.undefined;
+		});
+		it("has notes", () => {
+			expect(actor.system.notes).is.not.undefined;
+		});
+
+		/**  Player Specific  */
+		it("has abilities", () => {
+			expect(actor.system.abilities).is.not.undefined;
+		});
+		it("has abilities.str", () => {
+			expect(actor.system.abilities.str).is.not.undefined;
+		});
+		it("has abilities.str.value", () => {
+			expect(actor.system.abilities.str.value).is.not.undefined;
+		});
+		it("has abilities.dex", () => {
+			expect(actor.system.abilities.dex).is.not.undefined;
+		});
+		it("has abilities.dex.value", () => {
+			expect(actor.system.abilities.dex.value).is.not.undefined;
+		});
+		it("has abilities.con", () => {
+			expect(actor.system.abilities.con).is.not.undefined;
+		});
+		it("has abilities.con.value", () => {
+			expect(actor.system.abilities.con.value).is.not.undefined;
+		});
+		it("has abilities.int", () => {
+			expect(actor.system.abilities.int).is.not.undefined;
+		});
+		it("has abilities.int.value", () => {
+			expect(actor.system.abilities.int.value).is.not.undefined;
+		});
+		it("has abilities.wis", () => {
+			expect(actor.system.abilities.wis).is.not.undefined;
+		});
+		it("has abilities.wis.value", () => {
+			expect(actor.system.abilities.wis.value).is.not.undefined;
+		});
+		it("has abilities.cha", () => {
+			expect(actor.system.abilities.cha).is.not.undefined;
+		});
+		it("has abilities.cha.value", () => {
+			expect(actor.system.abilities.cha.value).is.not.undefined;
+		});
+		it("has ancestry", () => {
+			expect(actor.system.ancestry).is.not.undefined;
+		});
+		it("has background", () => {
+			expect(actor.system.background).is.not.undefined;
+		});
+		it("has class", () => {
+			expect(actor.system.class).is.not.undefined;
+		});
+		it("has coins", () => {
+			expect(actor.system.coins).is.not.undefined;
+		});
+		it("has coins.gp", () => {
+			expect(actor.system.coins.gp).is.not.undefined;
+		});
+		it("has coins.sp", () => {
+			expect(actor.system.coins.sp).is.not.undefined;
+		});
+		it("has coins.cp", () => {
+			expect(actor.system.coins.cp).is.not.undefined;
+		});
+		it("has deity", () => {
+			expect(actor.system.deity).is.not.undefined;
+		});
+		it("has languages", () => {
+			expect(actor.system.languages).is.not.undefined;
+			expect(actor.system.languages.length).equal(0);
+		});
+		it("has level", () => {
+			expect(actor.system.level).is.not.undefined;
+		});
+		it("has level.value", () => {
+			expect(actor.system.level.value).is.not.undefined;
+		});
+		it("has level.xp", () => {
+			expect(actor.system.level.xp).is.not.undefined;
+		});
+		it("has luck", () => {
+			expect(actor.system.luck).is.not.undefined;
+		});
+		it("has title", () => {
+			expect(actor.system.title).is.not.undefined;
+		});
+
+		after(async () => {
+			await actor.delete();
+		});
+	});
+
+	describe("NPC actor has expected information", () => {
+		let actor = {};
+
+		before(async () => {
+			actor = await createMockActor("NPC");
+		});
+
+		/* Shared Details */
+		it("has attributes", () => {
+			expect(actor.system.attributes).is.not.undefined;
+		});
+		it("has attributes.ac", () => {
+			expect(actor.system.attributes.ac).is.not.undefined;
+		});
+		it("has attributes.ac.value", () => {
+			expect(actor.system.attributes.ac.value).is.not.undefined;
+		});
+		it("has attributes.hp", () => {
+			expect(actor.system.attributes.hp).is.not.undefined;
+		});
+		it("has attributes.hp.max", () => {
+			expect(actor.system.attributes.hp.max).is.not.undefined;
+		});
+		it("has attributes.hp.value", () => {
+			expect(actor.system.attributes.hp.value).is.not.undefined;
+		});
+		it("has alignment", () => {
+			expect(actor.system.alignment).is.not.undefined;
+		});
+		it("has notes", () => {
+			expect(actor.system.notes).is.not.undefined;
+		});
+
+		/**  NPC Specific  */
+		it("has abilities", () => {
+			expect(actor.system.abilities).is.not.undefined;
+		});
+		it("has abilities.str", () => {
+			expect(actor.system.abilities.str).is.not.undefined;
+		});
+		it("has abilities.str.mod", () => {
+			expect(actor.system.abilities.str.mod).is.not.undefined;
+		});
+		it("has abilities.dex", () => {
+			expect(actor.system.abilities.dex).is.not.undefined;
+		});
+		it("has abilities.dex.mod", () => {
+			expect(actor.system.abilities.dex.mod).is.not.undefined;
+		});
+		it("has abilities.con", () => {
+			expect(actor.system.abilities.con).is.not.undefined;
+		});
+		it("has abilities.con.mod", () => {
+			expect(actor.system.abilities.con.mod).is.not.undefined;
+		});
+		it("has abilities.int", () => {
+			expect(actor.system.abilities.int).is.not.undefined;
+		});
+		it("has abilities.int.mod", () => {
+			expect(actor.system.abilities.int.mod).is.not.undefined;
+		});
+		it("has abilities.wis", () => {
+			expect(actor.system.abilities.wis).is.not.undefined;
+		});
+		it("has abilities.wis.mod", () => {
+			expect(actor.system.abilities.wis.mod).is.not.undefined;
+		});
+		it("has abilities.cha", () => {
+			expect(actor.system.abilities.cha).is.not.undefined;
+		});
+		it("has abilities.cha.mod", () => {
+			expect(actor.system.abilities.cha.mod).is.not.undefined;
+		});
+		it("has attributes.hp.hd", () => {
+			expect(actor.system.attributes.hp.hd).is.not.undefined;
+		});
+
+		after(async () => {
 			await actor.delete();
 		});
 	});

--- a/system/src/documents/__tests__/documents-actor.test.mjs
+++ b/system/src/documents/__tests__/documents-actor.test.mjs
@@ -157,13 +157,13 @@ export default ({ describe, it, after, before, expect }) => {
 				{
 					type: "Armor",
 					name: "Test Shield 1",
-					shield: true,
+					"system.properties": ["shield"],
 					"system.equipped": true,
 				},
 				{
 					type: "Armor",
 					name: "Test Shield 2",
-					shield: true,
+					"system.properties": ["shield"],
 				},
 			]);
 		});
@@ -225,7 +225,7 @@ export default ({ describe, it, after, before, expect }) => {
 				{
 					type: "Armor",
 					name: "Test Shield 1",
-					shield: true,
+					"system.properties": ["shield"],
 					"system.ac.modifier": 3,
 					"system.equipped": true,
 				},

--- a/system/src/documents/__tests__/documents-actor.test.mjs
+++ b/system/src/documents/__tests__/documents-actor.test.mjs
@@ -238,6 +238,13 @@ export default ({ describe, it, after, before, expect }) => {
 		it("has attributes.hp.hd", () => {
 			expect(actor.system.attributes.hp.hd).is.not.undefined;
 		});
+		it("has level", () => {
+			expect(actor.system.level).is.not.undefined;
+		});
+		it("has movement", () => {
+			expect(actor.system.movement).is.not.undefined;
+		});
+		// Expecting attacks to be items rather than system data
 
 		after(async () => {
 			await actor.delete();

--- a/system/src/documents/__tests__/documents-actor.test.mjs
+++ b/system/src/documents/__tests__/documents-actor.test.mjs
@@ -112,5 +112,29 @@ export default ({ describe, it, after, before, expect }) => {
 		});
 	});
 
+	describe("attackBonus(attackType)", () => {
+		let actor = {};
+
+		before(async () => {
+			actor = await createMockActor("Player");
+			await actor.update({
+				"system.abilities.str.value": 18,
+				"system.abilities.dex.value": 3,
+			});
+		});
+
+		// @todo: talent bonus for both melee & ranged
+		it("melee attack returns str modifier", async () => {
+			expect(actor.attackBonus("melee")).equal(4);
+		});
+		it("ranged attack returns dex modifier", async () => {
+			expect(actor.attackBonus("ranged")).equal(-4);
+		});
+
+		after(async () => {
+			await actor.delete();
+		});
+	});
+
 	describe("rollAbility(abilityId, options={})", () => {});
 };

--- a/system/src/documents/__tests__/documents-item.test.mjs
+++ b/system/src/documents/__tests__/documents-item.test.mjs
@@ -3,7 +3,7 @@
  * @file Contains tests for item documents
  */
 import ItemSD from "../ItemSD.mjs";
-import { cleanUpItemsByKey } from "../../testing/testUtils.mjs";
+import { cleanUpItemsByKey, itemTypes } from "../../testing/testUtils.mjs";
 
 export const key = "shadowdark.documents.item";
 export const options = {
@@ -23,13 +23,13 @@ export default ({ describe, it, after, expect }) => {
 	});
 
 	describe("Item creation", () => {
-		it("can create Gem item", async () => {
-			const item = await createMockItem("Gem");
-			expect(item).is.not.undefined;
-			await item.delete();
+		itemTypes.forEach(type => {
+			it(`can create ${type} item`, async () => {
+				const item = await createMockItem(type);
+				expect(item).is.not.undefined;
+				await item.delete();
+			});
 		});
-
-		// @todo: Write creation tests for the rest of the items
 	});
 
 	describe("_preCreate(data, options, user)", () => {
@@ -39,6 +39,64 @@ export default ({ describe, it, after, expect }) => {
 			expect(CONFIG.SHADOWDARK.INVENTORY.GEMS_PER_SLOT).is.not.null;
 			expect(item.system.slots.per_slot).equal(CONFIG.SHADOWDARK.INVENTORY.GEMS_PER_SLOT);
 			expect(item.system.slots.slots_used).equal(1);
+			await item.delete();
+		});
+	});
+
+	describe("hasProperty(property)", () => {
+		it("read a system property correctly", async () => {
+			const item = await ItemSD.create({
+				name: `Test Item ${key}: Armor`,
+				type: "Armor",
+				"system.properties": ["Test"],
+			});
+
+			expect(item.hasProperty("Test")).equal(true);
+			await item.delete();
+		});
+	});
+
+	describe("isAShield()", () => {
+		it("returns true for a shield", async () => {
+			const item = await ItemSD.create({
+				name: `Test Item ${key}: Armor`,
+				type: "Armor",
+				"system.properties": ["shield"],
+			});
+			expect(item.isAShield()).equal(true);
+			await item.delete();
+		});
+
+		it("returns false for an armor", async () => {
+			const item = await ItemSD.create({
+				name: `Test Item ${key}: Armor`,
+				type: "Armor",
+				"system.properties": [],
+			});
+			expect(item.isAShield()).equal(false);
+			await item.delete();
+		});
+	});
+
+	describe("isNotAShield()", () => {
+		it("returns true for a shield", async () => {
+			const item = await ItemSD.create({
+				name: `Test Item ${key}: Armor`,
+				type: "Armor",
+				"system.properties": ["shield"],
+			});
+			expect(item.isNotAShield()).equal(false);
+			await item.delete();
+		});
+
+		it("returns false for an armor", async () => {
+			const item = await ItemSD.create({
+				name: `Test Item ${key}: Armor`,
+				type: "Armor",
+				"system.properties": [],
+			});
+			expect(item.isNotAShield()).equal(true);
+			await item.delete();
 		});
 	});
 };

--- a/system/src/sheets/__tests__/sheets-actor.test.mjs
+++ b/system/src/sheets/__tests__/sheets-actor.test.mjs
@@ -8,6 +8,7 @@ import {
 	closeDialogs,
 	abilities,
 	waitForInput,
+	cleanUpItemsByKey,
 } from "../../testing/testUtils.mjs";
 
 export const key = "shadowdark.sheets.actor";
@@ -32,6 +33,7 @@ const createMockItem = async type => {
 export default ({ describe, it, after, before, expect }) => {
 	after(async () => {
 		cleanUpActorsByKey(key);
+		cleanUpItemsByKey(key);
 		// await closeSheets();
 		await closeDialogs();
 	});
@@ -146,6 +148,7 @@ export default ({ describe, it, after, before, expect }) => {
 			item = await createMockItem("Armor");
 			await actor.createEmbeddedDocuments("Item", [item]);
 			actorItem = await actor.items.contents[0];
+			await item.delete();
 			// Render the inventory
 			await actor.sheet.render(true);
 			await waitForInput();

--- a/system/src/testing/testUtils.mjs
+++ b/system/src/testing/testUtils.mjs
@@ -9,6 +9,7 @@ const delay = ms =>
 	});
 
 export const abilities = ["str", "dex", "con", "int", "wis", "cha"];
+export const itemTypes = ["Armor", "Basic", "Gem", "Spell", "Talent", "Weapon"];
 
 export const waitForInput = () => delay(inputDelay);
 


### PR DESCRIPTION
Added tests for added features on `Actor` documents:
- `attackBonus(attackType)`
- `updateArmor(updatedItem)`
- `updateArmorClass()`

Added tests for `Item` documents:
- Tests to create all item types
- `hasProperty(property)`
- `isAShield()`
- `isNotAShield()`

Added cleanup for  tests for `ActorSheet`.