### PR TITLE
Move onRenderChatMessage hook to root

### DIFF
--- a/system/shadowdark.mjs
+++ b/system/shadowdark.mjs
@@ -11,7 +11,7 @@ import * as dice from "./src/dice/_module.mjs";
 import * as documents from "./src/documents/_module.mjs";
 import * as sheets from "./src/sheets/_module.mjs";
 
-import { addChatMessageContextOptions } from "./src/chat/hooks.mjs";
+import { addChatMessageContextOptions, onRenderChatMessage } from "./src/chat/hooks.mjs";
 import { cacheForeignDocuments } from "./src/documents/cacheForeignDocuments.js";
 import { ModuleArt } from "./src/utils/module-art.mjs";
 import { ToursSD } from "./src/tours.mjs";
@@ -161,3 +161,8 @@ Hooks.once("setup", () => {
  * menu of the Chat entries.
  */
 Hooks.on("getChatLogEntryContext", addChatMessageContextOptions);
+
+/**
+ * Hooks for rendering the chat messages
+ */
+Hooks.on("renderChatMessage", (app, html, data) => onRenderChatMessage(app, html, data));

--- a/system/src/chat/hooks.mjs
+++ b/system/src/chat/hooks.mjs
@@ -127,7 +127,7 @@ export function chatCardBlind(app, html, data) {
  * @param {jQuery} html - Rendered chat message html
  * @param {object} data - Data passed to the render context
  */
-export default function onRenderChatMessage(app, html, data) {
+export function onRenderChatMessage(app, html, data) {
 	chatCardButtonAction(app, html, data);
 	const blind = chatCardBlind(app, html, data);
 	if (!blind) highlightSuccessFailure(app, html, data);

--- a/system/src/hooks.mjs
+++ b/system/src/hooks.mjs
@@ -1,5 +1,4 @@
 import { CanvasHooks } from "./hooks/canvas.mjs";
-import { ChatMessageHooks } from "./hooks/chat-messages.mjs";
 import { DropLightsourceHooks } from "./hooks/drop-lightsource-on-scene.mjs";
 import { EffectHooks } from "./hooks/effects.mjs";
 import { EffectPanelHooks } from "./hooks/effect-panel.mjs";
@@ -12,7 +11,6 @@ export const HooksSD = {
 	attach: () => {
 		const listeners = [
 			CanvasHooks,
-			ChatMessageHooks,
 			DropLightsourceHooks,
 			EffectHooks,
 			ForeignDocumentHooks,

--- a/system/src/hooks/chat-messages.mjs
+++ b/system/src/hooks/chat-messages.mjs
@@ -1,3 +1,7 @@
+/*
+Everything here was moved to the main shadowdark.mjs.
+They were not triggering on time.
+
 import onRenderChatMessage from "../chat/hooks.mjs";
 
 export const ChatMessageHooks = {
@@ -5,3 +9,4 @@ export const ChatMessageHooks = {
 		Hooks.on("renderChatMessage", (app, html, data) => onRenderChatMessage(app, html, data));
 	},
 };
+*/


### PR DESCRIPTION
Fix for #470 

Moving the `onRenderChatMessage` hooks all of the way up to root because chat messages seem to get processed before the hooks are otherwise initialized.

I ran into this issue when doing the Damage Cards. Turns out the same issue was happening for the rendering.