### PR TITLE
fix(chat): Blinding of rolls

### DIFF
--- a/system/src/chat/hooks.mjs
+++ b/system/src/chat/hooks.mjs
@@ -90,6 +90,16 @@ export function chatCardButtonAction(app, html, data) {
 	});
 }
 
+export function chatCardBlind(app, html, data) {
+	if (app.blind && !game.user.isGM) {
+		$(html).find(".blindable .dice-total").text("???");
+		$(html).find(".dice-rolls").remove();
+		$(html).find(".dice .part-total").remove();
+		return false; // Prevent further actions to happen
+	}
+	return true;
+}
+
 /**
  * Handles the rendering of a chat message to the log
  * @param {ChatLog} app - The ChatLog instance
@@ -98,5 +108,6 @@ export function chatCardButtonAction(app, html, data) {
  */
 export default function onRenderChatMessage(app, html, data) {
 	chatCardButtonAction(app, html, data);
-	highlightSuccessFailure(app, html, data);
+	const blind = chatCardBlind(app, html, data);
+	if (!blind) highlightSuccessFailure(app, html, data);
 }

--- a/system/src/dice/RollSD.mjs
+++ b/system/src/dice/RollSD.mjs
@@ -525,7 +525,7 @@ export default class RollSD extends Roll {
 	) {
 		const chatCardTemplate = options.chatCardTemplate
 			? options.chatCardTemplate
-			: "systems/shadowdark/templates/chat/roll-d20-card.hbs";
+			: "systems/shadowdark/templates/chat/roll-card.hbs";
 
 		const chatCardData = this._getChatCardTemplateData(data, options);
 
@@ -553,9 +553,10 @@ export default class RollSD extends Roll {
 			? chatData.flags.success
 			: null;
 
+		if ( options.rollMode === "blindroll" ) data.rolls.main.blind = true;
+
 		const content = await this._getChatCardContent(data, options);
 
-		if ( options.rollMode === "blindroll" ) chatData.blind = true;
 		chatData.content = content;
 
 		// Modify the flavor of the chat card

--- a/system/templates/chat/item-card.hbs
+++ b/system/templates/chat/item-card.hbs
@@ -26,7 +26,7 @@
   <div class="d20-roll card-attack-rolls">
     <div
 			class="card-attack-roll blindable"
-			data-blind="{{data.rolls.main.roll.blindroll}}"
+			data-blind="{{data.rolls.main.blind}}"
 		>
       {{#if data.rolls.main}}
         <div><h3>
@@ -61,14 +61,14 @@
 				{{#if isVersatile}}
 					<div
 						class="card-damage-roll blindable"
-						data-blind="{{data.rolls.main.roll.blindroll}}"
+						data-blind="{{data.rolls.main.blind}}"
 					>
 						<h3>{{localize "SHADOWDARK.damage.one_handed"}}</h3>
 						{{{data.rolls.primaryDamage.renderedHTML}}}
 					</div>
 					<div
 						class="card-damage-roll blindable"
-						data-blind="{{data.rolls.main.roll.blindroll}}"
+						data-blind="{{data.rolls.main.blind}}"
 					>
 						<h3>{{localize "SHADOWDARK.damage.two_handed"}}</h3>
 						{{{data.rolls.secondaryDamage.renderedHTML}}}
@@ -76,7 +76,7 @@
 				{{else}}
 					<div
 						class="card-damage-roll-single blindable"
-						data-blind="{{data.rolls.main.roll.blindroll}}"
+						data-blind="{{data.rolls.main.blind}}"
 					>
 						<h3>{{localize "SHADOWDARK.roll.damage"}}</h3>
 						{{{data.rolls.primaryDamage.renderedHTML}}}
@@ -91,7 +91,7 @@
 			<div class="card-damage-rolls">
 				<div
 					class="card-damage-roll-single blindable"
-					data-blind="{{data.rolls.main.roll.blindroll}}"
+					data-blind="{{data.rolls.main.blind}}"
 				>
 					<h3>{{localize "SHADOWDARK.roll.damage"}}</h3>
 					{{{data.rolls.primaryDamage.renderedHTML}}}

--- a/system/templates/chat/roll-d20-card.hbs
+++ b/system/templates/chat/roll-d20-card.hbs
@@ -3,10 +3,10 @@
     <img src="{{data.actor.img}}" data-tooltip="{{title}}"/>
     <h3 class="roll-name">{{title}}</h3>
   </header>
-  {{{rolls.d20.renderedHTML}}}
+  {{{data.rolls.d20.renderedHTML}}}
   <div class="d20-roll card-roll blindable" data-blind="{{rolls.blindroll}}">
-    {{#if rolls.d20}}
-      <div>{{{rolls.d20.renderedHTML}}}</div>
+    {{#if data.rolls.d20}}
+      <div>{{{data.rolls.d20.renderedHTML}}}</div>
     {{/if}}
   </div>
 </div>


### PR DESCRIPTION
resolves #359

This could act as a short-term fix for rolls not being blinded properly. As mentioned on discord, I think we need to review and cleanup the technicals behind chat cards, but I suggest having that in a later release.