### PR TITLE
feat(talent): Custom talent choice

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -211,6 +211,7 @@ SHADOWDARK.spell_range.near: Near
 SHADOWDARK.talent.type.ability_improvement: Ability Improvement
 SHADOWDARK.talent.type.armor_bonus: Armor AC Bonus
 SHADOWDARK.talent.type.attack_bonus: Attack Roll Bonus
+SHADOWDARK.talent.type.custom: Custom Talent
 SHADOWDARK.talent.type.backstab_die: Extra Backstab Die
 SHADOWDARK.talent.type.damage_bonus: Damage Roll Bonus
 SHADOWDARK.talent.type.initiative_advantage: Initiative Advantage

--- a/system/src/apps/TalentTypesSD.mjs
+++ b/system/src/apps/TalentTypesSD.mjs
@@ -27,6 +27,7 @@ export default class TalentTypesSD extends ItemPropertiesSD {
 			case "spellAdvantage": return "icons/magic/air/air-smoke-casting.webp";
 			case "weaponMastery": return "icons/skills/melee/weapons-crossed-swords-white-blue.webp";
 			case "backstabDie": return "icons/skills/melee/strike-dagger-white-orange.webp";
+			case "custom": return "icons/svg/upgrade.svg";
 		}
 	}
 
@@ -103,6 +104,14 @@ export default class TalentTypesSD extends ItemPropertiesSD {
 				changes.push({
 					key: "system.talent.backstabDie",
 					value: 1,
+					mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+				});
+				break;
+			}
+			case "custom": {
+				changes.push({
+					key: "",
+					value: "",
 					mode: CONST.ACTIVE_EFFECT_MODES.ADD,
 				});
 				break;

--- a/system/src/config.mjs
+++ b/system/src/config.mjs
@@ -109,6 +109,7 @@ SHADOWDARK.TALENT_TYPES = {
 	spellAdvantage: "SHADOWDARK.talent.type.spell_advantage",
 	weaponMastery: "SHADOWDARK.talent.type.weapon_mastery",
 	backstabDie: "SHADOWDARK.talent.type.backstab_die",
+	custom: "SHADOWDARK.talent.type.custom",
 };
 
 SHADOWDARK.TALENT_PROPERTIES = {


### PR DESCRIPTION
Added another choice that creates an empty custom talent. Still needs a unique name so it doesn't get hidden if Custom Talent is deselected from the Talent Type choice.