### PR TITLE
chore(test): Full test suite skeleton

### DIFF
--- a/system/src/__tests__/base-config.test.mjs
+++ b/system/src/__tests__/base-config.test.mjs
@@ -1,0 +1,14 @@
+/* eslint-disable no-unused-expressions */
+/**
+ * @file Contains tests for the Config
+ */
+
+export const key = "shadowdark.config";
+export const options = {
+	displayName: "Shadowdark: Config",
+	preSelected: true,
+};
+
+export default ({ describe, it, after, beforeEach, before, expect }) => {
+	describe("test", () => {});
+};

--- a/system/src/__tests__/base-handlebars.test.mjs
+++ b/system/src/__tests__/base-handlebars.test.mjs
@@ -1,11 +1,11 @@
 /* eslint-disable no-unused-expressions */
 /**
- * @file Contains tests for talent item documents
+ * @file Contains tests for the Handlebar helpers
  */
 
-export const key = "shadowdark.documents.item.talent";
+export const key = "shadowdark.root.handlebars";
 export const options = {
-	displayName: "Shadowdark: Documents: Item, Talent",
+	displayName: "Shadowdark: Handlebar Helpers",
 	preSelected: true,
 };
 

--- a/system/src/__tests__/base-hooks.test.mjs
+++ b/system/src/__tests__/base-hooks.test.mjs
@@ -1,11 +1,11 @@
 /* eslint-disable no-unused-expressions */
 /**
- * @file Contains tests for talent item documents
+ * @file Contains tests for the Hooks
  */
 
-export const key = "shadowdark.documents.item.talent";
+export const key = "shadowdark.root.hooks";
 export const options = {
-	displayName: "Shadowdark: Documents: Item, Talent",
+	displayName: "Shadowdark: Hooks",
 	preSelected: true,
 };
 

--- a/system/src/__tests__/base-settings.test.mjs
+++ b/system/src/__tests__/base-settings.test.mjs
@@ -1,11 +1,11 @@
 /* eslint-disable no-unused-expressions */
 /**
- * @file Contains tests for talent item documents
+ * @file Contains tests for the Settings
  */
 
-export const key = "shadowdark.documents.item.talent";
+export const key = "shadowdark.root.Settings";
 export const options = {
-	displayName: "Shadowdark: Documents: Item, Talent",
+	displayName: "Shadowdark: Settings",
 	preSelected: true,
 };
 

--- a/system/src/__tests__/base-templates.test.mjs
+++ b/system/src/__tests__/base-templates.test.mjs
@@ -1,11 +1,11 @@
 /* eslint-disable no-unused-expressions */
 /**
- * @file Contains tests for talent item documents
+ * @file Contains tests for the Templates
  */
 
-export const key = "shadowdark.documents.item.talent";
+export const key = "shadowdark.root.templates";
 export const options = {
-	displayName: "Shadowdark: Documents: Item, Talent",
+	displayName: "Shadowdark: Templates",
 	preSelected: true,
 };
 

--- a/system/src/apps/__tests__/apps-active-effects.test.mjs
+++ b/system/src/apps/__tests__/apps-active-effects.test.mjs
@@ -1,11 +1,11 @@
 /* eslint-disable no-unused-expressions */
 /**
- * @file Contains tests for talent item documents
+ * @file Contains tests for the Active Effects app
  */
 
-export const key = "shadowdark.documents.item.talent";
+export const key = "shadowdark.apps.active-effects";
 export const options = {
-	displayName: "Shadowdark: Documents: Item, Talent",
+	displayName: "Shadowdark: Apps: Active Effects",
 	preSelected: true,
 };
 

--- a/system/src/apps/__tests__/apps-armor-properties.test.mjs
+++ b/system/src/apps/__tests__/apps-armor-properties.test.mjs
@@ -1,11 +1,11 @@
 /* eslint-disable no-unused-expressions */
 /**
- * @file Contains tests for talent item documents
+ * @file Contains tests for the Armor Properties app
  */
 
-export const key = "shadowdark.documents.item.talent";
+export const key = "shadowdark.apps.armor-properties";
 export const options = {
-	displayName: "Shadowdark: Documents: Item, Talent",
+	displayName: "Shadowdark: Apps: Armor Properties",
 	preSelected: true,
 };
 

--- a/system/src/apps/__tests__/apps-gem-bag.test.mjs
+++ b/system/src/apps/__tests__/apps-gem-bag.test.mjs
@@ -1,11 +1,11 @@
 /* eslint-disable no-unused-expressions */
 /**
- * @file Contains tests for talent item documents
+ * @file Contains tests for the Gem Bag app
  */
 
-export const key = "shadowdark.documents.item.talent";
+export const key = "shadowdark.apps.gembag";
 export const options = {
-	displayName: "Shadowdark: Documents: Item, Talent",
+	displayName: "Shadowdark: Apps: Gem Bag",
 	preSelected: true,
 };
 

--- a/system/src/apps/__tests__/apps-item-properties.test.mjs
+++ b/system/src/apps/__tests__/apps-item-properties.test.mjs
@@ -1,11 +1,11 @@
 /* eslint-disable no-unused-expressions */
 /**
- * @file Contains tests for talent item documents
+ * @file Contains tests for the Item Properties app
  */
 
-export const key = "shadowdark.documents.item.talent";
+export const key = "shadowdark.apps.item-properties";
 export const options = {
-	displayName: "Shadowdark: Documents: Item, Talent",
+	displayName: "Shadowdark: Apps: Item Properties",
 	preSelected: true,
 };
 

--- a/system/src/apps/__tests__/apps-lightsource-tracker.test.mjs
+++ b/system/src/apps/__tests__/apps-lightsource-tracker.test.mjs
@@ -1,11 +1,11 @@
 /* eslint-disable no-unused-expressions */
 /**
- * @file Contains tests for talent item documents
+ * @file Contains tests for the Lightsource Tracker app
  */
 
-export const key = "shadowdark.documents.item.talent";
+export const key = "shadowdark.apps.lightsource-tracker";
 export const options = {
-	displayName: "Shadowdark: Documents: Item, Talent",
+	displayName: "Shadowdark: Apps: Lightsource Tracker",
 	preSelected: true,
 };
 

--- a/system/src/apps/__tests__/apps-magic-item-effects.test.mjs
+++ b/system/src/apps/__tests__/apps-magic-item-effects.test.mjs
@@ -1,11 +1,11 @@
 /* eslint-disable no-unused-expressions */
 /**
- * @file Contains tests for talent item documents
+ * @file Contains tests for the Magic Item Effects app
  */
 
-export const key = "shadowdark.documents.item.talent";
+export const key = "shadowdark.apps.magic-item-effects";
 export const options = {
-	displayName: "Shadowdark: Documents: Item, Talent",
+	displayName: "Shadowdark: Apps: Magic Item Effect",
 	preSelected: true,
 };
 

--- a/system/src/apps/__tests__/apps-npc-attack-ranges.test.mjs
+++ b/system/src/apps/__tests__/apps-npc-attack-ranges.test.mjs
@@ -1,11 +1,11 @@
 /* eslint-disable no-unused-expressions */
 /**
- * @file Contains tests for talent item documents
+ * @file Contains tests for the NPC Attack Ranges app
  */
 
-export const key = "shadowdark.documents.item.talent";
+export const key = "shadowdark.apps.npc-attack-ranges";
 export const options = {
-	displayName: "Shadowdark: Documents: Item, Talent",
+	displayName: "Shadowdark: Apps: NPC Attack Ranges",
 	preSelected: true,
 };
 

--- a/system/src/apps/__tests__/apps-player-languages.test.mjs
+++ b/system/src/apps/__tests__/apps-player-languages.test.mjs
@@ -1,11 +1,11 @@
 /* eslint-disable no-unused-expressions */
 /**
- * @file Contains tests for talent item documents
+ * @file Contains tests for the Player Languages app
  */
 
-export const key = "shadowdark.documents.item.talent";
+export const key = "shadowdark.apps.player-languages";
 export const options = {
-	displayName: "Shadowdark: Documents: Item, Talent",
+	displayName: "Shadowdark: Apps: Player Languages",
 	preSelected: true,
 };
 

--- a/system/src/apps/__tests__/apps-spellcaster-class.test.mjs
+++ b/system/src/apps/__tests__/apps-spellcaster-class.test.mjs
@@ -1,11 +1,11 @@
 /* eslint-disable no-unused-expressions */
 /**
- * @file Contains tests for talent item documents
+ * @file Contains tests for the Spellcaster Class app
  */
 
-export const key = "shadowdark.documents.item.talent";
+export const key = "shadowdark.apps.spellcaster-class";
 export const options = {
-	displayName: "Shadowdark: Documents: Item, Talent",
+	displayName: "Shadowdark: Apps: Spellcaster Class",
 	preSelected: true,
 };
 

--- a/system/src/apps/__tests__/apps-talent-types.test.mjs
+++ b/system/src/apps/__tests__/apps-talent-types.test.mjs
@@ -1,11 +1,11 @@
 /* eslint-disable no-unused-expressions */
 /**
- * @file Contains tests for talent item documents
+ * @file Contains tests for the Talent Types app
  */
 
-export const key = "shadowdark.documents.item.talent";
+export const key = "shadowdark.apps.talent-types";
 export const options = {
-	displayName: "Shadowdark: Documents: Item, Talent",
+	displayName: "Shadowdark: Apps: Talent Types",
 	preSelected: true,
 };
 

--- a/system/src/apps/__tests__/apps-weapon-properties.test.mjs
+++ b/system/src/apps/__tests__/apps-weapon-properties.test.mjs
@@ -1,11 +1,11 @@
 /* eslint-disable no-unused-expressions */
 /**
- * @file Contains tests for talent item documents
+ * @file Contains tests for the Weapon Properties app
  */
 
-export const key = "shadowdark.documents.item.talent";
+export const key = "shadowdark.apps.weapon-properties";
 export const options = {
-	displayName: "Shadowdark: Documents: Item, Talent",
+	displayName: "Shadowdark: Apps: Weapon Properties",
 	preSelected: true,
 };
 

--- a/system/src/chat/__tests__/chat-chatcard.test.mjs
+++ b/system/src/chat/__tests__/chat-chatcard.test.mjs
@@ -5,7 +5,8 @@
 
 export const key = "shadowdark.chat.chatcards";
 export const options = {
-	displayName: "ShadowDark: Chat: ChatCards",
+	displayName: "Shadowdark: Chat: ChatCards",
+	preSelected: true,
 };
 
 export default ({ describe, it, after, before, expect }) => {

--- a/system/src/dice/__tests__/dice-chat-templates.test.mjs
+++ b/system/src/dice/__tests__/dice-chat-templates.test.mjs
@@ -7,7 +7,8 @@ import RollSD from "../RollSD.mjs";
 
 export const key = "shadowdark.dice.chat-templates";
 export const options = {
-	displayName: "ShadowDark: Dice: Chat Templates",
+	displayName: "Shadowdark: Dice: Chat Templates",
+	preSelected: true,
 };
 
 const mockRollResult = (faces, result, critical=null) => {

--- a/system/src/dice/__tests__/dice.test.mjs
+++ b/system/src/dice/__tests__/dice.test.mjs
@@ -6,7 +6,8 @@ import RollSD from "../RollSD.mjs";
 
 export const key = "shadowdark.dice";
 export const options = {
-	displayName: "ShadowDark: Dice",
+	displayName: "Shadowdark: Dice",
+	preSelected: true,
 };
 
 const mockRollResult = (faces, result) => {

--- a/system/src/documents/__tests__/documents-active-effects.test.mjs
+++ b/system/src/documents/__tests__/documents-active-effects.test.mjs
@@ -1,0 +1,12 @@
+/* eslint-disable no-unused-expressions */
+/**
+ * @file Contains tests for the Active Effects documents
+ */
+
+export const key = "shadowdark.documents.documents.active-effects";
+export const options = {
+	displayName: "Shadowdark: Documents: Active Effects",
+	preSelected: true,
+};
+
+export default ({ describe, it, after, beforeEach, before, expect }) => {};

--- a/system/src/documents/__tests__/documents-actor.test.mjs
+++ b/system/src/documents/__tests__/documents-actor.test.mjs
@@ -11,7 +11,8 @@ import {
 
 export const key = "shadowdark.documents.actor";
 export const options = {
-	displayName: "ShadowDark: Documents: Actor",
+	displayName: "Shadowdark: Documents: Actor",
+	preSelected: true,
 };
 
 const createMockActor = async type => {

--- a/system/src/documents/__tests__/documents-item-magic-items.test.mjs
+++ b/system/src/documents/__tests__/documents-item-magic-items.test.mjs
@@ -1,11 +1,11 @@
 /* eslint-disable no-unused-expressions */
 /**
- * @file Contains tests for talent item documents
+ * @file Contains tests for the Magic Item documents
  */
 
-export const key = "shadowdark.documents.item.talent";
+export const key = "shadowdark.documents.item.magic-items";
 export const options = {
-	displayName: "Shadowdark: Documents: Item, Talent",
+	displayName: "Shadowdark: Documents: Item, Magic Items",
 	preSelected: true,
 };
 

--- a/system/src/documents/__tests__/documents-item-spell.test.mjs
+++ b/system/src/documents/__tests__/documents-item-spell.test.mjs
@@ -7,7 +7,8 @@ import { cleanUpItemsByKey, closeDialogs, openDialogs, trashChat, waitForInput }
 
 export const key = "shadowdark.documents.item.spell";
 export const options = {
-	displayName: "ShadowDark: Documents: Item, Spell",
+	displayName: "Shadowdark: Documents: Item, Spell",
+	preSelected: false,
 };
 
 const createMockItem = async type => {

--- a/system/src/documents/__tests__/documents-item.test.mjs
+++ b/system/src/documents/__tests__/documents-item.test.mjs
@@ -7,7 +7,8 @@ import { cleanUpItemsByKey, itemTypes } from "../../testing/testUtils.mjs";
 
 export const key = "shadowdark.documents.item";
 export const options = {
-	displayName: "ShadowDark: Documents: Item",
+	displayName: "Shadowdark: Documents: Item",
+	preSelected: true,
 };
 
 const createMockItem = async type => {

--- a/system/src/hooks/__tests__/hooks-chat-message.test.mjs
+++ b/system/src/hooks/__tests__/hooks-chat-message.test.mjs
@@ -1,11 +1,11 @@
 /* eslint-disable no-unused-expressions */
 /**
- * @file Contains tests for talent item documents
+ * @file Contains tests for the Chat Message hooks
  */
 
-export const key = "shadowdark.documents.item.talent";
+export const key = "shadowdark.hooks.chat-message";
 export const options = {
-	displayName: "Shadowdark: Documents: Item, Talent",
+	displayName: "Shadowdark: Hooks: Chat Message",
 	preSelected: true,
 };
 

--- a/system/src/hooks/__tests__/hooks-light-source-tracker.test.mjs
+++ b/system/src/hooks/__tests__/hooks-light-source-tracker.test.mjs
@@ -1,11 +1,11 @@
 /* eslint-disable no-unused-expressions */
 /**
- * @file Contains tests for talent item documents
+ * @file Contains tests for the Lightsource Tracker hooks
  */
 
-export const key = "shadowdark.documents.item.talent";
+export const key = "shadowdark.hooks.lightsource-tracker";
 export const options = {
-	displayName: "Shadowdark: Documents: Item, Talent",
+	displayName: "Shadowdark: Hooks: Lightsource Tracker",
 	preSelected: true,
 };
 

--- a/system/src/sheets/__tests__/sheets-actor-npc.test.mjs
+++ b/system/src/sheets/__tests__/sheets-actor-npc.test.mjs
@@ -1,0 +1,12 @@
+/* eslint-disable no-unused-expressions */
+/**
+ * @file Contains tests for the NPC sheets
+ */
+
+export const key = "shadowdark.sheets.actor.npc";
+export const options = {
+	displayName: "Shadowdark: Sheets: Actor, NPC",
+	preSelected: false,
+};
+
+export default ({ describe, it, after, beforeEach, before, expect }) => {};

--- a/system/src/sheets/__tests__/sheets-actor-player.test.mjs
+++ b/system/src/sheets/__tests__/sheets-actor-player.test.mjs
@@ -12,9 +12,10 @@ import {
 	cleanUpItemsByKey,
 } from "../../testing/testUtils.mjs";
 
-export const key = "shadowdark.sheets.player";
+export const key = "shadowdark.sheets.actor.player";
 export const options = {
-	displayName: "ShadowDark: Sheets: Player",
+	displayName: "Shadowdark: Sheets: Actor, Player",
+	preSelected: false,
 };
 
 const createMockActor = async type => {

--- a/system/src/sheets/__tests__/sheets-actor.test.mjs
+++ b/system/src/sheets/__tests__/sheets-actor.test.mjs
@@ -13,7 +13,8 @@ import {
 
 export const key = "shadowdark.sheets.actor";
 export const options = {
-	displayName: "ShadowDark: Sheets: Actor",
+	displayName: "Shadowdark: Sheets: Actor",
+	preSelected: false,
 };
 
 const createMockActor = async type => {

--- a/system/src/sheets/__tests__/sheets-item.test.mjs
+++ b/system/src/sheets/__tests__/sheets-item.test.mjs
@@ -12,7 +12,8 @@ import {
 
 export const key = "shadowdark.sheets.item";
 export const options = {
-	displayName: "ShadowDark: Sheets: Item",
+	displayName: "Shadowdark: Sheets: Item",
+	preSelected: false,
 };
 
 const createMockItem = async type => {

--- a/system/src/testing/index.mjs
+++ b/system/src/testing/index.mjs
@@ -2,31 +2,105 @@
  * @file Orchestration for our Quench tests
  */
 
-/* Utils Import */
+/* Base/Root Imports */
+import baseConfigTests, {
+	key as baseConfigKey,
+	options as baseConfigOptions,
+} from "../__tests__/base-config.test.mjs";
+import baseHandlebarsTests, {
+	key as baseHandlebarsKey,
+	options as baseHandlebarsOptions,
+} from "../__tests__/base-handlebars.test.mjs";
+import baseHooksTests, {
+	key as baseHooksKey,
+	options as baseHooksOptions,
+} from "../__tests__/base-hooks.test.mjs";
+import baseSettingsTests, {
+	key as baseSettingsKey,
+	options as baseSettingsOptions,
+} from "../__tests__/base-settings.test.mjs";
+import baseTemplatesTests, {
+	key as baseTemplatesKey,
+	options as baseTemplatesOptions,
+} from "../__tests__/base-templates.test.mjs";
+
+/* Apps Imports */
+import appsActiveEffectsTests, {
+	key as appsActiveEffectsKey,
+	options as appsActiveEffectsOptions,
+} from "../apps/__tests__/apps-active-effects.test.mjs";
+import appsArmorPropertiesTests, {
+	key as appsArmorPropertiesKey,
+	options as appsArmorPropertiesOptions,
+} from "../apps/__tests__/apps-armor-properties.test.mjs";
+import appsGemBagTests, {
+	key as appsGemBagKey,
+	options as appsGemBagOptions,
+} from "../apps/__tests__/apps-gem-bag.test.mjs";
+import appsItemPropertiesTests, {
+	key as appsItemPropertiesKey,
+	options as appsItemPropertiesOptions,
+} from "../apps/__tests__/apps-item-properties.test.mjs";
+import appsLightsourceTrackerTests, {
+	key as appsLightsourceTrackerKey,
+	options as appsLightsourceTrackerOptions,
+} from "../apps/__tests__/apps-lightsource-tracker.test.mjs";
+import appsMagicItemEffectsTests, {
+	key as appsMagicItemEffectsKey,
+	options as appsMagicItemEffectsOptions,
+} from "../apps/__tests__/apps-magic-item-effects.test.mjs";
+import appsNPCAttackRangesTests, {
+	key as appsNPCAttackRangesKey,
+	options as appsNPCAttackRangesOptions,
+} from "../apps/__tests__/apps-npc-attack-ranges.test.mjs";
+
+import appsPlayerLanguagesTests, {
+	key as appsPlayerLanguagesKey,
+	options as appsPlayerLanguagesOptions,
+} from "../apps/__tests__/apps-player-languages.test.mjs";
+import appsSpellcasterClassTests, {
+	key as appsSpellcasterClassKey,
+	options as appsSpellcasterClassOptions,
+} from "../apps/__tests__/apps-spellcaster-class.test.mjs";
+import appsTalentTypesTests, {
+	key as appsTalentTypesKey,
+	options as appsTalentTypesOptions,
+} from "../apps/__tests__/apps-talent-types.test.mjs";
+import appsWeaponPropertiesTests, {
+	key as appsWeaponPropertiesKey,
+	options as appsWeaponPropertiesOptions,
+} from "../apps/__tests__/apps-weapon-properties.test.mjs";
+
+/* Chat Imports */
 import chatChatcardTests, {
 	key as chatChatcardKey,
 	options as chatChatcardOptions,
-} from "../chat/__tests__/chat-chatcard.test.js";
+} from "../chat/__tests__/chat-chatcard.test.mjs";
 
-/* Dice Import */
+/* Dice Imports */
+// @todo: Refactor the Dice mechanics to be more intiutive to find
 import diceTests, {
 	key as diceKey,
 	options as diceOptions,
-} from "../dice/__tests__/dice.test.js";
+} from "../dice/__tests__/dice.test.mjs";
 import diceChatTemplateTests, {
 	key as diceChatTemplateKey,
 	options as diceChatTemplateOptions,
-} from "../dice/__tests__/dice-chat-templates.test.js";
+} from "../dice/__tests__/dice-chat-templates.test.mjs";
 
-/* Document imports */
+/* Document Imports */
+import documentsActiveEffectsTests, {
+	key as documentsActiveEffectsKey,
+	options as documentsActiveEffectsOptions,
+} from "../documents/__tests__/documents-active-effects.test.mjs";
 import documentsActorTests, {
 	key as documentsActorKey,
 	options as documentsActorOptions,
 } from "../documents/__tests__/documents-actor.test.mjs";
-import documentsItemsTests, {
-	key as documentsItemsKey,
-	options as documentsItemsOptions,
-} from "../documents/__tests__/documents-item.test.mjs";
+import documentsItemMagicItemsTests, {
+	key as documentsItemMagicItemsKey,
+	options as documentsItemMagicItemsOptions,
+} from "../documents/__tests__/documents-item-magic-items.test.mjs";
 import documentsItemsSpellsTests, {
 	key as documentsItemsSpellsKey,
 	options as documentsItemsSpellsOptions,
@@ -35,6 +109,20 @@ import documentsItemsTalentTests, {
 	key as documentsItemsTalentKey,
 	options as documentsItemsTalentOptions,
 } from "../documents/__tests__/documents-item-talent.test.mjs";
+import documentsItemsTests, {
+	key as documentsItemsKey,
+	options as documentsItemsOptions,
+} from "../documents/__tests__/documents-item.test.mjs";
+
+/* Hooks Imports */
+import hooksChatMessageTests, {
+	key as hooksChatMessageKey,
+	options as hooksChatMessageOptions,
+} from "../hooks/__tests__/hooks-chat-message.test.mjs";
+import hooksLightsourceTrackerTests, {
+	key as hooksLightsourceTrackerKey,
+	options as hooksLightsourceTrackerOptions,
+} from "../hooks/__tests__/hooks-light-source-tracker.test.mjs";
 
 /* Sheet Imports */
 import sheetsActorTests, {
@@ -45,16 +133,101 @@ import sheetsItemTests, {
 	key as sheetsItemKey,
 	options as sheetsItemOptions,
 } from "../sheets/__tests__/sheets-item.test.mjs";
-import sheetsPlayerTests, {
-	key as sheetsPlayerKey,
-	options as sheetsPlayerOptions,
-} from "../sheets/__tests__/sheets-player.test.mjs";
-
-/* Apps import */
-// @todo: Write tests
+import sheetsActorNPCTests, {
+	key as sheetsActorNPCKey,
+	options as sheetsActorNPCOptions,
+} from "../sheets/__tests__/sheets-actor-npc.test.mjs";
+import sheetsActorPlayerTests, {
+	key as sheetsActorPlayerKey,
+	options as sheetsActorPlayerOptions,
+} from "../sheets/__tests__/sheets-actor-player.test.mjs";
 
 Hooks.on("quenchReady", async quench => {
-	// Utils test
+	// Base/Root test
+	quench.registerBatch(
+		baseConfigKey,
+		baseConfigTests,
+		baseConfigOptions
+	);
+	quench.registerBatch(
+		baseHandlebarsKey,
+		baseHandlebarsTests,
+		baseHandlebarsOptions
+	);
+	quench.registerBatch(
+		baseHooksKey,
+		baseHooksTests,
+		baseHooksOptions
+	);
+	quench.registerBatch(
+		baseSettingsKey,
+		baseSettingsTests,
+		baseSettingsOptions
+	);
+	quench.registerBatch(
+		baseTemplatesKey,
+		baseTemplatesTests,
+		baseTemplatesOptions
+	);
+
+	// Apps test
+	quench.registerBatch(
+		appsActiveEffectsKey,
+		appsActiveEffectsTests,
+		appsActiveEffectsOptions
+	);
+	quench.registerBatch(
+		appsArmorPropertiesKey,
+		appsArmorPropertiesTests,
+		appsArmorPropertiesOptions
+	);
+	quench.registerBatch(
+		appsGemBagKey,
+		appsGemBagTests,
+		appsGemBagOptions
+	);
+	quench.registerBatch(
+		appsItemPropertiesKey,
+		appsItemPropertiesTests,
+		appsItemPropertiesOptions
+	);
+	quench.registerBatch(
+		appsLightsourceTrackerKey,
+		appsLightsourceTrackerTests,
+		appsLightsourceTrackerOptions
+	);
+	quench.registerBatch(
+		appsMagicItemEffectsKey,
+		appsMagicItemEffectsTests,
+		appsMagicItemEffectsOptions
+	);
+	quench.registerBatch(
+		appsNPCAttackRangesKey,
+		appsNPCAttackRangesTests,
+		appsNPCAttackRangesOptions
+	);
+	quench.registerBatch(
+		appsPlayerLanguagesKey,
+		appsPlayerLanguagesTests,
+		appsPlayerLanguagesOptions
+	);
+	quench.registerBatch(
+		appsSpellcasterClassKey,
+		appsSpellcasterClassTests,
+		appsSpellcasterClassOptions
+	);
+	quench.registerBatch(
+		appsTalentTypesKey,
+		appsTalentTypesTests,
+		appsTalentTypesOptions
+	);
+	quench.registerBatch(
+		appsWeaponPropertiesKey,
+		appsWeaponPropertiesTests,
+		appsWeaponPropertiesOptions
+	);
+
+	// Chat test
 	quench.registerBatch(
 		chatChatcardKey,
 		chatChatcardTests,
@@ -75,9 +248,19 @@ Hooks.on("quenchReady", async quench => {
 
 	// Document tests
 	quench.registerBatch(
+		documentsActiveEffectsKey,
+		documentsActiveEffectsTests,
+		documentsActiveEffectsOptions
+	);
+	quench.registerBatch(
 		documentsActorKey,
 		documentsActorTests,
 		documentsActorOptions
+	);
+	quench.registerBatch(
+		documentsItemMagicItemsKey,
+		documentsItemMagicItemsTests,
+		documentsItemMagicItemsOptions
 	);
 	quench.registerBatch(
 		documentsItemsKey,
@@ -95,6 +278,19 @@ Hooks.on("quenchReady", async quench => {
 		documentsItemsTalentOptions
 	);
 
+	// Hooks test
+	quench.registerBatch(
+		hooksChatMessageKey,
+		hooksChatMessageTests,
+		hooksChatMessageOptions
+	);
+	quench.registerBatch(
+		hooksLightsourceTrackerKey,
+		hooksLightsourceTrackerTests,
+		hooksLightsourceTrackerOptions
+	);
+
+
 	// Sheet tests
 	quench.registerBatch(
 		sheetsActorKey,
@@ -107,10 +303,13 @@ Hooks.on("quenchReady", async quench => {
 		sheetsItemOptions
 	);
 	quench.registerBatch(
-		sheetsPlayerKey,
-		sheetsPlayerTests,
-		sheetsPlayerOptions
+		sheetsActorNPCKey,
+		sheetsActorNPCTests,
+		sheetsActorNPCOptions
 	);
-
-	// Apps test
+	quench.registerBatch(
+		sheetsActorPlayerKey,
+		sheetsActorPlayerTests,
+		sheetsActorPlayerOptions
+	);
 });


### PR DESCRIPTION
This PR should probably wait until after `1.0.0` release. It doesn't change anything, but adds the skeleton files for writings tests for everything in the system. 

I plan on starting to populate these after release. I plan on doing these in smaller batches, so it doesn't become a huge blob of tests by the end, and this is the structure I plan on building!