### PR TITLE
fix(ae): Custom talents prevented app display

### DIFF
--- a/system/src/apps/ActiveEffectsSD.mjs
+++ b/system/src/apps/ActiveEffectsSD.mjs
@@ -15,8 +15,10 @@ export default class ActiveEffectsSD extends FormApplication {
 		const values = this.object.effects.contents.filter(ae => !ae.disabled);
 
 		for (const key of values) {
-			this.effects[key.label].selected = true;
-			this.effects[key.label].id = key._id;
+			if (Object.keys(this.effects).includes(key.label)) {
+				this.effects[key.label].selected = true;
+				this.effects[key.label].id = key._id;
+			}
 		}
 	}
 


### PR DESCRIPTION
When a custom effect was renamed, it caused an error that prevented the selector app to open. This fixes that.