### PR TITLE
Fixed #573

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+## v.1.x.x
+
+### Bugfixes
+* [#573] Fixed an issue with item attack bonuses not being calculated if added manually via the roll dialog.
+
 ## v.1.5.1
 
 ### Bugfixes

--- a/system/src/documents/ActorSD.mjs
+++ b/system/src/documents/ActorSD.mjs
@@ -834,7 +834,7 @@ export default class ActorSD extends Actor {
 		const bonuses = this.system.bonuses;
 
 		// Summarize the bonuses for the attack roll
-		const parts = ["1d20", "@abilityBonus", "@talentBonus"];
+		const parts = ["1d20", "@itemBonus", "@abilityBonus", "@talentBonus"];
 		data.damageParts = [];
 
 		// Check damage multiplier
@@ -846,7 +846,6 @@ export default class ActorSD extends Actor {
 
 		// Magic Item bonuses
 		if (item.system.bonuses.attackBonus) {
-			parts.push("@itemBonus");
 			data.itemBonus = item.system.bonuses.attackBonus;
 		}
 		if (item.system.bonuses.damageBonus) {


### PR DESCRIPTION
The dialog form was collecting manual inputs for _itemBonuses_, but _@itemBonus_ was only added for consideration during rolling if _item.system.bonuses.attackBonus_ was set.

Similar to @talentBonus, adding @itembonus to all rolls corrects the issue and is ignored if 0. 