### PR TITLE
Monster attack evolved

### DIFF
--- a/system/src/documents/ActorSD.mjs
+++ b/system/src/documents/ActorSD.mjs
@@ -525,6 +525,17 @@ export default class ActorSD extends Actor {
 			data.itemDamageBonus = item.system.bonuses.damageBonus * damageMultiplier;
 		}
 
+		/* Attach Special Ability if part of the attack.
+			Created in `data.itemSpecial` field.
+			Can be used in the rendering template or further automation.
+		*/
+		if (item.system.damage.special) {
+			let itemSpecial = data.actor.items.find(e => e.name === item.system.damage.special);
+			if (itemSpecial) {
+				data.itemSpecial = itemSpecial;
+			}
+		}
+
 		// Talents & Ability modifiers
 		if (this.type === "Player") {
 

--- a/system/src/documents/ActorSD.mjs
+++ b/system/src/documents/ActorSD.mjs
@@ -530,7 +530,7 @@ export default class ActorSD extends Actor {
 			Can be used in the rendering template or further automation.
 		*/
 		if (item.system.damage.special) {
-			let itemSpecial = data.actor.items.find(e => e.name === item.system.damage.special);
+			const itemSpecial = data.actor.items.find(e => e.name === item.system.damage.special);
 			if (itemSpecial) {
 				data.itemSpecial = itemSpecial;
 			}

--- a/system/templates/chat/item-card.hbs
+++ b/system/templates/chat/item-card.hbs
@@ -103,6 +103,17 @@
 		{{/ifNeq}}
   {{/if}}
 
+  {{#if data.item.system.damage.special}}
+	<div class="card-content">
+		<h3>
+			{{{data.itemSpecial.name}}}
+		</h3>
+		<p>
+			{{{data.itemSpecial.system.description}}}
+		</p>
+	</div>
+  {{/if}}
+
   <footer class="card-footer">
     {{#if isWeapon}}
 			<span>


### PR DESCRIPTION
Provide both the ability name and description. Should address #320 

There's space for improvements. Such as not revealing that nature of the effect until an actual hit. But that's a thing for a future revision.

Sample screen for Gelatinous Cube
Source: 
![image](https://github.com/Muttley/foundryvtt-shadowdark/assets/319590/55521d00-952d-414c-a34a-f9dd877dc372)

Updated chat output:
![image](https://github.com/Muttley/foundryvtt-shadowdark/assets/319590/957aeca5-f1e4-4680-bddf-73c9e39e84f9)

