### PR TITLE
fix error parsing +X weapon attacks with monsterImporter

### DIFF
--- a/system/src/apps/MonsterImporterSD.mjs
+++ b/system/src/apps/MonsterImporterSD.mjs
@@ -85,7 +85,7 @@ export default class MonsterImporterSD extends FormApplication {
 	_parseAttack(str) {
 		const atk = str.match([
 			/(\d*)\s*/,				// atk[1] matches # of attacks
-			/([\w\s\d]*)/,			// atk[2] matches attack name
+			/([+\w\s\d]?[\w\s\d]*)/,			// atk[2] matches attack name
 			/(?:\(([^)]*)\))?\s*/,	// atk[3] matches attack range
 			/([+-]\d*)?\s*/,		// atk[4] matches attack bonus
 			/(?:\((.*)\))?/,		// atk[5] matches damage string


### PR DESCRIPTION
Fixes  #583. I tested a mass import of the entire rulebook, and with this fix, the Monster Importer now works on every monster in the core rulebook.