### PR TITLE
fix(css): Chatcard styling

### DIFF
--- a/scss/base/_chat.scss
+++ b/scss/base/_chat.scss
@@ -35,8 +35,23 @@
     border-top: 2px groove #FFF;
   }
 
+  .card-damage-rolls {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
   .card-damage-roll {
-    padding: 3px 0 3px;
+    padding: 2px 6px 3px;
+
+    h3 {
+      font-size: 12px;
+    }
+
+  }
+
+  .card-damage-roll-single {
+    padding: 12px 0 3px;
+    grid-column: span 2;
   }
 
   .card-spell-critical {
@@ -54,13 +69,13 @@
     border-top: 2px groove #FFF;
 
     span {
-      border-right: 2px groove #FFF;
-      padding: 0 3px 0 0;
+      border: 2px groove #FFF;
+      border-radius: 5px;
+      padding: 0 4px 0 4px;
       font-size: 10px;
 
       &:last-child {
-        border-right: none;
-        padding-right: 0;
+        border: none;
       }
     }
   }

--- a/system/templates/chat/item-card.hbs
+++ b/system/templates/chat/item-card.hbs
@@ -46,17 +46,21 @@
   {{#if isWeapon}}
   {{#ifNeq data.rolls.main.critical "failure"}}
   <div class="card-damage-rolls">
+    {{#if isVersatile}}
     <div class="card-damage-roll blindable" data-blind="{{data.rolls.main.roll.blindroll}}">
-        {{#if isVersatile}}
-        <div><h3>{{localize "SHADOWDARK.damage.one_handed"}}</h3></div>
-        <div>{{{data.rolls.primaryDamage.renderedHTML}}}</div>
-        <div><h3>{{localize "SHADOWDARK.damage.two_handed"}}</h3></div>
-        <div>{{{data.rolls.secondaryDamage.renderedHTML}}}</div>
-        {{else}}
-        <div><h3>{{localize "SHADOWDARK.roll.damage"}}</h3></div>
-        <div>{{{data.rolls.primaryDamage.renderedHTML}}}</div>
-        {{/if}}
+      <h3>{{localize "SHADOWDARK.damage.one_handed"}}</h3>
+      {{{data.rolls.primaryDamage.renderedHTML}}}
     </div>
+    <div class="card-damage-roll blindable" data-blind="{{data.rolls.main.roll.blindroll}}">
+      <h3>{{localize "SHADOWDARK.damage.two_handed"}}</h3>
+      {{{data.rolls.secondaryDamage.renderedHTML}}}
+    </div>
+    {{else}}
+    <div class="card-damage-roll-single blindable" data-blind="{{data.rolls.main.roll.blindroll}}">
+      <h3>{{localize "SHADOWDARK.roll.damage"}}</h3>
+      {{{data.rolls.primaryDamage.renderedHTML}}}
+    </div>
+    {{/if}}
   </div>
   {{/ifNeq}}
   {{/if}}


### PR DESCRIPTION
Reworked the Item Chatcard a bit, so that versatile weapon damage rolls are shown next to eachother:
![image](https://user-images.githubusercontent.com/105067023/226168864-8cb21742-a3d7-4f0b-8767-b72bfedf5c64.png)

Whereas if it is not versatile it shows as:
![image](https://user-images.githubusercontent.com/105067023/226168879-9229e375-0ba9-40f5-828c-93870613ead5.png)

Also made the properties be shown in "pills" instead of a "pipe-separated" row.