### PR TITLE
fix(token): Default token disp. #163

### DIFF
--- a/system/src/documents/ActorSD.mjs
+++ b/system/src/documents/ActorSD.mjs
@@ -6,7 +6,7 @@ export default class ActorSD extends Actor {
 		// Some sensible token defaults for Actors
 		const prototypeToken = {
 			actorLink: false,
-			disposition: CONST.TOKEN_DISPOSITIONS.HOSTILE,
+			// disposition: CONST.TOKEN_DISPOSITIONS.HOSTILE,
 			sight: {
 				enabled: false,
 			},


### PR DESCRIPTION
Resolves #163 

The comment in #163 makes sense that we maybe shouldn't override the default settings from foundry. I don't know if we should merge this PR, but I commented away the part where this causes the override.