### PR TITLE
feat(ci): Tests for Light basic items

### DIFF
--- a/system/packs/__tests__/fixture/basic-gear.json
+++ b/system/packs/__tests__/fixture/basic-gear.json
@@ -1,0 +1,5 @@
+{
+	"Light Spell": "PkQXG3AaHNMVwGTc",
+	"Light Spell (Double Time)": "rjNBToTJCYLLdVcT",
+	"Light Spell (Double Range)": "BBDG7QpHOFXG6sKe"
+}

--- a/system/packs/__tests__/item.jest.test.js
+++ b/system/packs/__tests__/item.jest.test.js
@@ -1,0 +1,18 @@
+/* eslint-disable no-unused-expressions */
+const fs = require("fs");
+const path = require("path");
+
+describe("import", () => {
+	const data = fs.readFileSync(path.resolve(__dirname, "../basic-gear.db"));
+	const fixtureData = fs.readFileSync(path.resolve(__dirname, "./fixture/basic-gear.json")).toString();
+	const expectedIds = JSON.parse(fixtureData);
+
+	const packData = data.toString().trim().split("\n").map(l => JSON.parse(l));
+
+	test("Light items have the expected ids", () => {
+		for (const [itemName, itemId] of Object.entries(expectedIds)) {
+			packItem = packData.find(e => e.name === itemName);
+			expect(packItem._id).toBe(itemId);
+		}
+	});
+});


### PR DESCRIPTION
With the lightsource items for Light Spell using IDs to trigger the source if dropped onto an actor, we need CI tests to make sure the IDs are not changing by mistake.