### PR TITLE
Updated Finnish translations for 1.0.1

### DIFF
--- a/i18n/fi.yaml
+++ b/i18n/fi.yaml
@@ -10,88 +10,88 @@ SHADOWDARK.ability_str: Voi
 SHADOWDARK.ability_strength: Voimakkuus
 SHADOWDARK.ability_wis: Vii
 SHADOWDARK.ability_wisdom: Viisaus
-SHADOWDARK.alignment.chaotic_short: C
-SHADOWDARK.alignment.chaotic: Chaotic
+SHADOWDARK.alignment.chaotic_short: K
+SHADOWDARK.alignment.chaotic: Kaoottinen
 SHADOWDARK.alignment.lawful_short: L
-SHADOWDARK.alignment.lawful: Lawful
+SHADOWDARK.alignment.lawful: Lainkuuliainen
 SHADOWDARK.alignment.neutral_short: 'N'
-SHADOWDARK.alignment.neutral: Neutral
-SHADOWDARK.app.gem_bag.sell_all: Sell All Gems
-SHADOWDARK.app.gem_bag.title: Gem Bag
-SHADOWDARK.app.gem_bag.tooltip.sell_gem: Sell Gem
-SHADOWDARK.app.gem_bag.total_value: Total Value
-SHADOWDARK.app.item_properties.armor.title: Armor Properties
-SHADOWDARK.app.item_properties.caster_classes.title: Caster Classes
-SHADOWDARK.app.item_properties.languages.title: Languages
+SHADOWDARK.alignment.neutral: Neutraali
+SHADOWDARK.app.gem_bag.sell_all: Myy kaikki jalokivet
+SHADOWDARK.app.gem_bag.title: Jalokivipussi
+SHADOWDARK.app.gem_bag.tooltip.sell_gem: Myy jalokivi
+SHADOWDARK.app.gem_bag.total_value: Yhteisarvo
+SHADOWDARK.app.item_properties.armor.title: Panssarin ominaisuudet
+SHADOWDARK.app.item_properties.caster_classes.title: Loihtimisluokat
+SHADOWDARK.app.item_properties.languages.title: Kielet
 SHADOWDARK.app.item_properties.save: Tallenna
-SHADOWDARK.app.item_properties.talent.effects.title: Talent Effect Types
+SHADOWDARK.app.item_properties.talent.effects.title: Lahjakkuus efektien tyypit
 SHADOWDARK.app.item_properties.title: Asetukset
-SHADOWDARK.app.item_properties.weapon.title: Weapon Properties
+SHADOWDARK.app.item_properties.weapon.title: Aseen ominaisuudet
 SHADOWDARK.app.light_tracker.minute_short: min
-SHADOWDARK.app.light_tracker.minutes_short: mins
-SHADOWDARK.app.light_tracker.title: Light Tracker
-SHADOWDARK.app.light-tracker.douse-light: Douse Light
-SHADOWDARK.app.light-tracker.turn-out-the-lights: Turn Out the Lights
+SHADOWDARK.app.light_tracker.minutes_short: min
+SHADOWDARK.app.light_tracker.title: Valon seuranta
+SHADOWDARK.app.light-tracker.douse-light: Sammuta valo
+SHADOWDARK.app.light-tracker.turn-out-the-lights: Sammuta kaikki valot
 SHADOWDARK.armor.properties.disadvantage_stealth: Haitta/Hiipiminen
 SHADOWDARK.armor.properties.disadvantage_swimming: Haitta/Uiminen
 SHADOWDARK.armor.properties.no_swimming: Ei voi uida
 SHADOWDARK.armor.properties.one_handed: Varaa yhden käden
 SHADOWDARK.armor.properties.shield: Kilpi
-SHADOWDARK.chat.item_roll.double_numerical: Double any one numerical value!
-SHADOWDARK.chat.item_roll.mishap: Roll on the appropriate Mishap table!
-SHADOWDARK.chat.item_roll.title: Attack roll with {name}
-SHADOWDARK.chat.spell_roll.title: Casting {name} at tier {tier} with spell DC {spellDC}
-SHADOWDARK.chatcard.default: Roll
-SHADOWDARK.class.fighter: Fighter
-SHADOWDARK.class.priest: Priest
-SHADOWDARK.class.thief: Thief
-SHADOWDARK.class.wizard: Wizard
+SHADOWDARK.chat.item_roll.double_numerical: Tuplaa yksi numeerinen arvo!
+SHADOWDARK.chat.item_roll.mishap: Heitä noppaa sopivaa loihtimisen tapahturmataulua vasten!
+SHADOWDARK.chat.item_roll.title: Hyökkäysheitto käyttäen {name}
+SHADOWDARK.chat.spell_roll.title: Loihditaan {name} tasolla {tier} jolloin vaikeusaste on {spellDC}
+SHADOWDARK.chatcard.default: Heitä noppaa
+SHADOWDARK.class.fighter: Taistelija
+SHADOWDARK.class.priest: Pappi
+SHADOWDARK.class.thief: Varas
+SHADOWDARK.class.wizard: Velho
 SHADOWDARK.coins.cp: Kupari
 SHADOWDARK.coins.gp: Kulta
 SHADOWDARK.coins.sp: Hopea
-SHADOWDARK.damage.one_handed: 'One-Handed Damage:'
-SHADOWDARK.damage.two_handed: 'Two-Handed Damage:'
-SHADOWDARK.dialog.ability_check.cha: Charisma Check
-SHADOWDARK.dialog.ability_check.con: Constitution Check
-SHADOWDARK.dialog.ability_check.dex: Dexterity Check
-SHADOWDARK.dialog.ability_check.int: Intelligence Check
-SHADOWDARK.dialog.ability_check.str: Strength Check
-SHADOWDARK.dialog.ability_check.title: Ability Check
-SHADOWDARK.dialog.ability_check.wis: Wisdom Check
+SHADOWDARK.damage.one_handed: 'Yksikätinen vahinko:'
+SHADOWDARK.damage.two_handed: 'Kaksikätinen vahinko:'
+SHADOWDARK.dialog.ability_check.cha: Karismaheitto
+SHADOWDARK.dialog.ability_check.con: Sitkeysheitto
+SHADOWDARK.dialog.ability_check.dex: Ketteryysheitto
+SHADOWDARK.dialog.ability_check.int: Älykkyysheitto
+SHADOWDARK.dialog.ability_check.str: Voimakkuusheitto
+SHADOWDARK.dialog.ability_check.title: Kyvykkyysheitto
+SHADOWDARK.dialog.ability_check.wis: Viisausheitto
 SHADOWDARK.dialog.general.are_you_sure: Oletko varma?
-SHADOWDARK.dialog.general.cancel: Cancel
-SHADOWDARK.dialog.general.no: 'No'
-SHADOWDARK.dialog.general.yes: 'Yes'
-SHADOWDARK.dialog.hp_roll: HP Roll
-SHADOWDARK.dialog.item_roll.ability_bonus: Ability Bonus
-SHADOWDARK.dialog.item_roll.item_bonus: Item Bonus
-SHADOWDARK.dialog.item_roll.talent_bonus: Talent Bonus
-SHADOWDARK.dialog.item_roll.title: Roll Attack with
-SHADOWDARK.dialog.item.confirm_delete: Confirm Deletion
-SHADOWDARK.dialog.item.confirm_sale: Confirm Sale
+SHADOWDARK.dialog.general.cancel: Peruuta
+SHADOWDARK.dialog.general.no: 'Ei'
+SHADOWDARK.dialog.general.yes: 'Kyllä'
+SHADOWDARK.dialog.hp_roll: Osumapisteheitto
+SHADOWDARK.dialog.item_roll.ability_bonus: Kykybonus
+SHADOWDARK.dialog.item_roll.item_bonus: Esinebonus
+SHADOWDARK.dialog.item_roll.talent_bonus: Lahjakkuusbonus
+SHADOWDARK.dialog.item_roll.title: Heitä hyökkäysheitto käyttäen
+SHADOWDARK.dialog.item.confirm_delete: Varmista poisto
+SHADOWDARK.dialog.item.confirm_sale: Varmista myyminen
 SHADOWDARK.dialog.item.delete: Poista
-SHADOWDARK.dialog.item.sell_all: Sell All
-SHADOWDARK.dialog.item.sell: Sell
-SHADOWDARK.dialog.roll_mode_label: Select rolling mode
-SHADOWDARK.dialog.roll: Roll
-SHADOWDARK.dialog.spell_roll.title: Roll Spell with
-SHADOWDARK.dialog.tooltip.talent_advantage: A talent is giving you advantage to this roll
-SHADOWDARK.effect.footer.add_custom: Add Custom Effect
-SHADOWDARK.effect.header.active: Active
-SHADOWDARK.effect.header.delete: Delete
-SHADOWDARK.effect.header.edit: Edit
-SHADOWDARK.effect.header.name: Effect
-SHADOWDARK.effect.header.options: Options
-SHADOWDARK.effect.item: Item Effects
-SHADOWDARK.effect.new: New Effect
-SHADOWDARK.effect.spell: Spell Effects
-SHADOWDARK.effect.talent: Talent Effects
-SHADOWDARK.effect.temporary: Temporary Effects
-SHADOWDARK.effect.unavailable: Disabled Effects
-SHADOWDARK.error.general.gm_required: You must have the Game Master role to do that.
+SHADOWDARK.dialog.item.sell_all: Myy kaikki
+SHADOWDARK.dialog.item.sell: Myy
+SHADOWDARK.dialog.roll_mode_label: Valitse heittotapa
+SHADOWDARK.dialog.roll: Heitä noppaa
+SHADOWDARK.dialog.spell_roll.title: Heitä loihtimisheitto käyttäen
+SHADOWDARK.dialog.tooltip.talent_advantage: Jokin lahjakkuuksistasi antaa sinulle edun tähän heittoon
+SHADOWDARK.effect.footer.add_custom: Lisää mukautettu efekti
+SHADOWDARK.effect.header.active: Aktivoi
+SHADOWDARK.effect.header.delete: Poista
+SHADOWDARK.effect.header.edit: Muokkaa
+SHADOWDARK.effect.header.name: Efekti
+SHADOWDARK.effect.header.options: Asetukset
+SHADOWDARK.effect.item: Esineen efektit
+SHADOWDARK.effect.new: Uusi efekti
+SHADOWDARK.effect.spell: Loitsun efektit
+SHADOWDARK.effect.talent: Lahjakkuuden efektit
+SHADOWDARK.effect.temporary: Väliaikaiset efektit
+SHADOWDARK.effect.unavailable: Poissaolevat efektit
+SHADOWDARK.error.general.gm_required: Tarvitset pelinjohtajan roolin tehdäksesi noin.
 SHADOWDARK.inventory.coins: Kolikot
-SHADOWDARK.inventory.item.light_remaining: '{timeRemaining} Mins Remaining'
-SHADOWDARK.inventory.item.light_used: (partially used)
+SHADOWDARK.inventory.item.light_remaining: '{timeRemaining} minuuttia jäljellä'
+SHADOWDARK.inventory.item.light_used: (osittain käytetty)
 SHADOWDARK.inventory.label.quantity: Kpl
 SHADOWDARK.inventory.label.slots: Varusteet/Tarvikkeet
 SHADOWDARK.inventory.section.armor: Panssari
@@ -104,9 +104,9 @@ SHADOWDARK.inventory.slots: Tarviketila
 SHADOWDARK.inventory.tooltip.gem_bag: Avaa jalokivipussi
 SHADOWDARK.inventory.tooltip.item_decrement: Vähennä määrää
 SHADOWDARK.inventory.tooltip.item_increment: Lisää määrää
-SHADOWDARK.inventory.tooltip.sell_treasure: Sell Treasure
+SHADOWDARK.inventory.tooltip.sell_treasure: Myy aarre
 SHADOWDARK.inventory.tooltip.toggle_equipped: Ota käyttöön
-SHADOWDARK.inventory.tooltip.toggle_light_source: Toggle Light Source
+SHADOWDARK.inventory.tooltip.toggle_light_source: Sammuta/Sytytä valonlähde
 SHADOWDARK.inventory.total_coins: Kolikoita yhteensä
 SHADOWDARK.inventory.total_gems: Jalokiviä yhteensä
 SHADOWDARK.item_type.armor: Panssari
@@ -125,142 +125,142 @@ SHADOWDARK.item.inventory_free_carry: Vapaat kannettavat
 SHADOWDARK.item.inventory_per_slot: Maksimi per tarviketila
 SHADOWDARK.item.inventory_quantity: Lukumäärä
 SHADOWDARK.item.inventory_slots: Tarviketiloja per esine
-SHADOWDARK.item.level: Level
-SHADOWDARK.item.light.is_source: Light Source
-SHADOWDARK.item.light.longevity: Longevity (Mins)
-SHADOWDARK.item.light.remaining: Remaining (Mins)
+SHADOWDARK.item.level: Taso
+SHADOWDARK.item.light.is_source: Valonlähde
+SHADOWDARK.item.light.longevity: Kestoaika (min)
+SHADOWDARK.item.light.remaining: Jäljellä (min)
 SHADOWDARK.item.properties: Asetukset
-SHADOWDARK.item.spell_caster_classes: Caster Classes
-SHADOWDARK.item.spell_duration: Duration
-SHADOWDARK.item.spell_range: Range
-SHADOWDARK.item.spell_tier: Tier
-SHADOWDARK.item.treasure: Treasure
+SHADOWDARK.item.spell_caster_classes: Loihtimisluokat
+SHADOWDARK.item.spell_duration: Kestoaika
+SHADOWDARK.item.spell_range: Kantama
+SHADOWDARK.item.spell_tier: Loitsutaso
+SHADOWDARK.item.treasure: Aarre
 SHADOWDARK.item.weapon_damage.oneHanded_short: 1H
 SHADOWDARK.item.weapon_damage.oneHanded: Vahinkoa yhdellä kädellä
 SHADOWDARK.item.weapon_damage.twoHanded_short: 2H
 SHADOWDARK.item.weapon_damage.twoHanded: Vahinkoa kahdella kädellä
 SHADOWDARK.item.weapon_range: Kantama
 SHADOWDARK.item.weapon_type: Aseen tyyppi
-SHADOWDARK.language.celestial: Celestial
-SHADOWDARK.language.common: Common
-SHADOWDARK.language.diabolic: Diabolic
-SHADOWDARK.language.draconic: Draconic
-SHADOWDARK.language.dwarvish: Dwarvish
-SHADOWDARK.language.elvish: Elvish
-SHADOWDARK.language.giant: Giant
-SHADOWDARK.language.goblin: Goblin
-SHADOWDARK.language.merran: Merran
-SHADOWDARK.language.orcish: Orcish
-SHADOWDARK.language.primordial: Primordial
+SHADOWDARK.language.celestial: Valonkieli
+SHADOWDARK.language.common: Yleiskieli
+SHADOWDARK.language.diabolic: Pimeydenpuhe
+SHADOWDARK.language.draconic: Lohikäärme
+SHADOWDARK.language.dwarvish: Kääpiö
+SHADOWDARK.language.elvish: Haltia
+SHADOWDARK.language.giant: Jätti
+SHADOWDARK.language.goblin: Peikkolaiskieli
+SHADOWDARK.language.merran: Meripuhe
+SHADOWDARK.language.orcish: Örkki
+SHADOWDARK.language.primordial: Alkukieli
 SHADOWDARK.language.reptilian: Reptilian
-SHADOWDARK.language.sylvan: Sylvan
-SHADOWDARK.language.thanian: Thanian
-SHADOWDARK.light-tracker.active: Active
-SHADOWDARK.light-tracker.paused: Paused
-SHADOWDARK.light-tracker.status.label: Status
-SHADOWDARK.light-tracker.title.prefix: Light
-SHADOWDARK.light-tracker.title.suffix: Tracker
-SHADOWDARK.range.close_short: C
+SHADOWDARK.language.sylvan: Salokieli
+SHADOWDARK.language.thanian: Petopuhe
+SHADOWDARK.light-tracker.active: Aktiivinen
+SHADOWDARK.light-tracker.paused: Pausetettu
+SHADOWDARK.light-tracker.status.label: Tila
+SHADOWDARK.light-tracker.title.prefix: Valo
+SHADOWDARK.light-tracker.title.suffix: Seurain
+SHADOWDARK.range.close_short: V
 SHADOWDARK.range.close: Vieressä
-SHADOWDARK.range.far_short: F
+SHADOWDARK.range.far_short: K
 SHADOWDARK.range.far: Kaukana
-SHADOWDARK.range.near_short: 'N'
+SHADOWDARK.range.near_short: 'L'
 SHADOWDARK.range.near: Lähellä
-SHADOWDARK.range.self_short: S
-SHADOWDARK.range.self: Self
-SHADOWDARK.roll.advantage_title: '{title} with Advantage'
-SHADOWDARK.roll.advantage: Advantage
-SHADOWDARK.roll.critical.failure: Critical Failure! ({value})
-SHADOWDARK.roll.critical.success: Critical Success! ({value})
-SHADOWDARK.roll.D20: Roll D20
-SHADOWDARK.roll.damage: 'Damage Roll:'
-SHADOWDARK.roll.disadvantage_title: '{title} with Disadvantage'
-SHADOWDARK.roll.disadvantage: Disadvantage
-SHADOWDARK.roll.failure: Failure! ({value})
-SHADOWDARK.roll.normal: Normal
-SHADOWDARK.roll.spell_casting_check: Spellcasting Check
-SHADOWDARK.roll.success: Success! ({value})
-SHADOWDARK.settings.track_light_sources.hint: If checked the system will track and update the time remaining on any active light sources.
-SHADOWDARK.settings.track_light_sources.inactive_user.hint: If checked light sources belonging to inactive (not logged in) users will still be tracked
-SHADOWDARK.settings.track_light_sources.inactive_user.name: Track Inactive User Light Sources
-SHADOWDARK.settings.track_light_sources.interval.hint: How frequently tracked light sources will be updated, in minutes.
-SHADOWDARK.settings.track_light_sources.interval.name: Light Tracking Interval
-SHADOWDARK.settings.track_light_sources.name: Track Light Sources
-SHADOWDARK.settings.track_light_sources.open_on_start.hint: If checked the Light Tracking interface will open on startup (GM only).
-SHADOWDARK.settings.track_light_sources.open_on_start.name: Open Light Tracking UI on Startup
-SHADOWDARK.settings.track_light_sources.pause_with_game.hint: If checked the Light Tracking will pause whenever Foundry is paused.
-SHADOWDARK.settings.track_light_sources.pause_with_game.name: Pause Light Tracking
-SHADOWDARK.sheet.actor.ac: AC
-SHADOWDARK.sheet.actor.alignment_short: Align
-SHADOWDARK.sheet.actor.alignment: Alignment
+SHADOWDARK.range.self_short: I
+SHADOWDARK.range.self: Itse
+SHADOWDARK.roll.advantage_title: '{title} edun kanssa'
+SHADOWDARK.roll.advantage: Etu
+SHADOWDARK.roll.critical.failure: Kriittinen epäonnistuminen! ({value})
+SHADOWDARK.roll.critical.success: Kriittinen onnistuminen! ({value})
+SHADOWDARK.roll.D20: Heitä n20
+SHADOWDARK.roll.damage: 'Heitä vahinkonoppa:'
+SHADOWDARK.roll.disadvantage_title: '{title} haitan kanssa'
+SHADOWDARK.roll.disadvantage: Haitta
+SHADOWDARK.roll.failure: Epäonnistui! ({value})
+SHADOWDARK.roll.normal: Normaali
+SHADOWDARK.roll.spell_casting_check: Loihtimistesti
+SHADOWDARK.roll.success: Onnistui! ({value})
+SHADOWDARK.settings.track_light_sources.hint: Jos valitset tämän, järjestelmä seuraa ja päivittää aktiivisten valonlähteiden jäljellä olevaa aikaa.
+SHADOWDARK.settings.track_light_sources.inactive_user.hint: Jos valitset tämän, järjestelmä seuraa epäaktiivisten (uloskirjautuneiden) käyttäjien valonlähteitä.
+SHADOWDARK.settings.track_light_sources.inactive_user.name: Seuraa epäaktiivisten käyttäjien valonlähteitä
+SHADOWDARK.settings.track_light_sources.interval.hint: Kuinka usein seurattuja valonlähteitä päivitetään (minuuteissa).
+SHADOWDARK.settings.track_light_sources.interval.name: Valonlähteiden seurannan intervalli
+SHADOWDARK.settings.track_light_sources.name: Seuraa valonlähteiden aikaa
+SHADOWDARK.settings.track_light_sources.open_on_start.hint: Jos valitset tämän, valonlähteiden seurannan ikkuna avautuu järjestelmän käynnistyksen yhteydessä. (vain pelimestarille)
+SHADOWDARK.settings.track_light_sources.open_on_start.name: Avaa valonlähteiden seurannan ikkuna käynnistyksen yhteydessä
+SHADOWDARK.settings.track_light_sources.pause_with_game.hint: Jos valitset tämän, valonlähteiden seurannan ajastimet eivät tikitä Foundryn ollessa pausella.
+SHADOWDARK.settings.track_light_sources.pause_with_game.name: Pauseta valonlähteiden seuranta
+SHADOWDARK.sheet.actor.ac: Puolustuspisteet
+SHADOWDARK.sheet.actor.alignment_short: Vakaus
+SHADOWDARK.sheet.actor.alignment: Vakaumus
 SHADOWDARK.sheet.actor.hp_max: Max
-SHADOWDARK.sheet.actor.hp: HP
-SHADOWDARK.sheet.actor.level: Level
-SHADOWDARK.sheet.actor.placeholder.name: New Actor Name
+SHADOWDARK.sheet.actor.hp: Osumapisteet
+SHADOWDARK.sheet.actor.level: Taso
+SHADOWDARK.sheet.actor.placeholder.name: Uusi nimi
 SHADOWDARK.sheet.class.item: Shadowdark esineikkuna
-SHADOWDARK.sheet.class.npc: Shadowdark NPC Sheet
+SHADOWDARK.sheet.class.npc: Shadowdark NPC ikkuna
 SHADOWDARK.sheet.class.player: Shadowdark hahmoikkuna
 SHADOWDARK.sheet.general.item_delete.title: Poista esine
 SHADOWDARK.sheet.general.item_edit.title: Muokkaa esinettä
-SHADOWDARK.sheet.npc.attacks_label: Attacks
-SHADOWDARK.sheet.npc.dark_adapted: Dark-Adapted
-SHADOWDARK.sheet.npc.dark-adapted: Dark-Adapted
-SHADOWDARK.sheet.npc.description_label: Description
-SHADOWDARK.sheet.npc.movement_short: Move
-SHADOWDARK.sheet.npc.movement: Movement
-SHADOWDARK.sheet.npc.special_label: Special
-SHADOWDARK.sheet.npc.tab.abilities: Abilities
-SHADOWDARK.sheet.npc.tab.description: Description
+SHADOWDARK.sheet.npc.attacks_label: Hyökkäykset
+SHADOWDARK.sheet.npc.dark_adapted: Sopeutunut pimeään
+SHADOWDARK.sheet.npc.dark-adapted: Sopeutunut pimeään
+SHADOWDARK.sheet.npc.description_label: Kuvaus
+SHADOWDARK.sheet.npc.movement_short: Liike
+SHADOWDARK.sheet.npc.movement: Liikkumisnopeus
+SHADOWDARK.sheet.npc.special_label: Erikoisuudet
+SHADOWDARK.sheet.npc.tab.abilities: Kyvyt
+SHADOWDARK.sheet.npc.tab.description: Kuvaus
 SHADOWDARK.sheet.player.ancestry: Laji
 SHADOWDARK.sheet.player.background: Tausta
 SHADOWDARK.sheet.player.class: Hahmoluokka
 SHADOWDARK.sheet.player.deity: Jumala
 SHADOWDARK.sheet.player.languages: Languages
 SHADOWDARK.sheet.player.luck: Tuuripiste
-SHADOWDARK.sheet.player.melee_attacks: Melee Attacks
+SHADOWDARK.sheet.player.melee_attacks: Lähihyökkäykset
 SHADOWDARK.sheet.player.notes: Muistiinpanot
-SHADOWDARK.sheet.player.ranged_attacks: Ranged Attacks
-SHADOWDARK.sheet.player.spells_tier: Tier
+SHADOWDARK.sheet.player.ranged_attacks: Kantamahyökkäykset
+SHADOWDARK.sheet.player.spells_tier: Loitsutaso
 SHADOWDARK.sheet.player.spells: Loitsut
 SHADOWDARK.sheet.player.tab.abilities: Kyvyt
 SHADOWDARK.sheet.player.tab.background: Tausta
 SHADOWDARK.sheet.player.tab.inventory: Kantamukset
 SHADOWDARK.sheet.player.tab.spells: Loitsut
 SHADOWDARK.sheet.player.tab.talents: Lahjakkuudet
-SHADOWDARK.sheet.player.talents_level: Level
-SHADOWDARK.sheet.player.talents_name: Name
+SHADOWDARK.sheet.player.talents_level: Taso
+SHADOWDARK.sheet.player.talents_name: Nimi
 SHADOWDARK.sheet.player.talents: Lahjakkuudet
 SHADOWDARK.sheet.player.title: Arvonimi
-SHADOWDARK.sheet.player.toggle_spell_lost: Toggle Spell Lost
-SHADOWDARK.sheet.player.tooltip.cast_spell: Cast Spell
+SHADOWDARK.sheet.player.toggle_spell_lost: Merkkaa menetetty loitsu
+SHADOWDARK.sheet.player.tooltip.cast_spell: Loihdi loitsu
 SHADOWDARK.sheet.player.xp: Kokemuspisteet
-SHADOWDARK.spell_caster.priest: Priest
-SHADOWDARK.spell_caster.wizard: Wizard
-SHADOWDARK.spell_duration.days: Days
+SHADOWDARK.spell_caster.priest: Pappi
+SHADOWDARK.spell_caster.wizard: Velho
+SHADOWDARK.spell_duration.days: Päivää
 SHADOWDARK.spell_duration.focus: Keskittyessä
 SHADOWDARK.spell_duration.instant: Välitön
-SHADOWDARK.spell_duration.real_time: Real Time
+SHADOWDARK.spell_duration.real_time: Oikea aika
 SHADOWDARK.spell_duration.rounds: Kierrosta
 SHADOWDARK.spell_range.close: Vieressä
 SHADOWDARK.spell_range.far: Kaukana
 SHADOWDARK.spell_range.near: Lähellä
-SHADOWDARK.spellcasting_ability: Spellcasting Ability
-SHADOWDARK.talent.backstab: Backstab
-SHADOWDARK.talent.type.ability_improvement: Ability Improvement
-SHADOWDARK.talent.type.advantage.hp: HP Roll Advantage
-SHADOWDARK.talent.type.advantage.initiative: Initiative Advantage
-SHADOWDARK.talent.type.advantage.spell: Spellcasting Advantage
-SHADOWDARK.talent.type.advantage.title: Advantage Bonus
-SHADOWDARK.talent.type.armor_bonus: Armor AC Bonus
-SHADOWDARK.talent.type.backstab_die: Extra Backstab Die
-SHADOWDARK.talent.type.custom: Custom Talent
-SHADOWDARK.talent.type.melee_attack_bonus: Melee Attack Roll Bonus
-SHADOWDARK.talent.type.melee_damage_bonus: Melee Damage Roll Bonus
-SHADOWDARK.talent.type.ranged_attack_bonus: Ranged Attack Roll Bonus
-SHADOWDARK.talent.type.ranged_damage_bonus: Ranged Damage Roll Bonus
-SHADOWDARK.talent.type.spell_bonus: Spellcasting Bonus
-SHADOWDARK.talent.type.title: Talent Type(s)
-SHADOWDARK.talent.type.weapon_mastery: Weapon Mastery
+SHADOWDARK.spellcasting_ability: Loihtimiskyky
+SHADOWDARK.talent.backstab: Yllätyshyökkäys
+SHADOWDARK.talent.type.ability_improvement: Kyvyn parannus
+SHADOWDARK.talent.type.advantage.hp: Osumapisteiden heitto edun kanssa
+SHADOWDARK.talent.type.advantage.initiative: Aloiteheitot edun kanssa
+SHADOWDARK.talent.type.advantage.spell: Loihtiminen edun kanssa
+SHADOWDARK.talent.type.advantage.title: Etubonus
+SHADOWDARK.talent.type.armor_bonus: Puolustuspistebonus panssarista
+SHADOWDARK.talent.type.backstab_die: Lisänoppa yllätyshyökkäykseen
+SHADOWDARK.talent.type.custom: Mukautettu lahjakkuus
+SHADOWDARK.talent.type.melee_attack_bonus: Lähitaistelun hyökkäysheittoihin bonus
+SHADOWDARK.talent.type.melee_damage_bonus: Lähitaistelun vahinkoheittoihin bonus
+SHADOWDARK.talent.type.ranged_attack_bonus: Kantama-aseiden hyökkäysheittoihin bonus
+SHADOWDARK.talent.type.ranged_damage_bonus: Kantama-aseiden vahinkoheittoihin bonus
+SHADOWDARK.talent.type.spell_bonus: Loihtimisbonus
+SHADOWDARK.talent.type.title: Lahjakkuustyypit
+SHADOWDARK.talent.type.weapon_mastery: Asemestaruus
 SHADOWDARK.weapon.properties.finesse: Hienovarainen
 SHADOWDARK.weapon.properties.loading: Ladattava
 SHADOWDARK.weapon.properties.thrown: Heitettävä
@@ -268,38 +268,38 @@ SHADOWDARK.weapon.properties.two_handed: Kaksikätinen
 SHADOWDARK.weapon.properties.versatile: Yhden tai kahden käden ase
 SHADOWDARK.weapon.type.melee: Lähitaistelu ase
 SHADOWDARK.weapon.type.ranged: Kantama-ase
-SHADOWDARK.item.magic_item.is_magic: Magic Item
-SHADOWDARK.item.magic_item.title: Magic Item Effect(s)
-SHADOWDARK.item.magic_item.type.critMultiplier: Critical Multiplier
-SHADOWDARK.item.magic_item.type.attackBonus: Attack Bonus
-SHADOWDARK.item.magic_item.type.damageBonus: Damage Bonus
-SHADOWDARK.item.magic_item.type.permanentAbility: Permanent Ability Change
-SHADOWDARK.item.magic_item.type.criticalSuccessThreshold: Lower Critical Success Threshold
-SHADOWDARK.item.magic_item.type.criticalFailureThreshold: Higher Critical Failure Threshold
-SHADOWDARK.item.magic_item.type.custom: Custom Effect
-SHADOWDARK.app.item_properties.magic_item.effects.title: Magic Item Effects
-SHADOWDARK.effect.custom: Custom Effects
-SHADOWDARK.app.active_effects.title: Active Effects
-SHADOWDARK.sheet.player.available_spells: Available Spells
-SHADOWDARK.item.armor.base_armor.title: Base Armor
-SHADOWDARK.item.armor.base_armor.chainmail: Chainmail
-SHADOWDARK.item.armor.base_armor.leather_armor: Leather Armor
-SHADOWDARK.item.armor.base_armor.plate_mail: Plate Mail
-SHADOWDARK.item.armor.base_armor.shield: Shield
-SHADOWDARK.item.armor.base_weapon.title: Base Weapon
-SHADOWDARK.item.weapon.base_weapon.bastard_sword: Bastard Sword
-SHADOWDARK.item.weapon.base_weapon.club: Club
-SHADOWDARK.item.weapon.base_weapon.crossbow: Crossbow
-SHADOWDARK.item.weapon.base_weapon.dagger: Dagger
-SHADOWDARK.item.weapon.base_weapon.greataxe: Greataxe
-SHADOWDARK.item.weapon.base_weapon.greatsword: Greatsword
-SHADOWDARK.item.weapon.base_weapon.javelin: Javelin
-SHADOWDARK.item.weapon.base_weapon.longbow: Longbow
-SHADOWDARK.item.weapon.base_weapon.longsword: Longsword
-SHADOWDARK.item.weapon.base_weapon.mace: Mace
-SHADOWDARK.item.weapon.base_weapon.shortbow: Shortbow
-SHADOWDARK.item.weapon.base_weapon.shortsword: Shortsword
-SHADOWDARK.item.weapon.base_weapon.spear: Spear
-SHADOWDARK.item.weapon.base_weapon.staff: Staff
-SHADOWDARK.item.weapon.base_weapon.wand: Wand
-SHADOWDARK.item.weapon.base_weapon.warhammer: Warhammer
+SHADOWDARK.item.magic_item.is_magic: Taikaesine
+SHADOWDARK.item.magic_item.title: Taikaesineen efektit
+SHADOWDARK.item.magic_item.type.critMultiplier: Kriittisen kerroin
+SHADOWDARK.item.magic_item.type.attackBonus: Hyökkäysbonus
+SHADOWDARK.item.magic_item.type.damageBonus: Vahinkobonus
+SHADOWDARK.item.magic_item.type.permanentAbility: Pysyvä muutos kykyyn
+SHADOWDARK.item.magic_item.type.criticalSuccessThreshold: Alempi kynnys kriittiseen onnistumiseen
+SHADOWDARK.item.magic_item.type.criticalFailureThreshold: Korkeampi kynnys kriittiseen epäonnistumiseen
+SHADOWDARK.item.magic_item.type.custom: Mukautettu efekti
+SHADOWDARK.app.item_properties.magic_item.effects.title: Taikaesineiden efektit
+SHADOWDARK.effect.custom: Mukautetut efektit
+SHADOWDARK.app.active_effects.title: Aktiiviset efektit
+SHADOWDARK.sheet.player.available_spells: Saatavilla olevat loitsut
+SHADOWDARK.item.armor.base_armor.title: Pohjapuolustus
+SHADOWDARK.item.armor.base_armor.chainmail: Rengaspanssari
+SHADOWDARK.item.armor.base_armor.leather_armor: Nahkapanssari
+SHADOWDARK.item.armor.base_armor.plate_mail: Levypanssari
+SHADOWDARK.item.armor.base_armor.shield: Kilpi
+SHADOWDARK.item.armor.base_weapon.title: Pohja-ase
+SHADOWDARK.item.weapon.base_weapon.bastard_sword: Äpärämiekka
+SHADOWDARK.item.weapon.base_weapon.club: Nuija
+SHADOWDARK.item.weapon.base_weapon.crossbow: Varsijousi
+SHADOWDARK.item.weapon.base_weapon.dagger: Tikari
+SHADOWDARK.item.weapon.base_weapon.greataxe: Suurkirves
+SHADOWDARK.item.weapon.base_weapon.greatsword: Suurmiekka
+SHADOWDARK.item.weapon.base_weapon.javelin: Heittokeihäs
+SHADOWDARK.item.weapon.base_weapon.longbow: Pitkäjousi
+SHADOWDARK.item.weapon.base_weapon.longsword: Pitkämiekka
+SHADOWDARK.item.weapon.base_weapon.mace: Rautanuija
+SHADOWDARK.item.weapon.base_weapon.shortbow: Lyhytjousi
+SHADOWDARK.item.weapon.base_weapon.shortsword: Lyhytmiekka
+SHADOWDARK.item.weapon.base_weapon.spear: Keihäs
+SHADOWDARK.item.weapon.base_weapon.staff: Sauva
+SHADOWDARK.item.weapon.base_weapon.wand: Taikasauva
+SHADOWDARK.item.weapon.base_weapon.warhammer: Sotavasara


### PR DESCRIPTION
Updated Finnish translations for 1.0.1
"AC" and "HP" are quite a bit longer and I noticed the Swedish translations kept these in. I think it might be fine to use them if this breaks any layouts.