### PR TITLE
fix(test): Shadowdarkling cost test for basic item

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@
 * [#325] Bonuses from Weapon Mastery now functions as intended
 * [#341] Wizard Mishap Tier 1-2 table now rerolls itself twice on a 1
 * [#350] Inline rolls of NPC Features now render properly
+* [#322] Flask or Bottle had typo-cost in the Shadowdarkling tests
 
 ### Enhancements
 * [#192] Use world time for Light Tracker in order to facilitate the usage of Calendar/Time adjustment tools. Allows time stepping through the use of third-party world time manipulation modules like [Simple Calendar](https://foundryvtt.com/packages/foundryvtt-simple-calendar), etc.
@@ -25,6 +26,7 @@
 * [#338] Added a Condition compendium with drag-n-droppable conditions. [#266]
 * [#339] Adds "Unlimited" as a choice for Spell Ranges
 * [#348] Adds missing config values for NPC Movement, Spell Ranges, and Spell Durations (#346, #347)
+* [#353] Shadowdarkling now tests basic items to have the correct cost
 
 ## v1.2.4
 

--- a/system/src/apps/__tests__/apps-shadowdarkling-importer.test.mjs
+++ b/system/src/apps/__tests__/apps-shadowdarkling-importer.test.mjs
@@ -1043,7 +1043,7 @@ export default ({ describe, it, after, afterEach, expect }) => {
 					totalUnits: 1,
 					slots: 1,
 					cost: 3,
-					currency: "gp",
+					currency: "sp",
 				},
 				{
 					instanceId: "lfxz9pod",
@@ -1169,6 +1169,7 @@ export default ({ describe, it, after, afterEach, expect }) => {
 							: item.name;
 					expect(actor.items.contents[0].name.toLowerCase()).equal(
 						name.toLowerCase());
+					expect(actor.items.contents[0].system.cost[item.currency]).equal(item.cost);
 					await actor.delete();
 				});
 			});


### PR DESCRIPTION
resolves #322

Updated the tests for Shadowdarkling to check that the expected cost of basic items work. It also updates the cost of `Flask or Bottle` to 3 _gp_ instead of _sp_.