### PR TITLE
Add initiative to the PC sheet

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,7 @@ We welcome @gatesvp as a contributor to the system!
 ### Enhancements
 * [#443] Kobold ancestry bonuses added, supports Shadowdarkling import
 * [#452] Added special attack to chat card when applicable
+* [#311] Initiative field on PC sheets
 
 ## v.1.3.3
 

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -453,6 +453,7 @@ SHADOWDARK.sheet.player.luck: Luck
 SHADOWDARK.sheet.player.melee_attacks: Melee Attacks
 SHADOWDARK.sheet.player.notes: Character Notes
 SHADOWDARK.sheet.player.ranged_attacks: Ranged Attacks
+SHADOWDARK.sheet.player.roll_initiative: Roll Initiative
 SHADOWDARK.sheet.player.spells_tier: Tier
 SHADOWDARK.sheet.player.spells: Spells
 SHADOWDARK.sheet.player.tab.abilities: Abilities

--- a/scss/sheets/actors/_player.scss
+++ b/scss/sheets/actors/_player.scss
@@ -73,6 +73,13 @@
 		}
 	}
 
+	.pc-roll-initiative {
+		@include p-reset;
+		display: grid;
+		grid-column: span 2;
+		row-gap: 4px;
+	}
+
 	.ac {
 		text-align: center;
 	}

--- a/system/src/sheets/ActorSheetSD.mjs
+++ b/system/src/sheets/ActorSheetSD.mjs
@@ -10,6 +10,10 @@ export default class ActorSheetSD extends ActorSheet {
 			event => this._onRollHP(event)
 		);
 
+		html.find(".pc-roll-initiative .rollable").click(
+			event => this._onRollInitiative(event)
+		);
+
 		html.find(".open-item").click(
 			event => this._onOpenItem(event)
 		);
@@ -217,6 +221,13 @@ export default class ActorSheetSD extends ActorSheet {
 		event.preventDefault();
 
 		this.actor.rollHP();
+	}
+
+	async _onRollInitiative(event) {
+		event.preventDefault();
+
+		// User the default roll available to each Actor / Token
+		await this.actor.rollInitiative({ createCombatants: true, rerollInitiative: true});
 	}
 
 	async _onRollAbilityCheck(event) {

--- a/system/src/templates.mjs
+++ b/system/src/templates.mjs
@@ -12,6 +12,7 @@ export default function() {
 		"systems/shadowdark/templates/actors/player/abilities/attacks.hbs",
 		"systems/shadowdark/templates/actors/player/abilities/hp.hbs",
 		"systems/shadowdark/templates/actors/player/abilities/luck.hbs",
+		"systems/shadowdark/templates/actors/player/abilities/initiative.hbs",
 		"systems/shadowdark/templates/actors/player/background.hbs",
 		"systems/shadowdark/templates/actors/player/inventory.hbs",
 		"systems/shadowdark/templates/actors/player/inventory/coins.hbs",

--- a/system/templates/actors/player/abilities.hbs
+++ b/system/templates/actors/player/abilities.hbs
@@ -22,6 +22,7 @@
 			{{/each}}
 			{{> actors/player/abilities/hp }}
 			{{> actors/player/abilities/ac }}
+			{{> actors/player/abilities/initiative }}
 		</div>
 		{{> actors/player/abilities/attacks }}
 	</div>

--- a/system/templates/actors/player/abilities/initiative.hbs
+++ b/system/templates/actors/player/abilities/initiative.hbs
@@ -1,0 +1,3 @@
+<div class="pc-roll-initiative value-box">
+	<label class="rollable">{{localize 'SHADOWDARK.sheet.player.roll_initiative'}}</label>
+</div>


### PR DESCRIPTION
This address issue #311. Uses existing primitives on the `Actor` object connected to the open sheet.

 - It's been placed at the bottom left. Seems to fit within default sizes
 - It's configured to both "add combatant" and "update initiative" when used. Shadowdark has pretty loos rules around Initiative, defaulting to one roll per session, so this seems pretty reasonable.

One additional translation required.

Sample screenshot below. 
![roll-initiative-sample](https://github.com/Muttley/foundryvtt-shadowdark/assets/319590/dc1c4dcf-0ca7-481d-b4d2-ecf4456a4cc3)
