### PR TITLE
chore(test): Lightsource Tracker

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+## V1.x.x
+
+### Bugfixes
+
+### Enhancements
+* [#241] Adds end to end testing for Lightsource Tracker
+
 ## v1.1.2
 
 ### Bugfixes

--- a/system/src/apps/__tests__/apps-lightsource-tracker.test.mjs
+++ b/system/src/apps/__tests__/apps-lightsource-tracker.test.mjs
@@ -12,6 +12,21 @@ export const options = {
 };
 
 export default ({ describe, it, after, beforeEach, before, expect }) => {
+	const originalSettings = {
+		trackLightSources: game.settings.get("shadowdark", "trackLightSources"),
+		trackInactiveUserLightSources: game.settings.get("shadowdark", "trackInactiveUserLightSources"),
+	};
+	const wasPaused = game.paused;
+
+	after(async () => {
+		for (const [key, value] of Object.entries(originalSettings)) {
+			await game.settings.set(
+				"shadowdark", key, value
+			);
+		}
+		game.togglePause(wasPaused);
+	});
+
 	describe("constructor(object, options)", () => {
 		it("can construct", () => {
 			const app = new LightSourceTrackerSD();
@@ -22,10 +37,14 @@ export default ({ describe, it, after, beforeEach, before, expect }) => {
 			const app = new LightSourceTrackerSD();
 			it("has the expected data", () => {
 				expect(app.monitoredLightSources.length).equal(0);
-				expect(app.updateInterval).equal(60*1000);
+				expect(app.updateInterval).equal(30*1000);
 				expect(app.updateIntervalId).is.null;
 				expect(app.lastUpdate).is.not.null;
 				expect(app.updatingLightSources).is.false;
+				expect(app.housekeepingInterval).equal(1000);
+				expect(app.housekeepingIntervalId).is.null;
+				expect(app.dirty).is.true;
+				expect(app.performingTick).is.false;
 				expect(app.pauseWithGame).is.true;
 			});
 		});
@@ -75,7 +94,7 @@ export default ({ describe, it, after, beforeEach, before, expect }) => {
 	});
 
 	describe("render(force, options)", () => {
-		// @todo: Write tests if you figure out how to mock another user
+		// Tested by E2E
 	});
 
 	describe("start()", () => {
@@ -102,38 +121,37 @@ export default ({ describe, it, after, beforeEach, before, expect }) => {
 	});
 
 	describe("toggleInterface()", () => {
-		// @todo: Write tests if you figure out how to mock another user
+		// Tested by E2E
 	});
 
 	describe("toggleLightSource()", () => {
-		// @todo: Figure out how to test sockets
-		// @todo: Mock an actor and test if there is a socket message in console
-		// @todo: Mock actor and activate a lightsource
+		// Tested by E2E
 	});
 
 	describe("_gatherLightSources()", () => {
-		// @todo: Mock actor and activate a lightsource
+		// Tested by E2E
 	});
 
-	describe("_isDisabled()", () => {
-		it("opposite of setting", () => {
-			const setting = game.settings.get(
-				"shadowdark", "trackLightSources"
-			);
-			expect(setting).is.not.undefined;
-			const app = new LightSourceTrackerSD();
-			expect(app._isDisabled()).equal(!setting);
+	describe("_deleteActorHook(actor, options, userId)", () => {
+		// Unable to test this with potential active tracker
+	});
+
+	describe("_deleteItemHook(item, options, userId)", () => {
+		// Unable to test this with potential active tracker
+	});
+
+	describe("_isEnabled() & _isDisabled()", () => {
+		const app = new LightSourceTrackerSD();
+		it("returns false when not enabled", async () => {
+			await game.settings.set("shadowdark", "trackLightSources", false);
+			expect(app._isEnabled()).is.false;
+			expect(app._isDisabled()).is.true;
 		});
-	});
 
-	describe("_isEnabled()", () => {
-		it("required trackLightSources settings exists", () => {
-			const setting = game.settings.get(
-				"shadowdark", "trackLightSources"
-			);
-			expect(setting).is.not.undefined;
-			const app = new LightSourceTrackerSD();
-			expect(app._isEnabled()).equal(setting);
+		it("returns false when not enabled", async () => {
+			await game.settings.set("shadowdark", "trackLightSources", true);
+			expect(app._isEnabled()).is.true;
+			expect(app._isDisabled()).is.false;
 		});
 	});
 
@@ -205,39 +223,42 @@ export default ({ describe, it, after, beforeEach, before, expect }) => {
 		});
 	});
 
+	describe("_makeDirty()", () => {
+		// This marks the lightsourceTracker as dirty, which then
+		// will have _updateLightSources() run through the interval.
+		// Thus tested by _updateLightSources()
+	});
+
 	describe("_monitorInactiveUsers()", () => {
-		it("required trackInactiveUserLightSources settings exists", () => {
-			const setting = game.settings.get(
-				"shadowdark", "trackInactiveUserLightSources"
-			);
-			expect(setting).is.not.undefined;
-			const app = new LightSourceTrackerSD();
-			expect(app._monitorInactiveUsers()).equal(setting);
+		const app = new LightSourceTrackerSD();
+		it("returns false when not enabled", async () => {
+			await game.settings.set("shadowdark", "trackInactiveUserLightSources", false);
+			expect(app._monitorInactiveUsers()).is.false;
+		});
+
+		it("returns false when not enabled", async () => {
+			await game.settings.set("shadowdark", "trackInactiveUserLightSources", true);
+			expect(app._monitorInactiveUsers()).is.true;
 		});
 	});
 
 	describe("_onToggleLightSource()", () => {
-		// Skipping tests as it is just a gatekeeping method
+		// Skipping tests as it is just a forwarding method
+	});
+
+	describe("_pauseGameHook()", () => {
+		// Skipping tests
+	});
+
+	describe("_performTick()", () => {
+		// Tested by E2E
 	});
 
 	describe("_settingsChanged()", () => {
 		// Tested in _isPaused(), as if this fails, the tests there fails
 	});
 
-	describe("_performTick()", () => {
-		// TODO This test will fail if the game is paused.
-		const app = new LightSourceTrackerSD();
-		it("updates the date", () => {
-			const datePre = app.lastUpdate;
-			app._performTick();
-			expect(app.lastUpdate > datePre).is.true;
-		});
-
-		// @todo: e2e tests with sheets
-	});
-
 	describe("_updateLightSources()", () => {
-		// Skipping tests as they are tested later when _gatherLightSources
-		//   tests are written
+		// Tested in _gatherLightSources()
 	});
 };

--- a/system/src/apps/__tests__/e2e-apps-lightsource-tracker.test.mjs
+++ b/system/src/apps/__tests__/e2e-apps-lightsource-tracker.test.mjs
@@ -1,0 +1,193 @@
+/* eslint-disable no-unused-expressions */
+/**
+ * @file Contains E2E tests for the Lightsource Tracker app
+ */
+
+import {
+	cleanUpActorsByKey,
+	cleanUpUsersByKey,
+	cleanUpItemsByKey,
+	createMockUserByKey,
+	createMockActorByKey,
+	createMockItemByKey,
+	delay,
+	openWindows,
+	waitForInput,
+	trashChat,
+} from "../../testing/testUtils.mjs";
+
+export const key = "shadowdark.e2e.apps.lightsource-tracker";
+export const options = {
+	displayName: "Shadowdark: E2E: Apps: Lightsource Tracker",
+	preSelected: false,
+};
+
+export default ({ describe, it, after, before, expect }) => {
+	const wasPaused = game.paused;
+	const originalSettings = {
+		trackLightSources: game.settings.get("shadowdark", "trackLightSources"),
+		trackInactiveUserLightSources: game.settings.get("shadowdark", "trackInactiveUserLightSources"),
+	};
+
+	after(async () => {
+		for (const [key, value] of Object.entries(originalSettings)) {
+			await game.settings.set(
+				"shadowdark", key, value
+			);
+		}
+		game.togglePause(wasPaused);
+	});
+
+	describe("render(force, options)", () => {
+		// @todo: Write tests if you figure out how to mock another user
+	});
+
+	describe("toggleInterface()", () => {
+		before(async () => {
+			await game.shadowdark.lightSourceTracker.close();
+			await delay(300);
+		});
+
+		it("renders for GM on toggle", async () => {
+			// Assume the window is the currently open window
+			const pre = openWindows("light-tracker");
+			expect(pre.length).equal(0);
+
+			await game.shadowdark.lightSourceTracker.toggleInterface();
+			await waitForInput();
+			const post = openWindows("light-tracker");
+			expect(post.length).equal(1);
+		});
+
+		it("closes for GM on another toggle", async () => {
+			// Assume the window is the currently open window
+			const pre = openWindows("light-tracker");
+			expect(pre.length).equal(1);
+
+			await game.shadowdark.lightSourceTracker.toggleInterface();
+			await delay(300);
+			const post = openWindows("light-tracker");
+			expect(post.length).equal(0);
+		});
+	});
+
+	describe("toggleLightSource()", () => {
+		// @todo: Figure out how to test sockets
+		// Mock an actor and test if there is a socket message in console
+		// Mock actor and activate a lightsource
+	});
+
+	describe("_gatherLightSources()", () => {
+		let mockActor;
+		let mockUser;
+		let mockItem;
+
+		before(async () => {
+			cleanUpActorsByKey(key);
+			cleanUpUsersByKey(key);
+			cleanUpItemsByKey(key);
+			await trashChat();
+		});
+
+		after(async () => {
+			cleanUpActorsByKey(key);
+			cleanUpUsersByKey(key);
+			cleanUpItemsByKey(key);
+			await trashChat();
+		});
+
+		before(async () => {
+			await game.settings.set("shadowdark", "trackInactiveUserLightSources", true);
+			// Add another user
+			mockUser = await createMockUserByKey(key);
+
+			// Create actir
+			mockActor = await createMockActorByKey(key, "Player");
+
+			// Create light source
+			mockItem = await createMockItemByKey(key, "Basic");
+			await mockItem.update({
+				system: {
+					light: {
+						active: false,
+						hasBeenUsed: false,
+						isSource: true,
+						longevityMins: 1,
+						remainingSecs: 5,
+						template: "torch",
+					},
+				},
+			});
+
+			// Add light source to character
+			await mockActor.createEmbeddedDocuments("Item", [mockItem]);
+
+			// Add a character to user
+			await mockUser.update({
+				character: mockActor._id,
+			});
+
+			// Render the actor sheet & go to the inventory
+			await mockActor.sheet.render(true);
+			await waitForInput();
+			await document.querySelector(
+				".player-navigation a[data-tab=tab-inventory]").click();
+			await game.shadowdark.lightSourceTracker.toggleInterface();
+		});
+
+		// Create a light tracker and replace the built in for now
+		const app = game.shadowdark.lightSourceTracker;
+		const preexistingSources = (app.monitoredLightSources.length)
+			? app.monitoredLightSources.length
+			: 0;
+
+		it("actor sanity check", () => {
+			expect(mockActor).is.not.undefined;
+			expect(mockActor.items.contents.length).equal(1);
+			expect(mockActor.items.contents[0].isLight()).is.true;
+			expect(mockActor.items.contents[0].system.light.remainingSecs).equal(5);
+		});
+
+		it("Turning the lightsource on puts it in a tracked state", async () => {
+			// click the torch button
+			await document.querySelector("a.item-toggle-light").click();
+			await app._gatherLightSources();
+			await waitForInput();
+			expect(app.monitoredLightSources.length).equal(
+				preexistingSources + 1
+			);
+
+			// Update the tracker
+			await app._updateLightSources();
+
+			// Get the right actor
+			const monitoredActor = app.monitoredLightSources.find(
+				o => o._id === mockActor._id
+			);
+			expect(monitoredActor.lightSources.length).equal(1);
+		});
+
+		it("Turning the lightsource off puts it in a untracked state", async () => {
+			// click the torch button
+			await document.querySelector("a.item-toggle-light").click();
+			await app._gatherLightSources();
+			await waitForInput();
+			expect(app.monitoredLightSources.length).equal(
+				preexistingSources + 1
+			);
+
+			// Update the tracker
+			await app._updateLightSources();
+
+			// Get the right actor
+			const monitoredActor = app.monitoredLightSources.find(
+				o => o._id === mockActor._id
+			);
+			expect(monitoredActor.lightSources.length).equal(0);
+		});
+	});
+
+	describe("_performTick()", () => {
+		// @todo: figure out how to test
+	});
+};

--- a/system/src/testing/index.mjs
+++ b/system/src/testing/index.mjs
@@ -118,6 +118,12 @@ import documentsItemsTests, {
 	options as documentsItemsOptions,
 } from "../documents/__tests__/documents-item.test.mjs";
 
+/* E2E Tests */
+import e2eAppsLightsourceTrackerTests, {
+	key as e2eAppsLightsourceTrackerKey,
+	options as e2eAppsLightsourceTrackerOptions,
+} from "../apps/__tests__/e2e-apps-lightsource-tracker.test.mjs";
+
 /* Hooks Imports */
 import hooksChatMessageTests, {
 	key as hooksChatMessageKey,
@@ -234,6 +240,13 @@ Hooks.on("quenchReady", async quench => {
 		appsWeaponPropertiesKey,
 		appsWeaponPropertiesTests,
 		appsWeaponPropertiesOptions
+	);
+
+	// E2E Apps test
+	quench.registerBatch(
+		e2eAppsLightsourceTrackerKey,
+		e2eAppsLightsourceTrackerTests,
+		e2eAppsLightsourceTrackerOptions
 	);
 
 	// Chat test

--- a/system/src/testing/testUtils.mjs
+++ b/system/src/testing/testUtils.mjs
@@ -8,8 +8,25 @@ export const delay = ms =>
 		setTimeout(resolve, ms);
 	});
 
-export const abilities = ["str", "dex", "con", "int", "wis", "cha"];
-export const itemTypes = ["Armor", "Basic", "Gem", "Spell", "Talent", "Weapon"];
+export const abilities = [
+	"str",
+	"dex",
+	"con",
+	"int",
+	"wis",
+	"cha",
+];
+
+export const itemTypes = [
+	"Armor",
+	"Basic",
+	"Gem",
+	"Spell",
+	"Talent",
+	"Weapon",
+	"NPC Attack",
+	"NPC Feature",
+];
 
 export const waitForInput = () => delay(inputDelay);
 
@@ -28,6 +45,12 @@ export const createMockItemByKey = async (key, type) => {
 	});
 };
 
+export const createMockUserByKey = async key => {
+	return User.create({
+		name: `Test User ${key}`,
+	});
+};
+
 /* CLEAN UP HELPERS */
 export const cleanUpActorsByKey = key => {
 	game.actors
@@ -39,6 +62,12 @@ export const cleanUpItemsByKey = key => {
 	game.items
 		?.filter(i => i.name.includes(`Test Item ${key}:`))
 		.forEach(i => i.delete());
+};
+
+export const cleanUpUsersByKey = key => {
+	game.users
+		?.filter(u => u.name === `Test User ${key}`)
+		.forEach(u => u.delete());
 };
 
 /**
@@ -68,5 +97,12 @@ export const openDialogs = () =>
 export const closeDialogs = async () => {
 	openDialogs()?.forEach(async o => {
 		await o.close();
+	});
+};
+
+/* HELPERS */
+export const assignActorToUser = async (actor, user) => {
+	return user.update({
+		character: actor.id,
 	});
 };


### PR DESCRIPTION
Adds E2E tests for the Lightsource Tracker. Probably can improve this quite a lot in the future, but should give us some more coverage at least.