### PR TITLE
feat(spells): Spell rolling incl. spell DC

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -26,6 +26,7 @@ SHADOWDARK.armor.properties.noSwim: No Swim
 SHADOWDARK.armor.properties.oneHanded: Occupies One Hand
 SHADOWDARK.armor.properties.shield: Shield
 SHADOWDARK.chat.ItemRoll.Title: Attack roll with {name}
+SHADOWDARK.chat.SpellRoll.Title: Casting {name}
 SHADOWDARK.coins.cp: CP
 SHADOWDARK.coins.gp: GP
 SHADOWDARK.coins.sp: SP
@@ -38,7 +39,7 @@ SHADOWDARK.dialog.AbilityCheck.title: Ability Check
 SHADOWDARK.dialog.AbilityCheck.wis: Wisdom Check
 SHADOWDARK.dialog.general.are_you_sure: Are you sure?
 SHADOWDARK.dialog.general.cancel: Cancel
-SHADOWDARK.dialog.general.yes: "Yes"
+SHADOWDARK.dialog.general.yes: 'Yes'
 SHADOWDARK.dialog.item.confirm_delete: Confirm Deletion
 SHADOWDARK.dialog.item.confirm_sale: Confirm Sale
 SHADOWDARK.dialog.item.delete: Delete
@@ -50,6 +51,7 @@ SHADOWDARK.dialog.ItemRoll.TalentBonus: Talent Bonus
 SHADOWDARK.dialog.ItemRoll.Title: Roll Attack with
 SHADOWDARK.dialog.Roll: Roll
 SHADOWDARK.dialog.RollModeLabel: Select rolling mode
+SHADOWDARK.dialog.SpellRoll.Title: Roll Spell with
 SHADOWDARK.inventory.coins: Coins
 SHADOWDARK.inventory.label.quantity: Qty
 SHADOWDARK.inventory.label.slots: Slots

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -26,7 +26,7 @@ SHADOWDARK.armor.properties.noSwim: No Swim
 SHADOWDARK.armor.properties.oneHanded: Occupies One Hand
 SHADOWDARK.armor.properties.shield: Shield
 SHADOWDARK.chat.ItemRoll.Title: Attack roll with {name}
-SHADOWDARK.chat.SpellRoll.Title: Casting {name}
+SHADOWDARK.chat.SpellRoll.Title: Casting {name} at tier {tier} with spell DC {spellDC}
 SHADOWDARK.coins.cp: CP
 SHADOWDARK.coins.gp: GP
 SHADOWDARK.coins.sp: SP

--- a/system/src/documents/ActorSD.mjs
+++ b/system/src/documents/ActorSD.mjs
@@ -52,22 +52,30 @@ export default class ActorSD extends Actor {
 	/** @inheritDoc */
 	prepareDerivedData() {}
 
+	/* -------------------------------------------- */
+	/*  Roll Methods                                */
+	/* -------------------------------------------- */
+
 	async rollAbility(abilityId, options={}) {
-		const bonus = this.abilityModifier(abilityId);
-		const parts = ["@bonus"];
-		const title = game.i18n.localize(`SHADOWDARK.dialog.AbilityCheck.${abilityId}`);
+		const parts = ["@abilityBonus"];
+		const abilityBonus = this.abilityModifier(abilityId);
+
 		const ability = CONFIG.SHADOWDARK.ABILITIES_LONG[abilityId];
-		const data = { bonus, ability };
+		const title = game.i18n.localize(`SHADOWDARK.dialog.AbilityCheck.${abilityId}`);
 		const speaker = ChatMessage.getSpeaker({ actor: this });
 
 		await CONFIG.Dice.D20RollSD.d20Roll({
 			parts,
-			data,
+			data: { abilityBonus, ability },
 			title,
 			speaker,
 			template: "systems/shadowdark/templates/dialog/roll-ability-check-dialog.hbs",
 		});
 	}
+
+	/* -------------------------------------------- */
+	/*  Selling Methods                             */
+	/* -------------------------------------------- */
 
 	async sellAllGems() {
 		const items = this.items.filter(item => item.type === "Gem");

--- a/system/src/documents/ItemSD.mjs
+++ b/system/src/documents/ItemSD.mjs
@@ -34,8 +34,10 @@ export default class ItemSD extends Item {
 	}
 
 	async rollSpell(parts, abilityBonus, talentBonus, tier, options={}) {
-		const title = game.i18n.format("SHADOWDARK.chat.SpellRoll.Title", {name: this.name});
 		const speaker = ChatMessage.getSpeaker({ actor: this.actor });
+		const spellDC = 10 + tier;
+
+		const title = game.i18n.format("SHADOWDARK.chat.SpellRoll.Title", {name: this.name, tier, spellDC});
 
 		await CONFIG.Dice.D20RollSD.d20Roll({
 			parts,

--- a/system/src/documents/ItemSD.mjs
+++ b/system/src/documents/ItemSD.mjs
@@ -15,20 +15,39 @@ export default class ItemSD extends Item {
 		}
 	}
 
-	async roll(parts, bonus, talents, options={}) {
+	/* -------------------------------------------- */
+	/*  Roll Methods                                */
+	/* -------------------------------------------- */
+
+	async rollItem(parts, abilityBonus, itemBonus, talentBonus, options={}) {
 		const title = game.i18n.format("SHADOWDARK.chat.ItemRoll.Title", {name: this.name});
 		const speaker = ChatMessage.getSpeaker({ actor: this.actor });
-		console.log(`rolling ${this}`);
 
 		await CONFIG.Dice.D20RollSD.d20Roll({
 			parts,
-			data: { bonus, talents, item: this },
+			data: { abilityBonus, itemBonus, talentBonus, item: this },
 			title,
 			speaker,
 			template: "systems/shadowdark/templates/dialog/roll-item-dialog.hbs",
 		});
 	}
 
+	async rollSpell(parts, abilityBonus, talentBonus, tier, options={}) {
+		const title = game.i18n.format("SHADOWDARK.chat.SpellRoll.Title", {name: this.name});
+		const speaker = ChatMessage.getSpeaker({ actor: this.actor });
+
+		await CONFIG.Dice.D20RollSD.d20Roll({
+			parts,
+			data: { abilityBonus, talentBonus, item: this },
+			title,
+			speaker,
+			template: "systems/shadowdark/templates/dialog/roll-spell-dialog.hbs",
+		});
+	}
+
+	/* -------------------------------------------- */
+	/*  Getter Methods                              */
+	/* -------------------------------------------- */
 
 	hasProperty(property) {
 		for (const key of this.system.properties) {

--- a/system/src/documents/ItemSD.mjs
+++ b/system/src/documents/ItemSD.mjs
@@ -29,6 +29,7 @@ export default class ItemSD extends Item {
 			title,
 			speaker,
 			template: "systems/shadowdark/templates/dialog/roll-item-dialog.hbs",
+			fastForward: options.fastForward ?? false,
 		});
 	}
 
@@ -42,6 +43,7 @@ export default class ItemSD extends Item {
 			title,
 			speaker,
 			template: "systems/shadowdark/templates/dialog/roll-spell-dialog.hbs",
+			fastForward: options.fastForward ?? false,
 		});
 	}
 

--- a/system/src/documents/__tests__/documents-item-spell.test.mjs
+++ b/system/src/documents/__tests__/documents-item-spell.test.mjs
@@ -1,0 +1,121 @@
+/* eslint-disable no-unused-expressions */
+/**
+ * @file Contains tests for spell item documents
+ */
+import ItemSD from "../ItemSD.mjs";
+import { cleanUpItemsByKey, closeDialogs, itemTypes, openDialogs, trashChat, waitForInput } from "../../testing/testUtils.mjs";
+
+export const key = "shadowdark.documents.item.spell";
+export const options = {
+	displayName: "ShadowDark: Documents: Item, Spell",
+};
+
+const createMockItem = async type => {
+	return ItemSD.create({
+		name: `Test Item ${key}: ${type}`,
+		type,
+	});
+};
+
+const clickNormal = async () => {
+	const button = document.querySelector(".normal");
+	await button.click();
+	await waitForInput();
+	await waitForInput();
+};
+
+export default ({ describe, it, after, beforeEach, before, expect }) => {
+	let spell = {};
+
+	before(async () => {
+		spell = await createMockItem("Spell");
+		await trashChat();
+	});
+
+	after(() => {
+		cleanUpItemsByKey(key);
+	});
+
+	describe("rollSpell(parts, abilityBonus, talentBonus, tier, options={})", () => {
+		beforeEach(async () => {
+			await trashChat();
+		});
+
+		it("renders dialog by default", async () => {
+			await closeDialogs();
+			expect(openDialogs().length).equal(0);
+			spell.rollSpell([], 0, 0, 0, {});
+			await waitForInput();
+			expect(openDialogs().length).equal(1);
+			await openDialogs().pop().close();
+			await waitForInput();
+		});
+
+		it("rolls and displays chat message", async () => {
+			expect(openDialogs().length).equal(0);
+			expect(game.messages.size).equal(0);
+			spell.rollSpell([], 0, 0, 0, {});
+			await waitForInput();
+			expect(openDialogs().length).equal(1);
+			await clickNormal();
+			expect(game.messages.size).equal(1);
+			await waitForInput();
+			expect(openDialogs().length).equal(0);
+		});
+
+		it("just rolls when given fastForward options", async () => {
+			expect(openDialogs().length).equal(0);
+			await spell.rollSpell([], 0, 0, 0, { fastForward: true });
+			await waitForInput();
+			expect(openDialogs().length).equal(0);
+			expect(game.messages.size).equal(1);
+		});
+
+		describe("ability bonus", () => {
+			it("ignores ability bonus without appropriate parts", async () => {
+				await spell.rollSpell([], 1, 2, 0, { fastForward: true });
+				await waitForInput();
+				expect(game.messages.size).equal(1);
+
+				const chatMessage = game.messages.contents.pop();
+				expect(chatMessage.rolls.pop()._formula).equal("1d20");
+			});
+
+			it("adds ability bonus with appropriate parts", async () => {
+				await spell.rollSpell(["@abilityBonus"], 1, 2, 0, { fastForward: true });
+				await waitForInput();
+				expect(game.messages.size).equal(1);
+
+				const chatMessage = game.messages.contents.pop();
+				expect(chatMessage.rolls.pop()._formula).equal("1d20 + 1");
+			});
+		});
+
+		describe("talent bonus", () => {
+			it("adds talent bonus with appropriate parts", async () => {
+				await spell.rollSpell(["@talentBonus"], 1, 2, 0, { fastForward: true });
+				await waitForInput();
+				expect(game.messages.size).equal(1);
+
+				const chatMessage = game.messages.contents.pop();
+				expect(chatMessage.rolls.pop()._formula).equal("1d20 + 2");
+			});
+		});
+
+		describe("tier", () => {
+			it("sets the DC appropriately according to spell tier", async () => {
+				await spell.rollSpell([], 0, 0, 3, { fastForward: true });
+				await waitForInput();
+				expect(game.messages.size).equal(1);
+
+				const chatMessage = game.messages.contents.pop();
+				expect(chatMessage.content.indexOf("<p>Casting Tier 3 spell with DC 13</p>")).not.equal(-1);
+			});
+		});
+
+		after(async () => {
+			await trashChat();
+		});
+	});
+
+};

--- a/system/src/documents/__tests__/documents-item-spell.test.mjs
+++ b/system/src/documents/__tests__/documents-item-spell.test.mjs
@@ -109,7 +109,7 @@ export default ({ describe, it, after, beforeEach, before, expect }) => {
 				expect(game.messages.size).equal(1);
 
 				const chatMessage = game.messages.contents.pop();
-				expect(chatMessage.content.indexOf("<p>Casting Tier 3 spell with DC 13</p>")).not.equal(-1);
+				expect(chatMessage.flavor.indexOf("at tier 3 with spell DC 13")).not.equal(-1);
 			});
 		});
 

--- a/system/src/sheets/ActorSheetSD.mjs
+++ b/system/src/sheets/ActorSheetSD.mjs
@@ -10,6 +10,10 @@ export default class ActorSheetSD extends ActorSheet {
 			event => this._onRollItem(event)
 		);
 
+		html.find(".cast-spell").click(
+			event => this._onCastSpell(event)
+		);
+
 		// Create context menu for items on both sheets
 		this._contextMenu(html);
 
@@ -140,18 +144,45 @@ export default class ActorSheetSD extends ActorSheet {
 		const item = this.actor.items.get(itemId);
 
 		const parts = [];
-		let bonus;
+		let	abilityBonus;
+		let talentBonus;
+		let itemBonus;
 
 		if ( item.type === "Weapon" ) {
 			const abilityId = item.system.type === "melee" ? "str" : "dex";
-			parts.push("@itemBonus", "@talentBonus", "@abilityBonus");
-			bonus = this.actor.abilityModifier(abilityId);
+			parts.push("@abilityBonus");
+			abilityBonus = this.actor.abilityModifier(abilityId);
+
+			if ( item.system.attackBonus !== 0 ) {
+				parts.push("@itemBonus");
+				itemBonus = item.system.attackBonus;
+			}
 		}
 
-		// @todo: push to parts & for talents affecting attack rolls
-		let talents;
+		// @todo: push to parts & for set talentBonus as sum of talents affecting attack rolls
 
-		return item.roll(parts, bonus, talents, {event: event});
+		return item.rollItem(parts, abilityBonus, itemBonus, talentBonus, {event: event});
+	}
+
+	async _onCastSpell(event) {
+		event.preventDefault();
+
+		const itemId = $(event.currentTarget).data("item-id");
+		const item = this.actor.items.get(itemId);
+		const tier = item.system.tier;
+
+		const parts = [];
+		let abilityBonus;
+		let talentBonus;
+
+		// @todo: How do we solve this with custom classes? Spellcasting modifier in system?
+		const abilityId = this.actor.system.class === "Wizard" ? "int" : "wis";
+		parts.push("@abilityBonus");
+		abilityBonus = this.actor.abilityModifier(abilityId);
+
+		// @todo: push to parts & for set talentBonus as sum of talents affecting spell rolls
+
+		return item.rollSpell(parts, abilityBonus, talentBonus, tier, {event: event});
 	}
 
 }

--- a/system/src/sheets/ActorSheetSD.mjs
+++ b/system/src/sheets/ActorSheetSD.mjs
@@ -144,7 +144,7 @@ export default class ActorSheetSD extends ActorSheet {
 		const item = this.actor.items.get(itemId);
 
 		const parts = [];
-		let	abilityBonus;
+		let abilityBonus;
 		let talentBonus;
 		let itemBonus;
 

--- a/system/src/sheets/__tests__/sheets-actor.test.mjs
+++ b/system/src/sheets/__tests__/sheets-actor.test.mjs
@@ -260,7 +260,6 @@ export default ({ describe, it, after, before, expect }) => {
 
 	describe("_onOpenItem(event)", () => {
 		let actor = {};
-		let actorItem = {};
 
 		before(async () => {
 			actor = await createMockActor("Player");

--- a/system/src/testing/index.mjs
+++ b/system/src/testing/index.mjs
@@ -10,6 +10,10 @@ import documentsItemsTests, {
 	key as documentsItemsKey,
 	options as documentsItemsOptions,
 } from "../documents/__tests__/documents-item.test.mjs";
+import documentsItemsSpellsTests, {
+	key as documentsItemsSpellsKey,
+	options as documentsItemsSpellsOptions,
+} from "../documents/__tests__/documents-item-spell.test.mjs";
 
 import sheetsActorTests, {
 	key as sheetsActorKey,
@@ -36,6 +40,11 @@ Hooks.on("quenchReady", async quench => {
 		documentsItemsKey,
 		documentsItemsTests,
 		documentsItemsOptions
+	);
+	quench.registerBatch(
+		documentsItemsSpellsKey,
+		documentsItemsSpellsTests,
+		documentsItemsSpellsOptions
 	);
 
 	// Sheet tests

--- a/system/templates/dialog/roll-spell-dialog.hbs
+++ b/system/templates/dialog/roll-spell-dialog.hbs
@@ -1,13 +1,6 @@
 <form autocomplete="off" spellcheck="off">
-  <h2>{{localize "SHADOWDARK.dialog.ItemRoll.Title"}} {{ data.item.name }}</h2>
+  <h2>{{localize "SHADOWDARK.dialog.SpellRoll.Title"}} {{ data.item.name }}</h2>
   <hr />
-
-  <div class="form-group">
-    <label>
-      {{localize "SHADOWDARK.dialog.ItemRoll.ItemBonus"}}
-    </label>
-    <input type="number" name="item-bonus" value="{{ data.itemBonus }}" placeholder="0">
-  </div>
   <div class="form-group">
     <label>
       {{localize "SHADOWDARK.dialog.ItemRoll.AbilityBonus"}}
@@ -18,7 +11,7 @@
     <label>
       {{localize "SHADOWDARK.dialog.ItemRoll.TalentBonus"}}
     </label>
-    <input type="number" name="talent-bonus" value="{{ data.talentBnous }}" placeholder="0">
+    <input type="number" name="talent-bonus" value="{{ data.talentBonus }}" placeholder="0">
   </div>
   <hr />
 


### PR DESCRIPTION
Added:
- Rolling spells, including showing the DC in the chat card

Modified:
- Refactored the previous rolling methods to be aligned in how to use bonuses & parts

Linting:
- Fixes linting message with `actorData` not being used in `sheets-actor.test.js`