### PR TITLE
Implement light tracking using world time

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -277,7 +277,9 @@ SHADOWDARK.settings.track_light_sources.interval.name: Light Tracking Interval
 SHADOWDARK.settings.track_light_sources.name: Track Light Sources
 SHADOWDARK.settings.track_light_sources.open_on_start.hint: If checked the Light Tracking interface will open on startup (GM only).
 SHADOWDARK.settings.track_light_sources.open_on_start.name: Open Light Tracking UI on Startup
-SHADOWDARK.settings.track_light_sources.pause_with_game.hint: If checked the Light Tracking will pause whenever Foundry is paused.
+SHADOWDARK.settings.track_light_sources.realtime_tracking.hint: If checked the Light Tracking will follow real time. Disable if an external time/calendar module is used.
+SHADOWDARK.settings.track_light_sources.realtime_tracking.name: Realtime Light Tracking
+SHADOWDARK.settings.track_light_sources.pause_with_game.hint: If checked the Realtime Light Tracking will pause whenever Foundry is paused.
 SHADOWDARK.settings.track_light_sources.pause_with_game.name: Pause Light Tracking
 SHADOWDARK.sheet.actor.ac: AC
 SHADOWDARK.sheet.actor.alignment_short: Align

--- a/i18n/fi.yaml
+++ b/i18n/fi.yaml
@@ -274,6 +274,8 @@ SHADOWDARK.settings.track_light_sources.interval.name: Valonlähteiden seurannan
 SHADOWDARK.settings.track_light_sources.name: Seuraa valonlähteiden aikaa
 SHADOWDARK.settings.track_light_sources.open_on_start.hint: Jos valitset tämän, valonlähteiden seurannan ikkuna avautuu järjestelmän käynnistyksen yhteydessä (vain pelimestarille).
 SHADOWDARK.settings.track_light_sources.open_on_start.name: Avaa valonlähteiden seurannan ikkuna käynnistyksen yhteydessä
+SHADOWDARK.settings.track_light_sources.realtime_tracking.hint: Jos valitset tämän, valonlähteet seuraa oikeaa aikaa. Poista tämä valinta jos käytät aika- tai kalenteri-moduuleja.
+SHADOWDARK.settings.track_light_sources.realtime_tracking.name: Reaaliaikainen valolähteiden aika
 SHADOWDARK.settings.track_light_sources.pause_with_game.hint: Jos valitset tämän, valonlähteiden seurannan ajastimet eivät tikitä Foundryn ollessa pausella.
 SHADOWDARK.settings.track_light_sources.pause_with_game.name: Pauseta valonlähteiden seuranta
 SHADOWDARK.sheet.actor.ac: Puolustuspisteet

--- a/system/src/apps/RealTimeSD.mjs
+++ b/system/src/apps/RealTimeSD.mjs
@@ -1,0 +1,47 @@
+export default class RealTimeSD {
+	constructor() {
+		this.updateIntervalMs = 1000;
+		this.updateIntervalId = undefined;
+	}
+
+	start() {
+		if (
+			!game.user.isGM
+			|| this.updateIntervalId !== undefined
+			|| !this.isEnabled()
+		) {
+			return;
+		}
+		this.updateIntervalId = setInterval(
+			this._tick.bind(this),
+			this.updateIntervalMs
+		);
+	}
+
+	stop() {
+		if (!game.user.isGM || this.updateIntervalId === undefined) return;
+		clearInterval(this.updateIntervalId);
+		this.updateIntervalId = undefined;
+	}
+
+	isEnabled() {
+		return game.settings.get("shadowdark", "realtimeLightTracking");
+	}
+
+	isPaused() {
+		return game.paused && this._shouldPauseWithGame;
+	}
+
+	_shouldPauseWithGame() {
+		return game.settings.get("shadowdark", "pauseLightTrackingWithGame");
+	}
+
+	_tick() {
+		if (!this.isEnabled()) {
+			this.stop();
+			return;
+		}
+		if (this.isPaused()) return;
+		game.time.advance(this.updateIntervalMs / 1000);
+	}
+}

--- a/system/src/apps/__tests__/apps-lightsource-tracker.test.mjs
+++ b/system/src/apps/__tests__/apps-lightsource-tracker.test.mjs
@@ -16,6 +16,7 @@ export default ({ describe, it, after, expect }) => {
 	const originalSettings = {
 		trackLightSources: game.settings.get("shadowdark", "trackLightSources"),
 		trackInactiveUserLightSources: game.settings.get("shadowdark", "trackInactiveUserLightSources"),
+		realtimeLightTracking: game.settings.get("shadowdark", "realtimeLightTracking"),
 	};
 	const wasPaused = game.paused;
 
@@ -40,15 +41,12 @@ export default ({ describe, it, after, expect }) => {
 			const app = new LightSourceTrackerSD();
 			it("has the expected data", () => {
 				expect(app.monitoredLightSources.length).equal(0);
-				expect(app.updateInterval).equal(30*1000);
-				expect(app.updateIntervalId).is.null;
-				expect(app.lastUpdate).is.not.null;
+				expect(app.lastUpdate).equal(0);
 				expect(app.updatingLightSources).is.false;
 				expect(app.housekeepingInterval).equal(1000);
 				expect(app.housekeepingIntervalId).is.null;
 				expect(app.dirty).is.true;
 				expect(app.performingTick).is.false;
-				expect(app.pauseWithGame).is.true;
 			});
 		});
 	});
@@ -159,6 +157,8 @@ export default ({ describe, it, after, expect }) => {
 	});
 
 	describe("_isPaused()", () => {
+		// Ensure that realtime tracking is enabled.
+		game.setting.set("shadodark", "realtimeLightTracking", true);
 		// Store original setting
 		const setting = game.settings.get(
 			"shadowdark", "pauseLightTrackingWithGame"
@@ -253,7 +253,7 @@ export default ({ describe, it, after, expect }) => {
 		// Skipping tests
 	});
 
-	describe("_performTick()", () => {
+	describe("onUpdateWorldTime", () => {
 		// Tested by E2E
 	});
 

--- a/system/src/apps/__tests__/e2e-apps-lightsource-tracker.test.mjs
+++ b/system/src/apps/__tests__/e2e-apps-lightsource-tracker.test.mjs
@@ -27,6 +27,7 @@ export default ({ describe, it, after, before, expect }) => {
 	const originalSettings = {
 		trackLightSources: game.settings.get("shadowdark", "trackLightSources"),
 		trackInactiveUserLightSources: game.settings.get("shadowdark", "trackInactiveUserLightSources"),
+		realtimeLightTracking: game.settings.get("shadowdark", "realtimeLightTracking"),
 	};
 
 	before(async () => {
@@ -185,7 +186,7 @@ export default ({ describe, it, after, before, expect }) => {
 		});
 	});
 
-	describe("_performTick()", () => {
+	describe("onUpdateWorldTime", () => {
 		// @todo: figure out how to test
 	});
 };

--- a/system/src/handlebars.mjs
+++ b/system/src/handlebars.mjs
@@ -1,7 +1,7 @@
 export default function registerHandlebarsHelpers() {
 
 	Handlebars.registerHelper("secondsToMins", seconds => {
-		return Math.ceil(seconds / 60);
+		return Math.floor(seconds / 60);
 	});
 
 	Handlebars.registerHelper("ifCond", function(v1, operator, v2, options) {

--- a/system/src/hooks/light-source-tracker.mjs
+++ b/system/src/hooks/light-source-tracker.mjs
@@ -10,6 +10,7 @@ export const LightSourceTrackerHooks = {
 			Hooks.on("pauseGame", lst._pauseGameHook.bind(lst));
 			Hooks.on("updateUser", lst._makeDirty.bind(lst));
 			Hooks.on("userConnected", lst._makeDirty.bind(lst));
+			Hooks.on("updateWorldTime", lst.onUpdateWorldTime.bind(lst));
 		}
 
 		game.socket.on("system.shadowdark", event => {

--- a/system/src/settings.mjs
+++ b/system/src/settings.mjs
@@ -90,6 +90,16 @@ export default function registerSystemSettings() {
 		onChange: () => game.shadowdark.lightSourceTracker._settingsChanged(),
 	});
 
+	game.settings.register("shadowdark", "realtimeLightTracking", {
+		name: "SHADOWDARK.settings.track_light_sources.realtime_tracking.name",
+		hint: "SHADOWDARK.settings.track_light_sources.realtime_tracking.hint",
+		scope: "world",
+		config: true,
+		default: true,
+		type: Boolean,
+		onChange: () => game.shadowdark.lightSourceTracker._settingsChanged(),
+	});
+
 	game.settings.register("shadowdark", "pauseLightTrackingWithGame", {
 		name: "SHADOWDARK.settings.track_light_sources.pause_with_game.name",
 		hint: "SHADOWDARK.settings.track_light_sources.pause_with_game.hint",
@@ -97,7 +107,6 @@ export default function registerSystemSettings() {
 		config: true,
 		default: true,
 		type: Boolean,
-		onChange: () => game.shadowdark.lightSourceTracker._settingsChanged(),
 	});
 
 	game.settings.register("shadowdark", "trackLightSourcesInterval", {

--- a/system/templates/apps/light-tracker.hbs
+++ b/system/templates/apps/light-tracker.hbs
@@ -8,28 +8,30 @@
 				{{localize 'SHADOWDARK.light-tracker.title.suffix'}}
 			</span>
 		</div>
-		<div class="status">
-			<p class="status__label">
-				{{localize 'SHADOWDARK.light-tracker.status.label'}}:
-			</p>
-			<p class="status__value">
-			{{#if paused}}
-				<i
-					class="status__paused fa-solid fa-circle-pause"
-					text={{localize 'SHADOWDARK.light-tracker.paused'}}
-				>
-				</i>
-				Paused
-			{{else}}
-				<i
-					class="status__active fa-solid fa-circle-play"
-					text={{localize 'SHADOWDARK.light-tracker.active'}}
-				>
-				</i>
-				Active
-			{{/if}}
-			</p>
-		</div>
+		{{#if isRealtimeEnabled}}
+			<div class="status">
+				<p class="status__label">
+					{{localize 'SHADOWDARK.light-tracker.status.label'}}:
+				</p>
+				<p class="status__value">
+				{{#if paused}}
+					<i
+						class="status__paused fa-solid fa-circle-pause"
+						text={{localize 'SHADOWDARK.light-tracker.paused'}}
+					>
+					</i>
+					Paused
+				{{else}}
+					<i
+						class="status__active fa-solid fa-circle-play"
+						text={{localize 'SHADOWDARK.light-tracker.active'}}
+					>
+					</i>
+					Active
+				{{/if}}
+				</p>
+			</div>
+		{{/if}}
 	</header>
 	<hr />
 	<section class="light-source-grid">


### PR DESCRIPTION
This adds support for using different time and calendar modules for tracking time in the campaign, and integrating that with torches. Allows for example to use SimpleCalendar module to move time forward when the party is spending extra time searching a room.

By default behavior is unchanged, but with a new option real time tracking can be disabled in cases where GM wants to use clock from another module.

Also changed the inventory and light tracker use same rounding for the time remaining.