### PR TITLE
feat(tour): Spell restore

### DIFF
--- a/system/src/tours/ShadowdarkTourPlayerRolling.mjs
+++ b/system/src/tours/ShadowdarkTourPlayerRolling.mjs
@@ -188,6 +188,14 @@ export class ShadowdarkPlayerRollingTour extends ShadowdarkTour {
 					content: "<p>For Magic Missile we get the chance to roll a 1d4 damage.</p>",
 					action: "scrollTo",
 				},
+
+				{
+					id: "sd-playerroll-spells-miscast",
+					selector: ".player a.toggle-spell-lost",
+					title: "Lost Spell",
+					content: "<p>If a spell is lost due to failed spell cast, clicking the cross will restore it.</p>",
+					action: "scrollTo",
+				},
 				{
 					id: "sd-playerroll-items-navigate",
 					selector: "a.item[data-tab='tab-inventory']",


### PR DESCRIPTION
Adds a step to the rolling tour about restoring spells if miscast.