### PR TITLE
fix(spell): No longer lost when close dialog

### DIFF
--- a/system/src/documents/ItemSD.mjs
+++ b/system/src/documents/ItemSD.mjs
@@ -69,7 +69,7 @@ export default class ItemSD extends Item {
 		options.dialogTemplate = "systems/shadowdark/templates/dialog/roll-spell-dialog.hbs";
 		options.chatCardTemplate = "systems/shadowdark/templates/chat/item-card.hbs";
 		const result = await CONFIG.DiceSD.RollD20Dialog(parts, data, options);
-		if (!result?.rolls?.main?.success) this.update({"system.lost": true});
+		if (result && !result?.rolls?.main?.success) this.update({"system.lost": true});
 	}
 
 	/* -------------------------------------------- */


### PR DESCRIPTION
Spells got lost if the roll dialog was closed, this fixes this so that it only checks for the lost automation if the spell was actually rolled.