### PR TITLE
fix: #221 Tour Settings

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+## v1.x.x
+
+### Bugfixes
+* [#221] Lightsource tracker tour now require the tracker to be on, otherwise warns. Also stores and restores original settings (assuming the user doesn't restart the world or the tour within a 10 minute interval).
+
+### Enhancements
+
 ## v1.1.0
 
 ### Bugfixes

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -339,6 +339,7 @@ SHADOWDARK.talent.type.ranged_damage_bonus: Ranged Damage Roll Bonus
 SHADOWDARK.talent.type.spell_bonus: Spellcasting Bonus
 SHADOWDARK.talent.type.title: Talent Type(s)
 SHADOWDARK.talent.type.weapon_mastery: Weapon Mastery
+SHADOWDARK.tours.lightsource.notification.not_enabled: You need to enable the Lightsource Tracker in settings to be able to run the Tour
 SHADOWDARK.weapon.properties.finesse: Finesse
 SHADOWDARK.weapon.properties.loading: Loading
 SHADOWDARK.weapon.properties.thrown: Thrown

--- a/system/src/tours/ShadowdarkTourLightsourceTracker.mjs
+++ b/system/src/tours/ShadowdarkTourLightsourceTracker.mjs
@@ -164,7 +164,7 @@ export default class ShadowdarkLightsourceTrackerTour extends ShadowdarkTour {
 	async _preStep() {
 		if (!game.settings.get("shadowdark", "trackLightSources")) {
 			ui.notifications.info(
-				"You need to enable the Lightsource Tracker in settings to be able to run the Tour",
+				game.i18n.localize("SHADOWDARK.tours.lightsource.notification.not_enabled"),
 				{permanent: true}
 			);
 			await document.querySelector("button[data-action=configure]").click();

--- a/system/src/tours/ShadowdarkTourLightsourceTracker.mjs
+++ b/system/src/tours/ShadowdarkTourLightsourceTracker.mjs
@@ -152,12 +152,35 @@ export default class ShadowdarkLightsourceTrackerTour extends ShadowdarkTour {
 		});
 	}
 
+	async _setSettings(settings) {
+		for (const [key, value] of Object.entries(settings)) {
+			await game.settings.set("shadowdark", key, value);
+		}
+	}
+
 	/**
    * Override _preStep to wait for elements to exist in the DOM
    */
 	async _preStep() {
+		if (!game.settings.get("shadowdark", "trackLightSources")) {
+			ui.notifications.info(
+				"You need to enable the Lightsource Tracker in settings to be able to run the Tour",
+				{permanent: true}
+			);
+			await document.querySelector("button[data-action=configure]").click();
+			await delay(200);
+			await document.querySelector("a.category-tab[data-tab=system]").click();
+			await this.reset();
+			return this.exit();
+		}
+
 		const MOCK_ACTOR_NAME = "Ms Fire-guide";
 		const MOCK_USER = "The Tour Guide";
+		const TOUR_SETTINGS = {
+			trackLightSourcesOpen: false,
+			trackInactiveUserLightSources: true,
+			pauseLightTrackingWithGame: true,
+		};
 
 		if (this.currentStep.id === "sd-lightsourcetracker-goto-tracker") {
 			// Clean-up previous tours if we have restarted
@@ -188,6 +211,30 @@ export default class ShadowdarkLightsourceTrackerTour extends ShadowdarkTour {
 
 			// Go to chat
 			document.querySelector('a[data-tab="chat"]').click();
+
+			// Check if the tour was started the last 10 minutes, if it was, then do not
+			// re-record the original settings. Otherwise, store current settings with runtime data.
+			if (!(
+				game.world.flags.tours
+				&& game.world.flags.tours.lightSourceTracker
+				&& (game.world.flags.tours.lightSourceTracker.lastRun - Date.now()) < 10*60*1000
+			)) {
+				// Store data for the run
+				game.world.flags.tours = {
+					lightsourceTracker: {
+						lastRun: Date.now(),
+						schemaVersion: game.settings.get("shadowdark", "schemaVersion"),
+						originalSettings: {
+							trackLightSourcesOpen: game.settings.get("shadowdark", "trackLightSourcesOpen"),
+							trackInactiveUserLightSources: game.settings.get("shadowdark", "trackInactiveUserLightSources"),
+							pauseLightTrackingWithGame: game.settings.get("shadowdark", "pauseLightTrackingWithGame"),
+						},
+					},
+				};
+			}
+
+			// Set the temporary settings
+			await this._setSettings(TOUR_SETTINGS);
 
 			// Render the lighttracker UI
 			if (!game.shadowdark.lightSourceTracker.rendered) {
@@ -231,6 +278,9 @@ export default class ShadowdarkLightsourceTrackerTour extends ShadowdarkTour {
 			await delay(200);
 			game.actors.filter(a => a.name === MOCK_ACTOR_NAME).forEach(a => a.delete());
 			game.users.find(u => u.name === MOCK_USER).delete();
+
+			// Restore the settings
+			await this._setSettings(game.world.flags.tours.lightsourceTracker.originalSettings);
 		}
 
 		await super._preStep();


### PR DESCRIPTION
I couldn't set the settings temporary for enabling the lightsource tracker as it requires a reload. So I did the next best thing, I put a notification and show the system settings to enable it.

resolves #221 