### PR TITLE
feat: Damage Multiplier effect

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,6 +28,7 @@
 	- [#272] Active Effects are ready for V11
 	- [#317] Users on Foundry v10 will now be locked out from editing effects if owned by actor. For V11 this is allowed since the database allows such operations.
 	- [#357] Added Light Source effects that are working like prior lightsources
+	- [#385] Added Damage Multiplier effects for both actors (should be used as temporary effects only) and items (may be permanent)
 * [#338] Added a Condition compendium with drag-n-droppable conditions. [#266]
 * [#339] Adds "Unlimited" as a choice for Spell Ranges
 * [#348] Adds missing config values for NPC Movement, Spell Ranges, and Spell Durations (#346, #347)

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -249,8 +249,9 @@ SHADOWDARK.item.effect.predefined_effect.rangedAttackBonus: Ranged Attack Roll B
 SHADOWDARK.item.effect.predefined_effect.rangedDamageBonus: Ranged Damage Bonus
 SHADOWDARK.item.effect.predefined_effect.spellAdvantage: Spellcasting Advantage on Spell
 SHADOWDARK.item.effect.predefined_effect.spellCastingBonus: Spellcasting Check Bonus
-SHADOWDARK.item.effect.predefined_effect.weaponAttackBonus: Attack Roll Bonus
-SHADOWDARK.item.effect.predefined_effect.weaponDamageBonus: Attack Damage Bonus
+SHADOWDARK.item.effect.predefined_effect.weaponAttackBonus: Weapon Attack Roll Bonus
+SHADOWDARK.item.effect.predefined_effect.weaponDamageBonus: Weapon Attack Damage Bonus
+SHADOWDARK.item.effect.predefined_effect.weaponDamageMultiplier: Weapon Damage Multiplier
 SHADOWDARK.item.effect.predefined_effect.weaponMastery: Weapon Mastery
 SHADOWDARK.item.effect.show-on-panel: Show on panel
 SHADOWDARK.item.effect.show-token-icon: Show token icon

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -113,9 +113,9 @@ SHADOWDARK.dialog.ability_check.str: Strength Check
 SHADOWDARK.dialog.ability_check.title: Ability Check
 SHADOWDARK.dialog.ability_check.wis: Wisdom Check
 SHADOWDARK.dialog.effect.choice.armor: Choose Armor Type
+SHADOWDARK.dialog.effect.choice.lightSource: Choose Light Source
 SHADOWDARK.dialog.effect.choice.spell: Choose Spell
 SHADOWDARK.dialog.effect.choice.weapon: Choose Weapon Type
-SHADOWDARK.dialog.effect.choice.lightSource: Choose Light Source
 SHADOWDARK.dialog.general.are_you_sure: Are you sure?
 SHADOWDARK.dialog.general.cancel: Cancel
 SHADOWDARK.dialog.general.no: "No"
@@ -212,13 +212,13 @@ SHADOWDARK.item.description: Description
 SHADOWDARK.item.effect.category.condition: Condition
 SHADOWDARK.item.effect.category.effect: Effect
 SHADOWDARK.item.effect.category.title: Effect Category
-SHADOWDARK.item.effect.pre-defined.title: Pre-defined effects
 SHADOWDARK.item.effect.lightSource.lantern: Lantern
 SHADOWDARK.item.effect.lightSource.lightSpellDouble: Light (Double Range)
 SHADOWDARK.item.effect.lightSource.lightSpellNear: Light
-SHADOWDARK.item.effect.lightSource.torch: Torch
-SHADOWDARK.item.effect.lightSource.purpleGlow: Purple Glow
 SHADOWDARK.item.effect.lightSource.lightSuppression: Light Suppression
+SHADOWDARK.item.effect.lightSource.purpleGlow: Purple Glow
+SHADOWDARK.item.effect.lightSource.torch: Torch
+SHADOWDARK.item.effect.pre-defined.title: Pre-defined effects
 SHADOWDARK.item.effect.predefined_effect.abilityImprovement: Ability Score Improvement
 SHADOWDARK.item.effect.predefined_effect.abilityImprovementCha: Ability Score Improvement (Cha)
 SHADOWDARK.item.effect.predefined_effect.abilityImprovementCon: Ability Score Improvement (Con)
@@ -233,6 +233,7 @@ SHADOWDARK.item.effect.predefined_effect.backstabDie: Additional Backstab Die
 SHADOWDARK.item.effect.predefined_effect.criticalFailureThreshold: Critical Failure Threshold
 SHADOWDARK.item.effect.predefined_effect.criticalSuccessThreshold: Critical Success Threshold
 SHADOWDARK.item.effect.predefined_effect.critMultiplier: Critical Multiplier
+SHADOWDARK.item.effect.predefined_effect.damageMultiplier: Damage Multiplier
 SHADOWDARK.item.effect.predefined_effect.hpAdvantage: HP Roll Advantage
 SHADOWDARK.item.effect.predefined_effect.initAdvantage: Initiative Advantage
 SHADOWDARK.item.effect.predefined_effect.lightSource: Light Source

--- a/system/assets/mappings/map-predefined-effects.json
+++ b/system/assets/mappings/map-predefined-effects.json
@@ -101,8 +101,7 @@
 		"effectKey": "system.bonuses.damageMultiplier",
 		"icon": "icons/skills/melee/strike-hammer-destructive-orange.webp",
 		"lang": "SHADOWDARK.item.effect.predefined_effect.damageMultiplier",
-		"mode": "CONST.ACTIVE_EFFECT_MODES.OVERRIDE",
-		"transfer": false
+		"mode": "CONST.ACTIVE_EFFECT_MODES.OVERRIDE"
 	},
   "hpAdvantage": {
     "defaultValue": "hp",

--- a/system/assets/mappings/map-predefined-effects.json
+++ b/system/assets/mappings/map-predefined-effects.json
@@ -103,6 +103,14 @@
 		"lang": "SHADOWDARK.item.effect.predefined_effect.damageMultiplier",
 		"mode": "CONST.ACTIVE_EFFECT_MODES.OVERRIDE"
 	},
+	"weaponDamageMultiplier": {
+		"defaultValue": 2,
+		"effectKey": "system.bonuses.damageMultiplier",
+		"icon": "icons/skills/melee/strike-hammer-destructive-orange.webp",
+		"lang": "SHADOWDARK.item.effect.predefined_effect.damageMultiplier",
+		"mode": "CONST.ACTIVE_EFFECT_MODES.OVERRIDE",
+		"transfer": false
+	},
   "hpAdvantage": {
     "defaultValue": "hp",
     "effectKey": "system.bonuses.advantage",

--- a/system/assets/mappings/map-predefined-effects.json
+++ b/system/assets/mappings/map-predefined-effects.json
@@ -96,6 +96,14 @@
     "mode": "CONST.ACTIVE_EFFECT_MODES.OVERRIDE",
     "transfer": false
   },
+	"damageMultiplier": {
+		"defaultValue": 2,
+		"effectKey": "system.bonuses.damageMultiplier",
+		"icon": "icons/skills/melee/strike-hammer-destructive-orange.webp",
+		"lang": "SHADOWDARK.item.effect.predefined_effect.damageMultiplier",
+		"mode": "CONST.ACTIVE_EFFECT_MODES.OVERRIDE",
+		"transfer": false
+	},
   "hpAdvantage": {
     "defaultValue": "hp",
     "effectKey": "system.bonuses.advantage",

--- a/system/src/dice/RollSD.mjs
+++ b/system/src/dice/RollSD.mjs
@@ -315,7 +315,11 @@ export default class RollSD extends Roll {
 			if ( data.rolls.main.critical === "success") numDice
 				*= parseInt(data.item.system.bonuses.critical.multiplier, 10);
 
-			const damageMultiplier = parseInt(data.actor.system.bonuses?.damageMultiplier, 10) ?? 1;
+			// Check if a damage multiplier is active for either Weapon or Actor
+			const damageMultiplier = Math.max(
+				parseInt(data.item.system.bonuses?.damageMultiplier, 10),
+				parseInt(data.actor.system.bonuses?.damageMultiplier, 10),
+				1);
 
 			const primaryDmgRoll = (damageMultiplier > 1)
 				? `${numDice}${damageDie}*${damageMultiplier}`

--- a/system/src/dice/RollSD.mjs
+++ b/system/src/dice/RollSD.mjs
@@ -315,14 +315,21 @@ export default class RollSD extends Roll {
 			if ( data.rolls.main.critical === "success") numDice
 				*= parseInt(data.item.system.bonuses.critical.multiplier, 10);
 
-			primaryParts = [`${numDice}${damageDie}`, ...data.damageParts];
+			const damageMultiplier = parseInt(data.item.system.bonuses?.damageMultiplier, 10) ?? 1;
+
+			const primaryDmgRoll = (damageMultiplier > 1)
+				? `${numDice}${damageDie}*${damageMultiplier}`
+				: `${numDice}${damageDie}`;
+
+			primaryParts = [primaryDmgRoll, ...data.damageParts];
 
 			data.rolls.primaryDamage = await this._roll(primaryParts, data);
 
 			if ( data.item.isVersatile() ) {
-				const secondaryParts = [
-					`${numDice}${data.item.system.damage.twoHanded}`,
-					...data.damageParts];
+				const secondaryDmgRoll = (damageMultiplier > 1)
+					? `${numDice}${data.item.system.damage.twoHanded} * ${damageMultiplier}`
+					: `${numDice}${data.item.system.damage.twoHanded}`;
+				const secondaryParts = [secondaryDmgRoll, ...data.damageParts];
 				data.rolls.secondaryDamage = await this._roll(secondaryParts, data);
 			}
 		}

--- a/system/src/dice/RollSD.mjs
+++ b/system/src/dice/RollSD.mjs
@@ -315,7 +315,7 @@ export default class RollSD extends Roll {
 			if ( data.rolls.main.critical === "success") numDice
 				*= parseInt(data.item.system.bonuses.critical.multiplier, 10);
 
-			const damageMultiplier = parseInt(data.item.system.bonuses?.damageMultiplier, 10) ?? 1;
+			const damageMultiplier = parseInt(data.actor.system.bonuses?.damageMultiplier, 10) ?? 1;
 
 			const primaryDmgRoll = (damageMultiplier > 1)
 				? `${numDice}${damageDie}*${damageMultiplier}`

--- a/system/src/dice/RollSD.mjs
+++ b/system/src/dice/RollSD.mjs
@@ -322,7 +322,7 @@ export default class RollSD extends Roll {
 				1);
 
 			const primaryDmgRoll = (damageMultiplier > 1)
-				? `${numDice}${damageDie}*${damageMultiplier}`
+				? `${numDice}${damageDie} * ${damageMultiplier}`
 				: `${numDice}${damageDie}`;
 
 			primaryParts = [primaryDmgRoll, ...data.damageParts];

--- a/system/src/dice/__tests__/dice.test.mjs
+++ b/system/src/dice/__tests__/dice.test.mjs
@@ -743,7 +743,7 @@ export default ({ describe, it, expect }) => {
 			const mockItemData = mockData();
 			mockItemData.rolls = { main: { critical: null } };
 			mockItemData.damageParts = [];
-			mockItemData.item.system.bonuses.damageMultiplier = 4;
+			mockItemData.actor.system.bonuses.damageMultiplier = 4;
 			expect(Object.keys(mockItemData.rolls).length).equal(1);
 
 			const response = await RollSD._rollWeapon(mockItemData);

--- a/system/src/dice/__tests__/dice.test.mjs
+++ b/system/src/dice/__tests__/dice.test.mjs
@@ -739,6 +739,32 @@ export default ({ describe, it, expect }) => {
 			expect(Object.keys(response.rolls).length).equal(1);
 		});
 
+		it("damageMultiplier is expected to multiply the formula", async () => {
+			const mockItemData = mockData();
+			mockItemData.rolls = { main: { critical: null } };
+			mockItemData.damageParts = [];
+			mockItemData.item.system.bonuses.damageMultiplier = 4;
+			expect(Object.keys(mockItemData.rolls).length).equal(1);
+
+			const response = await RollSD._rollWeapon(mockItemData);
+			expect(Object.keys(response.rolls).length).equal(3);
+			expect(response.rolls.primaryDamage).is.not.undefined;
+			expect(response.rolls.primaryDamage.renderedHTML).is.not.undefined;
+			expect(response.rolls.primaryDamage.roll).is.not.undefined;
+			expect(response.rolls.primaryDamage.roll.terms.length).equal(3);
+			expect(response.rolls.primaryDamage.roll.terms[0].number).is.not.undefined;
+			expect(response.rolls.primaryDamage.roll.terms[1].operator).equal("*");
+			expect(response.rolls.primaryDamage.roll.terms[2].number).equal(4);
+			expect(response.rolls.primaryDamage.roll._formula).equal("1d8 * 4");
+			expect(response.rolls.secondaryDamage).is.not.undefined;
+			expect(response.rolls.secondaryDamage.renderedHTML).is.not.undefined;
+			expect(response.rolls.secondaryDamage.roll).is.not.undefined;
+			expect(response.rolls.secondaryDamage.roll.terms.length).equal(3);
+			expect(response.rolls.secondaryDamage.roll.terms[0].number).is.not.undefined;
+			expect(response.rolls.secondaryDamage.roll.terms[1].operator).equal("*");
+			expect(response.rolls.secondaryDamage.roll.terms[2].number).equal(4);
+		});
+
 		describe("Backstabbing", () => {
 			it("Backstab rolls the expected dice", async () => {
 				const mockItemData = mockData();

--- a/system/src/documents/ActorSD.mjs
+++ b/system/src/documents/ActorSD.mjs
@@ -510,11 +510,13 @@ export default class ActorSD extends Actor {
 		}
 		if (item.system.bonuses.damageBonus) {
 			data.damageParts.push("@itemDamageBonus");
-			data.itemDamageBonus = item.system.bonuses.damageBonus;
+			data.itemDamageBonus = item.system.bonuses.damageBonus
+				*= item.system.bonuses.damageMultiplier;
 		}
 
 		// Talents & Ability modifiers
 		if (this.type === "Player") {
+
 			if (item.system.type === "melee") {
 				if (item.isFinesseWeapon()) {
 					data.abilityBonus = Math.max(
@@ -527,20 +529,24 @@ export default class ActorSD extends Actor {
 				}
 
 				data.talentBonus = bonuses.meleeAttackBonus;
-				data.meleeDamageBonus = bonuses.meleeDamageBonus;
+				data.meleeDamageBonus = bonuses.meleeDamageBonus
+					*= item.system.bonuses.damageMultiplier;
 				data.damageParts.push("@meleeDamageBonus");
 			}
 			else {
 				data.abilityBonus = this.abilityModifier("dex");
 
 				data.talentBonus = bonuses.rangedAttackBonus;
-				data.rangedDamageBonus = bonuses.rangedDamageBonus;
+				data.rangedDamageBonus = bonuses.rangedDamageBonus
+					*= item.system.bonuses.damageMultiplier;
 				data.damageParts.push("@rangedDamageBonus");
 			}
 
 			// Check Weapon Mastery & add if applicable
-			data.weaponMasteryBonus = this.calcWeaponMasterBonus(item);
-			data.talentBonus += data.weaponMasteryBonus;
+			const weaponMasterBonus = this.calcWeaponMasterBonus(item);
+			data.talentBonus += weaponMasterBonus;
+			data.weaponMasteryBonus = weaponMasterBonus
+				* item.system.bonuses.damageMultiplier;
 			if (data.weaponMasteryBonus) data.damageParts.push("@weaponMasteryBonus");
 		}
 

--- a/system/src/documents/ActorSD.mjs
+++ b/system/src/documents/ActorSD.mjs
@@ -511,7 +511,7 @@ export default class ActorSD extends Actor {
 		if (item.system.bonuses.damageBonus) {
 			data.damageParts.push("@itemDamageBonus");
 			data.itemDamageBonus = item.system.bonuses.damageBonus
-				*= item.system.bonuses.damageMultiplier;
+				*= parseInt(this.system.bonuses.damageMultiplier, 10);
 		}
 
 		// Talents & Ability modifiers
@@ -530,7 +530,7 @@ export default class ActorSD extends Actor {
 
 				data.talentBonus = bonuses.meleeAttackBonus;
 				data.meleeDamageBonus = bonuses.meleeDamageBonus
-					*= item.system.bonuses.damageMultiplier;
+					*= parseInt(this.system.bonuses.damageMultiplier, 10);
 				data.damageParts.push("@meleeDamageBonus");
 			}
 			else {
@@ -538,7 +538,7 @@ export default class ActorSD extends Actor {
 
 				data.talentBonus = bonuses.rangedAttackBonus;
 				data.rangedDamageBonus = bonuses.rangedDamageBonus
-					*= item.system.bonuses.damageMultiplier;
+					*= parseInt(this.system.bonuses.damageMultiplier, 10);
 				data.damageParts.push("@rangedDamageBonus");
 			}
 
@@ -546,7 +546,7 @@ export default class ActorSD extends Actor {
 			const weaponMasterBonus = this.calcWeaponMasterBonus(item);
 			data.talentBonus += weaponMasterBonus;
 			data.weaponMasteryBonus = weaponMasterBonus
-				* item.system.bonuses.damageMultiplier;
+				* parseInt(this.system.bonuses.damageMultiplier, 10);
 			if (data.weaponMasteryBonus) data.damageParts.push("@weaponMasteryBonus");
 		}
 

--- a/system/src/documents/ActorSD.mjs
+++ b/system/src/documents/ActorSD.mjs
@@ -503,6 +503,13 @@ export default class ActorSD extends Actor {
 		const parts = ["@abilityBonus", "@talentBonus"];
 		data.damageParts = [];
 
+		// Check damage multiplier
+		const damageMultiplier = Math.max(
+			parseInt(data.item.system.bonuses?.damageMultiplier, 10),
+			parseInt(data.actor.system.bonuses?.damageMultiplier, 10),
+			1);
+
+
 		// Magic Item bonuses
 		if (item.system.bonuses.attackBonus) {
 			parts.push("@itemBonus");
@@ -510,8 +517,7 @@ export default class ActorSD extends Actor {
 		}
 		if (item.system.bonuses.damageBonus) {
 			data.damageParts.push("@itemDamageBonus");
-			data.itemDamageBonus = item.system.bonuses.damageBonus
-				*= parseInt(this.system.bonuses.damageMultiplier, 10);
+			data.itemDamageBonus = item.system.bonuses.damageBonus * damageMultiplier;
 		}
 
 		// Talents & Ability modifiers
@@ -529,24 +535,21 @@ export default class ActorSD extends Actor {
 				}
 
 				data.talentBonus = bonuses.meleeAttackBonus;
-				data.meleeDamageBonus = bonuses.meleeDamageBonus
-					*= parseInt(this.system.bonuses.damageMultiplier, 10);
+				data.meleeDamageBonus = bonuses.meleeDamageBonus * damageMultiplier;
 				data.damageParts.push("@meleeDamageBonus");
 			}
 			else {
 				data.abilityBonus = this.abilityModifier("dex");
 
 				data.talentBonus = bonuses.rangedAttackBonus;
-				data.rangedDamageBonus = bonuses.rangedDamageBonus
-					*= parseInt(this.system.bonuses.damageMultiplier, 10);
+				data.rangedDamageBonus = bonuses.rangedDamageBonus * damageMultiplier;
 				data.damageParts.push("@rangedDamageBonus");
 			}
 
 			// Check Weapon Mastery & add if applicable
 			const weaponMasterBonus = this.calcWeaponMasterBonus(item);
 			data.talentBonus += weaponMasterBonus;
-			data.weaponMasteryBonus = weaponMasterBonus
-				* parseInt(this.system.bonuses.damageMultiplier, 10);
+			data.weaponMasteryBonus = weaponMasterBonus * damageMultiplier;
 			if (data.weaponMasteryBonus) data.damageParts.push("@weaponMasteryBonus");
 		}
 

--- a/system/src/documents/__tests__/documents-item-effect-predefined-effects.test.mjs
+++ b/system/src/documents/__tests__/documents-item-effect-predefined-effects.test.mjs
@@ -403,7 +403,7 @@ export default ({ describe, it, before, after, afterEach, expect }) => {
 				await _e.sheet._createPredefinedEffect(testKey, _pde);
 				await waitForInput();
 
-				expect(_e.effects.contents[0].transfer).is.false;
+				expect(_e.effects.contents[0].transfer).is.true;
 
 				const _pe = await _p.createEmbeddedDocuments("Item", [_e]);
 				expect(_pe.length).equal(1);
@@ -412,7 +412,7 @@ export default ({ describe, it, before, after, afterEach, expect }) => {
 				expect(_pe[0].effects.contents[0].changes[0].value).equal("2");
 				expect(_p.items.size).equal(1);
 
-				expect(_p.system.bonuses.damageMultiplier).is.undefined;
+				expect(_p.system.bonuses.damageMultiplier).equal(2);
 				await _pe[0].delete();
 			});
 		});

--- a/system/src/documents/__tests__/documents-item-effect-predefined-effects.test.mjs
+++ b/system/src/documents/__tests__/documents-item-effect-predefined-effects.test.mjs
@@ -379,6 +379,44 @@ export default ({ describe, it, before, after, afterEach, expect }) => {
 			});
 		});
 
+		describe("Damage multiplier", () => {
+			after(async () => {
+				await cleanUpActorItems(_p);
+				await cleanUpItemsByKey(key);
+			});
+
+			// @todo: This only checks that the effects are carried over to the
+			//        item. This seems to be the way Foundry works, and will probably
+			//        change with V11.
+			it("damageMultiplier", async () => {
+				const testKey = "damageMultiplier";
+				expect(_p.items.size).equal(0);
+				expect(_p.system.bonuses.damageMultiplier).is.undefined;
+
+				const _pde = predefinedEffects[testKey];
+				expect(_pde).is.not.undefined;
+
+				// @note: Only for weapons!
+				const _e = await createMockItemByKey(key, "Weapon");
+				expect(_e.system.bonuses.damageMultiplier).equal(1);
+
+				await _e.sheet._createPredefinedEffect(testKey, _pde);
+				await waitForInput();
+
+				expect(_e.effects.contents[0].transfer).is.false;
+
+				const _pe = await _p.createEmbeddedDocuments("Item", [_e]);
+				expect(_pe.length).equal(1);
+				expect(_pe[0]).is.not.undefined;
+				expect(_pe[0].effects.contents[0].changes[0].key).equal("system.bonuses.damageMultiplier");
+				expect(_pe[0].effects.contents[0].changes[0].value).equal("2");
+				expect(_p.items.size).equal(1);
+
+				expect(_p.system.bonuses.damageMultiplier).is.undefined;
+				await _pe[0].delete();
+			});
+		});
+
 		describe("Advantage: HP Rolls", () => {
 			after(async () => {
 				await cleanUpActorItems(_p);

--- a/system/template.json
+++ b/system/template.json
@@ -312,7 +312,8 @@
 					"failureThreshold": 1,
 					"successThreshold": 20,
 					"multiplier": 2
-				}
+				},
+				"damageMultiplier": 1
 			},
 			"range": "close",
 			"type": "melee",

--- a/system/template.json
+++ b/system/template.json
@@ -102,6 +102,7 @@
 					"failureThreshold": 1,
 					"multiplier": 2
 				},
+				"damageMultiplier": 1,
 				"gearSlots": 0,
 				"hauler": false,
 				"lightSource": "",
@@ -312,8 +313,7 @@
 					"failureThreshold": 1,
 					"successThreshold": 20,
 					"multiplier": 2
-				},
-				"damageMultiplier": 1
+				}
 			},
 			"range": "close",
 			"type": "melee",

--- a/system/template.json
+++ b/system/template.json
@@ -313,7 +313,8 @@
 					"failureThreshold": 1,
 					"successThreshold": 20,
 					"multiplier": 2
-				}
+				},
+				"damageMultiplier": 1
 			},
 			"range": "close",
 			"type": "melee",


### PR DESCRIPTION
resolves #380 

This feature will check for the maximum between the actors `bonuses.damageMultiplier` and the items. The idea is that this should support items like Potion of Giant Strength on a limited basis (multiplies damage for a certain amount of turns), as well as potential weapons having a permanent damage multiplier.