### PR TITLE
Fix the name of the Finnish language

### DIFF
--- a/system/system.json
+++ b/system/system.json
@@ -45,7 +45,7 @@
 		},
 		{
 			"lang": "fi",
-			"name": "Suomen Kieli",
+			"name": "suomi",
 			"path": "i18n/fi.json"
 		},
 		{


### PR DESCRIPTION
This PR corrects the name the Finnish language in `system.json` to be grammatically correct.