### PR TITLE
fix(npc): sheet fixes

### DIFF
--- a/system/src/dice/RollSD.mjs
+++ b/system/src/dice/RollSD.mjs
@@ -43,6 +43,10 @@ export default class RollSD extends Roll {
 			main: await this._rollAdvantage(parts, data, adv),
 		};
 
+		if (data.rollType === "ability") {
+			return this._renderRoll(data, adv, options);
+		}
+
 		// Roll damage for NPCs
 		if (data.actor?.type === "NPC") {
 			data = await this._rollNpcAttack(data);

--- a/system/src/documents/ActorSD.mjs
+++ b/system/src/documents/ActorSD.mjs
@@ -52,9 +52,7 @@ export default class ActorSD extends Actor {
 			attackName: item.name,
 			numAttacks: item.system.attack.num,
 			attackBonus: item.system.attack.bonus,
-			baseDamage: CONFIG.SHADOWDARK.WEAPON_BASE_DAMAGE[
-				item.system.damage.value
-			],
+			baseDamage: `${item.system.damage.numDice}${item.system.damage.value}`,
 			bonusDamage: item.system.damage.bonus,
 			special: item.system.damage.special,
 		};

--- a/system/templates/items/partials/npc-attack.hbs
+++ b/system/templates/items/partials/npc-attack.hbs
@@ -32,8 +32,8 @@
 	<div class="npc-attack-detail">
 		<label>{{localize 'SHADOWDARK.item.npc_attack.num_damage_dice'}}</label>
 		{{numberInput
-			system.attack.damage.numDice
-			name="system.attack.damage.numDice"
+			system.damage.numDice
+			name="system.damage.numDice"
 			placeholder="1"
 		}}
 	</div>


### PR DESCRIPTION
This fixes:
- Ability scores not rollable from NPC sheet
- Template used wrong data path for `numDice` on damage rolls for NPC attacks.