### PR TITLE
fix: Actor delete non-lightsource fix

### DIFF
--- a/system/src/apps/__tests__/apps-lightsource-tracker.test.mjs
+++ b/system/src/apps/__tests__/apps-lightsource-tracker.test.mjs
@@ -41,7 +41,7 @@ export default ({ describe, it, after, before, expect }) => {
 			const app = new LightSourceTrackerSD();
 			it("has the expected data", () => {
 				expect(app.monitoredLightSources.length).equal(0);
-				expect(app.lastUpdate).equal(0);
+				expect(app.lastUpdate).is.null;
 				expect(app.updatingLightSources).is.false;
 				expect(app.housekeepingInterval).equal(1000);
 				expect(app.housekeepingIntervalId).is.null;

--- a/system/src/documents/__tests__/documents-item-spell.test.mjs
+++ b/system/src/documents/__tests__/documents-item-spell.test.mjs
@@ -158,7 +158,7 @@ export default ({ describe, it, after, beforeEach, before, expect }) => {
 				expect(game.messages.size).equal(1);
 
 				const chatMessage = game.messages.contents.pop();
-				expect(chatMessage.flavor.indexOf("at tier 3 with spell DC 13")).not.equal(-1);
+				expect(chatMessage.flavor.indexOf(", DC 13")).not.equal(-1);
 			});
 		});
 

--- a/system/src/sheets/ActorSheetSD.mjs
+++ b/system/src/sheets/ActorSheetSD.mjs
@@ -185,7 +185,7 @@ export default class ActorSheetSD extends ActorSheet {
 						icon: "<i class=\"fa fa-check\"></i>",
 						label: `${game.i18n.localize("SHADOWDARK.dialog.general.yes")}`,
 						callback: async () => {
-							if (itemData.system.light.active) {
+							if (itemData.system.light?.active) {
 								await itemData.parent.sheet._toggleLightSource(itemData);
 							}
 							await this.actor.deleteEmbeddedDocuments(


### PR DESCRIPTION
This fixes the behavior of deleting items that is not a light source (NPC Attack for example) from an actor.

Also cleans up the failing tests due to recent updates!