### PR TITLE
fix: Dropped torches remaining unlit & allowing GM to pick up light sources for users

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,8 @@
 * [#322] Flask or Bottle had typo-cost in the Shadowdarkling tests
 * [#358] Updated Sleep spell description according to errata
 * [#394] Dragging a light from one character sheet to another should delete it from the original owner
+* [#396] Dropped light sources retain their active status
+
 
 ### Enhancements
 * [#23] In conjunction with [#329] add support for wand items with associated Spell data and ability to use from inventory/item chat cards
@@ -44,6 +46,7 @@
 * [#388] Adds a Light actor that is only used for dropping a light source on a scene, and allows it to be picked up again. The dropped lightsource will continue being tracked by the lightsource tracker
 * [#392] Official GM screen artwork added as default World login background image (thanks to Kelsey for giving us permission to use this awesome artwork)
 * [#393] Support for Ranger class, including importing from Shadowdarklings.net
+* [#395] Allows the GM to pick up light sources for users if they are logged in and have an assigned character
 
 ## v1.2.4
 

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -123,6 +123,7 @@ SHADOWDARK.dialog.general.are_you_sure: Are you sure?
 SHADOWDARK.dialog.general.cancel: Cancel
 SHADOWDARK.dialog.general.no: "No"
 SHADOWDARK.dialog.general.yes: "Yes"
+SHADOWDARK.dialog.general.select: Select
 SHADOWDARK.dialog.hp_roll.per_level: Roll HP for level {level}
 SHADOWDARK.dialog.hp_roll.previous_hp: "HP before rolling: {hp}"
 SHADOWDARK.dialog.hp_roll.roll_level_1: Rolled {hp} hp for level 1 (incl. con mod)
@@ -141,6 +142,7 @@ SHADOWDARK.dialog.item.delete: Delete
 SHADOWDARK.dialog.item.sell_all: Sell All
 SHADOWDARK.dialog.item.sell: Sell
 SHADOWDARK.dialog.item.use: Use
+SHADOWDARK.dialog.light_source.pick_up.title: Select actor to give lightsource
 SHADOWDARK.dialog.roll_mode_label: Rolling mode
 SHADOWDARK.dialog.roll: Roll
 SHADOWDARK.dialog.spell_roll.title: Cast Spell with

--- a/scss/base/_dialog.scss
+++ b/scss/base/_dialog.scss
@@ -13,6 +13,43 @@
 		grid-template-columns: 1fr min-content;
 		background-color: var(--form-background);
 	}
+
+	&.pickup-lightsource {
+		img {
+			width: 50px;
+			height: 50px;
+			max-width: 50px;
+			border-radius: 5px;
+			border: 3px solid rgba(0,0,0,0);
+			margin: 0 3px;
+		}
+
+		.actor-selector {
+			display: grid;
+			grid-template-columns: 1fr;
+
+			.actor {
+
+				input[type="radio"] {
+					display: none;
+				}
+
+				label {
+					display: inline-flex;
+					align-items: center;
+					cursor: pointer;
+				}
+
+				input[type="radio"]:checked+label img {
+					border: 3px solid var(--secondary);
+				}
+
+				label:hover {
+					background: var(--form-background);
+				}
+			}
+		}
+	}
 }
 
 .dialog-button.advantage.talent-highlight {

--- a/system/src/apps/LightSourceTrackerSD.mjs
+++ b/system/src/apps/LightSourceTrackerSD.mjs
@@ -515,8 +515,8 @@ export default class LightSourceTrackerSD extends Application {
 			game.actors.get(actorId).items.contents
 		);
 
-		// Inactivate light source
-		await item.update({"system.light.active": false});
+		// Invert the active setting of the light source, so the toggling works later
+		await item.update({"system.light.active": !item.system.light.active});
 
 		// Delete the actor
 		game.actors.get(actorId).delete();
@@ -553,8 +553,12 @@ export default class LightSourceTrackerSD extends Application {
 		lightActor.createEmbeddedDocuments("Item", [item]);
 
 		// Remove light from items parents
-		game.actors.get(itemOwner._id).sheet._toggleLightSource(
-			game.actors.get(itemOwner._id).items.get(item._id),
+		game.actors.get(itemOwner._id).toggleLight(false, "");
+
+		// Send message that the torch was dropped
+		game.actors.get(itemOwner._id).sheet._sendToggledLightSourceToChat(
+			false,
+			item,
 			{
 				speaker: speaker ?? ChatMessage.getSpeaker(),
 				picked_up: false,

--- a/system/src/sheets/LightSheetSD.mjs
+++ b/system/src/sheets/LightSheetSD.mjs
@@ -45,7 +45,7 @@ export default class LightSheetSD extends ActorSheetSD {
 		return context;
 	}
 
-	async _onPickupLight(event) {
+	async _onPickupLight(event, options = {}) {
 		event.preventDefault();
 
 		if (!game.user.isGM) {
@@ -55,11 +55,55 @@ export default class LightSheetSD extends ActorSheetSD {
 					type: "pickupLightSourceFromScene",
 					data: {
 						character: game.user.character,
-						lightActor: this.actor,
-						lightToken: this.object.token,
+						lightActor: options.actor ?? this.actor,
+						lightToken: options.token ?? this.object.token,
+						speaker: ChatMessage.getSpeaker(),
 					},
 				}
 			);
+		}
+		else {
+			// Display a dialog allowing the GM to choose which character to assign
+			// the dropped light source to.
+			const activeUsers = game.users
+				.filter(u => u.active && !u.isGM);
+
+			const content = await renderTemplate(
+				"systems/shadowdark/templates/dialog/assign-picked-up-lightsource.hbs",
+				{
+					users: activeUsers,
+				}
+			);
+
+			const targetActor = await Dialog.wait({
+				title: game.i18n.localize("SHADOWDARK.dialog.light_source.pick_up.title"),
+				content,
+				buttons: {
+					select: {
+						icon: "<i class=\"fa fa-square-check\"></i>",
+						label: `${game.i18n.localize("SHADOWDARK.dialog.general.select")}`,
+						callback: html => {
+							return html.find("input[type='radio']:checked").attr("id") ?? false;
+						},
+					},
+					cancel: {
+						icon: "<i class=\"fa fa-square-xmark\"></i>",
+						label: `${game.i18n.localize("SHADOWDARK.dialog.general.cancel")}`,
+						callback: () => false,
+					},
+				},
+				default: "select",
+				close: () => console.log("Closed Dialog"),
+			});
+
+			if (targetActor) {
+				game.shadowdark.lightSourceTracker.pickupLightSourceFromScene(
+					game.actors.get(targetActor),
+					options.actor ?? this.actor,
+					options.token ?? this.object.token,
+					ChatMessage.getSpeaker()
+				);
+			}
 		}
 
 		this.close();

--- a/system/src/sheets/PlayerSheetSD.mjs
+++ b/system/src/sheets/PlayerSheetSD.mjs
@@ -183,6 +183,9 @@ export default class PlayerSheetSD extends ActorSheetSD {
 				[item._id]
 			);
 		}
+		else {
+			super._onDropItem(event, data);
+		}
 	}
 
 	/**

--- a/system/src/sheets/PlayerSheetSD.mjs
+++ b/system/src/sheets/PlayerSheetSD.mjs
@@ -189,7 +189,9 @@ export default class PlayerSheetSD extends ActorSheetSD {
 	}
 
 	/**
-	 * Creates an item being a lightsource and activates it
+	 * Actives a lightsource if dropped onto the Player sheet. Used for
+	 * activating Light spell et.c.
+	 *
 	 * @param {Item} item - Item that is a lightsource
 	 */
 	async _dropActivateLightSource(item) {

--- a/system/templates/chat/lightsource-drop.hbs
+++ b/system/templates/chat/lightsource-drop.hbs
@@ -10,7 +10,7 @@
 		/>
     <h3 class="light-source-name">
       {{name}}
-      {{#if active}}
+      {{#if picked_up}}
       {{localize "SHADOWDARK.chat.light_source.source.picked_up"}}
       {{else}}
       {{localize "SHADOWDARK.chat.light_source.source.dropped"}}

--- a/system/templates/dialog/assign-picked-up-lightsource.hbs
+++ b/system/templates/dialog/assign-picked-up-lightsource.hbs
@@ -1,0 +1,20 @@
+<form autocomplete="off" spellcheck="off">
+  <div class="shadowdark-dialog pickup-lightsource">
+    <h2>{{localize "SHADOWDARK.dialog.light_source.pick_up.title"}} {{ data.item.name }}</h2>
+    <hr />
+
+    <div class="form-group">
+			<div class="actor-selector">
+				<div class="actor">
+				{{#each users as |user|}}
+					<input type="radio" id="{{user.character.id}}" name="selected-actor" value="{{user.character.name}}">
+					<label for="{{user.character.id}}">
+						<img src="{{user.character.img}}" />{{user.character.name}} (<b>{{user.name}}</b>)
+					</label>
+				{{/each}}
+				</div>
+			</div>
+    </div>
+    <hr />
+  </div>
+</form>


### PR DESCRIPTION
resolves #396
resolves #395

Adds a dialog for the GM to select what assigned actor should pick up the torch. It only looks for active users and their assigned characters for this.

Also fixes a bug where light sources that were dropped from the item sidebar was ignored due to the changes to dropping light sources between characters.