### PR TITLE
Implement option for Clockwise Initiative

### DIFF
--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -83,6 +83,7 @@ SHADOWDARK.chat_card.context.apply_damage_secondary: Apply Secondary Damage
 SHADOWDARK.chat_card.context.apply_damage: Apply Damage
 SHADOWDARK.chat_card.context.apply_healing_secondary: Apply Secondary Healing
 SHADOWDARK.chat_card.context.apply_healing: Apply Healing
+SHADOWDARK.chat.clockwise_initiative: Since {name} rolled highest, they will go first.
 SHADOWDARK.chat.hp_roll.apply_to_max: Zu Max HP hinzufügen
 SHADOWDARK.chat.item_roll.double_numerical: Verdoppele einen beliebigen numerischen Wert!
 SHADOWDARK.chat.item_roll.mishap: Würfle auf die entsprechenden Ungeschickstabelle!

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -508,6 +508,8 @@ SHADOWDARK.settings.track_light_sources.pause_with_game.hint: Wenn aktiviert, wi
 SHADOWDARK.settings.track_light_sources.pause_with_game.name: Licht-Tracking pausieren
 SHADOWDARK.settings.track_light_sources.realtime_tracking.hint: If checked the Light Tracking will follow real time. Disable if an external time/calendar module is used.
 SHADOWDARK.settings.track_light_sources.realtime_tracking.name: Realtime Light Tracking
+SHADOWDARK.settings.use_clockwise_initiative.hint: "If checked the combatant with the highest iniative will go first, and all other combatants will follow in a fixed order determined by User Management. All NPCs will act on the same initiative.",
+SHADOWDARK.settings.use_clockwise_initiative.name: "Use Clockwise Initiative",
 SHADOWDARK.settings.use_pulp_mode.hint: Shows Luck tokens as a numeric value rather than a checkbox
 SHADOWDARK.settings.use_pulp_mode.name: Enable Pulp Mode
 SHADOWDARK.sheet.abilities.label: Abilities

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -93,6 +93,7 @@ SHADOWDARK.chat_card.context.apply_damage_secondary: Apply Secondary Damage
 SHADOWDARK.chat_card.context.apply_damage: Apply Damage
 SHADOWDARK.chat_card.context.apply_healing_secondary: Apply Secondary Healing
 SHADOWDARK.chat_card.context.apply_healing: Apply Healing
+SHADOWDARK.chat.clockwise_initiative: Since {name} rolled highest, they will go first.
 SHADOWDARK.chat.hp_roll.apply_to_max: Add to Max HP
 SHADOWDARK.chat.item_roll.double_numerical: Double any one numerical value!
 SHADOWDARK.chat.item_roll.mishap: Roll on the appropriate Mishap table!

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -527,6 +527,8 @@ SHADOWDARK.settings.track_light_sources.pause_with_game.hint: If checked the Rea
 SHADOWDARK.settings.track_light_sources.pause_with_game.name: Pause Light Tracking
 SHADOWDARK.settings.track_light_sources.realtime_tracking.hint: If checked the Light Tracking will follow real time. Disable if an external time/calendar module is used.
 SHADOWDARK.settings.track_light_sources.realtime_tracking.name: Realtime Light Tracking
+SHADOWDARK.settings.use_clockwise_initiative.hint: "If checked the combatant with the highest iniative will go first, and all other combatants will follow in a fixed order determined by User Management. All NPCs will be grouped together in the initiative order.",
+SHADOWDARK.settings.use_clockwise_initiative.name: "Use Clockwise Initiative",
 SHADOWDARK.settings.use_pulp_mode.hint: Shows Luck tokens as a numeric value rather than a checkbox
 SHADOWDARK.settings.use_pulp_mode.name: Enable Pulp Mode
 SHADOWDARK.sheet.abilities.label: Abilities

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -508,7 +508,7 @@ SHADOWDARK.settings.track_light_sources.pause_with_game.hint: Si está marcado, 
 SHADOWDARK.settings.track_light_sources.pause_with_game.name: Pausar seguimiento de luz
 SHADOWDARK.settings.track_light_sources.realtime_tracking.hint: Si está marcado, el seguimiento de luz seguirá en tiempo real. Desactivar si se utiliza un módulo de hora/calendario externo.
 SHADOWDARK.settings.track_light_sources.realtime_tracking.name: Seguimiento de luz en tiempo real
-SHADOWDARK.settings.use_clockwise_initiative.hint: "If checked the combatant with the highest iniative will go first, and all other combatants will follow in a fixed order determined by user configuration. All NPCs will act on the same initiative.",
+SHADOWDARK.settings.use_clockwise_initiative.hint: "If checked the combatant with the highest iniative will go first, and all other combatants will follow in a fixed order determined by User Management. All NPCs will act on the same initiative.",
 SHADOWDARK.settings.use_clockwise_initiative.name: "Use Clockwise Initiative",
 SHADOWDARK.settings.use_pulp_mode.hint: Shows Luck tokens as a numeric value rather than a checkbox
 SHADOWDARK.settings.use_pulp_mode.name: Enable Pulp Mode

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -83,6 +83,7 @@ SHADOWDARK.chat_card.context.apply_damage_secondary: Apply Secondary Damage
 SHADOWDARK.chat_card.context.apply_damage: Apply Damage
 SHADOWDARK.chat_card.context.apply_healing_secondary: Apply Secondary Healing
 SHADOWDARK.chat_card.context.apply_healing: Apply Healing
+SHADOWDARK.chat.clockwise_initiative: Since {name} rolled highest, they will go first.
 SHADOWDARK.chat.hp_roll.apply_to_max: Añadir a PV máximos
 SHADOWDARK.chat.item_roll.double_numerical: '¡Duplica cualquier valor numérico!'
 SHADOWDARK.chat.item_roll.mishap: '¡Tira en la tabla de pifias apropiada!'

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -508,6 +508,8 @@ SHADOWDARK.settings.track_light_sources.pause_with_game.hint: Si está marcado, 
 SHADOWDARK.settings.track_light_sources.pause_with_game.name: Pausar seguimiento de luz
 SHADOWDARK.settings.track_light_sources.realtime_tracking.hint: Si está marcado, el seguimiento de luz seguirá en tiempo real. Desactivar si se utiliza un módulo de hora/calendario externo.
 SHADOWDARK.settings.track_light_sources.realtime_tracking.name: Seguimiento de luz en tiempo real
+SHADOWDARK.settings.use_clockwise_initiative.hint: "If checked the combatant with the highest iniative will go first, and all other combatants will follow in a fixed order determined by user configuration. All NPCs will act on the same initiative.",
+SHADOWDARK.settings.use_clockwise_initiative.name: "Use Clockwise Initiative",
 SHADOWDARK.settings.use_pulp_mode.hint: Shows Luck tokens as a numeric value rather than a checkbox
 SHADOWDARK.settings.use_pulp_mode.name: Enable Pulp Mode
 SHADOWDARK.sheet.abilities.label: Abilities

--- a/i18n/fi.yaml
+++ b/i18n/fi.yaml
@@ -508,6 +508,8 @@ SHADOWDARK.settings.track_light_sources.pause_with_game.hint: Jos valitset täm�
 SHADOWDARK.settings.track_light_sources.pause_with_game.name: Pauseta valonlähteiden seuranta
 SHADOWDARK.settings.track_light_sources.realtime_tracking.hint: Jos valitset tämän, valonlähteet seuraa oikeaa aikaa. Poista tämä valinta jos käytät aika- tai kalenteri-moduuleja.
 SHADOWDARK.settings.track_light_sources.realtime_tracking.name: Reaaliaikainen valolähteiden aika
+SHADOWDARK.settings.use_clockwise_initiative.hint: "If checked the combatant with the highest iniative will go first, and all other combatants will follow in a fixed order determined by User Management. All NPCs will act on the same initiative.",
+SHADOWDARK.settings.use_clockwise_initiative.name: "Use Clockwise Initiative",
 SHADOWDARK.settings.use_pulp_mode.hint: Shows Luck tokens as a numeric value rather than a checkbox
 SHADOWDARK.settings.use_pulp_mode.name: Enable Pulp Mode
 SHADOWDARK.sheet.abilities.label: Abilities

--- a/i18n/fi.yaml
+++ b/i18n/fi.yaml
@@ -83,6 +83,7 @@ SHADOWDARK.chat_card.context.apply_damage_secondary: Apply Secondary Damage
 SHADOWDARK.chat_card.context.apply_damage: Apply Damage
 SHADOWDARK.chat_card.context.apply_healing_secondary: Apply Secondary Healing
 SHADOWDARK.chat_card.context.apply_healing: Apply Healing
+SHADOWDARK.chat.clockwise_initiative: Since {name} rolled highest, they will go first.
 SHADOWDARK.chat.hp_roll.apply_to_max: Lisää osumapisteidesi maksimimäärään
 SHADOWDARK.chat.item_roll.double_numerical: Tuplaa yksi numeerinen arvo!
 SHADOWDARK.chat.item_roll.mishap: Heitä noppaa sopivaa loihtimisen tapahturmataulua vasten!

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -83,6 +83,7 @@ SHADOWDARK.chat_card.context.apply_damage_secondary: Appliquer les dégâts seco
 SHADOWDARK.chat_card.context.apply_damage: Appliquer les dégâts
 SHADOWDARK.chat_card.context.apply_healing_secondary: Appliquer la guérison secondaire
 SHADOWDARK.chat_card.context.apply_healing: Appliquer les soins
+SHADOWDARK.chat.clockwise_initiative: Since {name} rolled highest, they will go first.
 SHADOWDARK.chat.hp_roll.apply_to_max: Ajouter aux PV Max
 SHADOWDARK.chat.item_roll.double_numerical: Double une valeur numérique !
 SHADOWDARK.chat.item_roll.mishap: Jetez sur la table des mésaventures appropriée !

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -508,6 +508,8 @@ SHADOWDARK.settings.track_light_sources.pause_with_game.hint: If checked the Rea
 SHADOWDARK.settings.track_light_sources.pause_with_game.name: Pause Light Tracking
 SHADOWDARK.settings.track_light_sources.realtime_tracking.hint: If checked the Light Tracking will follow real time. Disable if an external time/calendar module is used.
 SHADOWDARK.settings.track_light_sources.realtime_tracking.name: Realtime Light Tracking
+SHADOWDARK.settings.use_clockwise_initiative.hint: "If checked the combatant with the highest iniative will go first, and all other combatants will follow in a fixed order determined by User Management. All NPCs will act on the same initiative.",
+SHADOWDARK.settings.use_clockwise_initiative.name: "Use Clockwise Initiative",
 SHADOWDARK.settings.use_pulp_mode.hint: Shows Luck tokens as a numeric value rather than a checkbox
 SHADOWDARK.settings.use_pulp_mode.name: Enable Pulp Mode
 SHADOWDARK.sheet.abilities.label: Abilities

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -508,7 +508,7 @@ SHADOWDARK.settings.track_light_sources.pause_with_game.hint: 체크하면 파�
 SHADOWDARK.settings.track_light_sources.pause_with_game.name: 빛 트래커 멈추기
 SHADOWDARK.settings.track_light_sources.realtime_tracking.hint: 체크하면 실시간으로 빛이 트래킹됩니다. 별도의 시계/달력 모듈을 사용하고 있다면 비활성화하세요.
 SHADOWDARK.settings.track_light_sources.realtime_tracking.name: 실시간 빛 트래킹
-SHADOWDARK.settings.use_clockwise_initiative.hint: "If checked the combatant with the highest iniative will go first, and all other combatants will follow in a fixed order determined by user configuration. All NPCs will act on the same initiative.",
+SHADOWDARK.settings.use_clockwise_initiative.hint: "If checked the combatant with the highest iniative will go first, and all other combatants will follow in a fixed order determined by User Management. All NPCs will act on the same initiative.",
 SHADOWDARK.settings.use_clockwise_initiative.name: "Use Clockwise Initiative",
 SHADOWDARK.settings.use_pulp_mode.hint: Shows Luck tokens as a numeric value rather than a checkbox
 SHADOWDARK.settings.use_pulp_mode.name: Enable Pulp Mode

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -83,6 +83,7 @@ SHADOWDARK.chat_card.context.apply_damage_secondary: 2차 피해 적용
 SHADOWDARK.chat_card.context.apply_damage: 피해 적용
 SHADOWDARK.chat_card.context.apply_healing_secondary: 2차 치유 적용
 SHADOWDARK.chat_card.context.apply_healing: 치유 적용
+SHADOWDARK.chat.clockwise_initiative: Since {name} rolled highest, they will go first.
 SHADOWDARK.chat.hp_roll.apply_to_max: 최대 HP에 추가
 SHADOWDARK.chat.item_roll.double_numerical: 숫자로 된 값 하나에 2를 곱하세요!
 SHADOWDARK.chat.item_roll.mishap: 적절한 사고 표를 보고 주사위를 굴리세요!

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -508,6 +508,8 @@ SHADOWDARK.settings.track_light_sources.pause_with_game.hint: 체크하면 파�
 SHADOWDARK.settings.track_light_sources.pause_with_game.name: 빛 트래커 멈추기
 SHADOWDARK.settings.track_light_sources.realtime_tracking.hint: 체크하면 실시간으로 빛이 트래킹됩니다. 별도의 시계/달력 모듈을 사용하고 있다면 비활성화하세요.
 SHADOWDARK.settings.track_light_sources.realtime_tracking.name: 실시간 빛 트래킹
+SHADOWDARK.settings.use_clockwise_initiative.hint: "If checked the combatant with the highest iniative will go first, and all other combatants will follow in a fixed order determined by user configuration. All NPCs will act on the same initiative.",
+SHADOWDARK.settings.use_clockwise_initiative.name: "Use Clockwise Initiative",
 SHADOWDARK.settings.use_pulp_mode.hint: Shows Luck tokens as a numeric value rather than a checkbox
 SHADOWDARK.settings.use_pulp_mode.name: Enable Pulp Mode
 SHADOWDARK.sheet.abilities.label: Abilities

--- a/i18n/sv.yaml
+++ b/i18n/sv.yaml
@@ -83,6 +83,7 @@ SHADOWDARK.chat_card.context.apply_damage_secondary: Applicera sekundärskada
 SHADOWDARK.chat_card.context.apply_damage: Applicera Skada
 SHADOWDARK.chat_card.context.apply_healing_secondary: Applicera sekundärläkning
 SHADOWDARK.chat_card.context.apply_healing: Applicera läkning
+SHADOWDARK.chat.clockwise_initiative: Since {name} rolled highest, they will go first.
 SHADOWDARK.chat.hp_roll.apply_to_max: Lägg till på max KP
 SHADOWDARK.chat.item_roll.double_numerical: Dubbla valfritt numeriskt värde!
 SHADOWDARK.chat.item_roll.mishap: Rulla på lämplig felkast-tabell!

--- a/i18n/sv.yaml
+++ b/i18n/sv.yaml
@@ -508,6 +508,8 @@ SHADOWDARK.settings.track_light_sources.pause_with_game.hint: Om markerad kommer
 SHADOWDARK.settings.track_light_sources.pause_with_game.name: Pausa ljusspårning
 SHADOWDARK.settings.track_light_sources.realtime_tracking.hint: Om markerad kommer ljusspårningen följa i realtid. Inaktivera om en extern tid/kalendermodul används.
 SHADOWDARK.settings.track_light_sources.realtime_tracking.name: Spåra ljuskällor realtid
+SHADOWDARK.settings.use_clockwise_initiative.hint: "If checked the combatant with the highest iniative will go first, and all other combatants will follow in a fixed order determined by user configuration. All NPCs will act on the same initiative.",
+SHADOWDARK.settings.use_clockwise_initiative.name: "Use Clockwise Initiative",
 SHADOWDARK.settings.use_pulp_mode.hint: Visar tur-tokens som ett numeriskt värde istället för en kryssruta
 SHADOWDARK.settings.use_pulp_mode.name: Aktivera pulp-läge
 SHADOWDARK.sheet.abilities.label: Förmågor

--- a/i18n/sv.yaml
+++ b/i18n/sv.yaml
@@ -508,7 +508,7 @@ SHADOWDARK.settings.track_light_sources.pause_with_game.hint: Om markerad kommer
 SHADOWDARK.settings.track_light_sources.pause_with_game.name: Pausa ljusspårning
 SHADOWDARK.settings.track_light_sources.realtime_tracking.hint: Om markerad kommer ljusspårningen följa i realtid. Inaktivera om en extern tid/kalendermodul används.
 SHADOWDARK.settings.track_light_sources.realtime_tracking.name: Spåra ljuskällor realtid
-SHADOWDARK.settings.use_clockwise_initiative.hint: "If checked the combatant with the highest iniative will go first, and all other combatants will follow in a fixed order determined by user configuration. All NPCs will act on the same initiative.",
+SHADOWDARK.settings.use_clockwise_initiative.hint: "If checked the combatant with the highest iniative will go first, and all other combatants will follow in a fixed order determined by User Management. All NPCs will act on the same initiative.",
 SHADOWDARK.settings.use_clockwise_initiative.name: "Use Clockwise Initiative",
 SHADOWDARK.settings.use_pulp_mode.hint: Visar tur-tokens som ett numeriskt värde istället för en kryssruta
 SHADOWDARK.settings.use_pulp_mode.name: Aktivera pulp-läge

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "foundryvtt-shadowdark",
 			"devDependencies": {
 				"@rollup/plugin-node-resolve": "^15.1.0",
 				"chalk": "^5.2.0",
@@ -39,15 +40,72 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.21.4",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.21.4.tgz",
-			"integrity": "sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==",
+			"version": "7.22.13",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+			"integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
 			"dev": true,
 			"dependencies": {
-				"@babel/highlight": "^7.18.6"
+				"@babel/highlight": "^7.22.13",
+				"chalk": "^2.4.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/code-frame/node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/code-frame/node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/@babel/code-frame/node_modules/has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/code-frame/node_modules/supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/@babel/compat-data": {
@@ -96,21 +154,21 @@
 			"dev": true
 		},
 		"node_modules/@babel/core/node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.21.4",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.4.tgz",
-			"integrity": "sha512-NieM3pVIYW2SwGzKoqfPrQsf4xGs9M9AIG3ThppsSRmO+m7eQhmI6amajKMUeIO37wFfsvnvcxQFx6x6iqxDnA==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.3.tgz",
+			"integrity": "sha512-keeZWAV4LU3tW0qRi19HRpabC/ilM0HRBBzf9/k8FFiG4KVpiv0FIy4hHfLfFQZNhziCTPTmd59zoyv6DNISzg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.21.4",
+				"@babel/types": "^7.23.3",
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"@jridgewell/trace-mapping": "^0.3.17",
 				"jsesc": "^2.5.1"
@@ -139,43 +197,43 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/@babel/helper-environment-visitor": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-			"integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+			"integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-function-name": {
-			"version": "7.21.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz",
-			"integrity": "sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+			"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/template": "^7.20.7",
-				"@babel/types": "^7.21.0"
+				"@babel/template": "^7.22.15",
+				"@babel/types": "^7.23.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-hoist-variables": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
-			"integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+			"integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.18.6"
+				"@babel/types": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -234,30 +292,30 @@
 			}
 		},
 		"node_modules/@babel/helper-split-export-declaration": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
-			"integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+			"version": "7.22.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+			"integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.18.6"
+				"@babel/types": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.19.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
-			"integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+			"integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.19.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
@@ -287,13 +345,13 @@
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-			"integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+			"integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.18.6",
-				"chalk": "^2.0.0",
+				"@babel/helper-validator-identifier": "^7.22.20",
+				"chalk": "^2.4.2",
 				"js-tokens": "^4.0.0"
 			},
 			"engines": {
@@ -357,9 +415,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.21.4",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.4.tgz",
-			"integrity": "sha512-alVJj7k7zIxqBZ7BTRhz0IqJFxW1VJbm6N8JbcYhQ186df9ZBPbZBmWSqAMXwHGsCJdYks7z/voa3ibiS5bCIw==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.3.tgz",
+			"integrity": "sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==",
 			"dev": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -546,33 +604,33 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
-			"integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
+			"version": "7.22.15",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+			"integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
 			"dev": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.18.6",
-				"@babel/parser": "^7.20.7",
-				"@babel/types": "^7.20.7"
+				"@babel/code-frame": "^7.22.13",
+				"@babel/parser": "^7.22.15",
+				"@babel/types": "^7.22.15"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.21.4",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.4.tgz",
-			"integrity": "sha512-eyKrRHKdyZxqDm+fV1iqL9UAHMoIg0nDaGqfIOd8rKH17m5snv7Gn4qgjBoFfLz9APvjFU/ICT00NVCv1Epp8Q==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.3.tgz",
+			"integrity": "sha512-+K0yF1/9yR0oHdE0StHuEj3uTPzwwbrLGfNOndVJVV2TqA5+j3oljJUb4nmB954FLGjNem976+B+eDuLIjesiQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.21.4",
-				"@babel/generator": "^7.21.4",
-				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.21.0",
-				"@babel/helper-hoist-variables": "^7.18.6",
-				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/parser": "^7.21.4",
-				"@babel/types": "^7.21.4",
+				"@babel/code-frame": "^7.22.13",
+				"@babel/generator": "^7.23.3",
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-function-name": "^7.23.0",
+				"@babel/helper-hoist-variables": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/parser": "^7.23.3",
+				"@babel/types": "^7.23.3",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
@@ -590,13 +648,13 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.21.4",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.4.tgz",
-			"integrity": "sha512-rU2oY501qDxE8Pyo7i/Orqma4ziCOrby0/9mvbDUGEfvZjb279Nk9k19e2fiCxHbRRpY2ZyrgW1eq22mvmOIzA==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.3.tgz",
+			"integrity": "sha512-OZnvoH2l8PK5eUvEcUyCt/sXgr/h+UWpVuBbOljwcrAgUl6lpchoQ++PHGyQy1AtYnVA6CEq3y5xeEI10brpXw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.19.4",
-				"@babel/helper-validator-identifier": "^7.19.1",
+				"@babel/helper-string-parser": "^7.22.5",
+				"@babel/helper-validator-identifier": "^7.22.20",
 				"to-fast-properties": "^2.0.0"
 			},
 			"engines": {
@@ -663,6 +721,18 @@
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@gulpjs/to-absolute-glob": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@gulpjs/to-absolute-glob/-/to-absolute-glob-4.0.0.tgz",
+			"integrity": "sha512-kjotm7XJrJ6v+7knhPaRgaT6q8F8K2jiafwYdNHLzmV0uGLuZY43FK6smNSHUPrhq5kX2slCUy+RGG/xGqmIKA==",
+			"dev": true,
+			"dependencies": {
+				"is-negated-glob": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
@@ -1623,9 +1693,9 @@
 			}
 		},
 		"node_modules/@types/eslint": {
-			"version": "8.37.0",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.37.0.tgz",
-			"integrity": "sha512-Piet7dG2JBuDIfohBngQ3rCt7MgO9xCO4xIMKxBThCq5PNRB91IjlJ10eJVwfoNtvTErmxLzwBZ7rHZtbOMmFQ==",
+			"version": "8.44.7",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.7.tgz",
+			"integrity": "sha512-f5ORu2hcBbKei97U73mf+l9t4zTGl74IqZ0GQk4oVea/VS8tQZYkUveSYojk+frraAVYId0V2WC9O4PTNru2FQ==",
 			"dev": true,
 			"dependencies": {
 				"@types/estree": "*",
@@ -1672,9 +1742,9 @@
 			}
 		},
 		"node_modules/@types/json-schema": {
-			"version": "7.0.11",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+			"version": "7.0.15",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
@@ -2531,6 +2601,31 @@
 			"optional": true,
 			"dependencies": {
 				"file-uri-to-path": "1.0.0"
+			}
+		},
+		"node_modules/bl": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
+			"integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
+			"dev": true,
+			"dependencies": {
+				"buffer": "^6.0.3",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.4.0"
+			}
+		},
+		"node_modules/bl/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/brace-expansion": {
@@ -3892,6 +3987,12 @@
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true
 		},
+		"node_modules/fast-fifo": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+			"integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+			"dev": true
+		},
 		"node_modules/fast-glob": {
 			"version": "3.2.12",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
@@ -4822,22 +4923,191 @@
 			}
 		},
 		"node_modules/gulp-eslint-new": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/gulp-eslint-new/-/gulp-eslint-new-1.8.0.tgz",
-			"integrity": "sha512-52h73ci3d2Xtz3eO/EHBtZFXOlX4vTKdinKKTfZFnlKewtjMWSZ2r7HGFprjog+kL+k8eJReQodP60PtMmzgVQ==",
+			"version": "1.8.4",
+			"resolved": "https://registry.npmjs.org/gulp-eslint-new/-/gulp-eslint-new-1.8.4.tgz",
+			"integrity": "sha512-T/eY9OWHJ0LGYvHUagPpC8tOMgLpniYKkgtwn3XA83e3IgeZV0NjlcWbhxkBHwO/LX/lbK01jp/Xqs6REyy+Vg==",
 			"dev": true,
 			"dependencies": {
-				"@types/eslint": "^8.37.0",
+				"@types/eslint": "^8.44.3",
 				"@types/node": ">=12",
 				"eslint": "8",
 				"fancy-log": "^2.0.0",
 				"plugin-error": "^2.0.1",
-				"semver": "^7.5.1",
+				"semver": "^7.5.4",
 				"ternary-stream": "^3.0.0",
-				"vinyl-fs": "^3.0.3"
+				"vinyl-fs": "^4.0.0"
 			},
 			"engines": {
 				"node": "^12.20 || ^14.13 || >=16"
+			}
+		},
+		"node_modules/gulp-eslint-new/node_modules/anymatch": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+			"dev": true,
+			"dependencies": {
+				"normalize-path": "^3.0.0",
+				"picomatch": "^2.0.4"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/gulp-eslint-new/node_modules/fs-mkdirp-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-2.0.1.tgz",
+			"integrity": "sha512-UTOY+59K6IA94tec8Wjqm0FSh5OVudGNB0NL/P6fB3HiE3bYOY3VYBGijsnOHNkQSwC1FKkU77pmq7xp9CskLw==",
+			"dev": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.8",
+				"streamx": "^2.12.0"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/gulp-eslint-new/node_modules/glob-parent": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"dev": true,
+			"dependencies": {
+				"is-glob": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/gulp-eslint-new/node_modules/glob-stream": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-8.0.0.tgz",
+			"integrity": "sha512-CdIUuwOkYNv9ZadR3jJvap8CMooKziQZ/QCSPhEb7zqfsEI5YnPmvca7IvbaVE3z58ZdUYD2JsU6AUWjL8WZJA==",
+			"dev": true,
+			"dependencies": {
+				"@gulpjs/to-absolute-glob": "^4.0.0",
+				"anymatch": "^3.1.3",
+				"fastq": "^1.13.0",
+				"glob-parent": "^6.0.2",
+				"is-glob": "^4.0.3",
+				"is-negated-glob": "^1.0.0",
+				"normalize-path": "^3.0.0",
+				"streamx": "^2.12.5"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/gulp-eslint-new/node_modules/lead": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/lead/-/lead-4.0.0.tgz",
+			"integrity": "sha512-DpMa59o5uGUWWjruMp71e6knmwKU3jRBBn1kjuLWN9EeIOxNeSAwvHf03WIl8g/ZMR2oSQC9ej3yeLBwdDc/pg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/gulp-eslint-new/node_modules/now-and-later": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-3.0.0.tgz",
+			"integrity": "sha512-pGO4pzSdaxhWTGkfSfHx3hVzJVslFPwBp2Myq9MYN/ChfJZF87ochMAXnvz6/58RJSf5ik2q9tXprBBrk2cpcg==",
+			"dev": true,
+			"dependencies": {
+				"once": "^1.4.0"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			}
+		},
+		"node_modules/gulp-eslint-new/node_modules/resolve-options": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-2.0.0.tgz",
+			"integrity": "sha512-/FopbmmFOQCfsCx77BRFdKOniglTiHumLgwvd6IDPihy1GKkadZbgQJBcTb2lMzSR1pndzd96b1nZrreZ7+9/A==",
+			"dev": true,
+			"dependencies": {
+				"value-or-function": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			}
+		},
+		"node_modules/gulp-eslint-new/node_modules/to-through": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/to-through/-/to-through-3.0.0.tgz",
+			"integrity": "sha512-y8MN937s/HVhEoBU1SxfHC+wxCHkV1a9gW8eAdTadYh/bGyesZIVcbjI+mSpFbSVwQici/XjBjuUyri1dnXwBw==",
+			"dev": true,
+			"dependencies": {
+				"streamx": "^2.12.5"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/gulp-eslint-new/node_modules/value-or-function": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-4.0.0.tgz",
+			"integrity": "sha512-aeVK81SIuT6aMJfNo9Vte8Dw0/FZINGBV8BfCraGtqVxIeLAEhJyoWs8SmvRVmXfGss2PmmOwZCuBPbZR+IYWg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 10.13.0"
+			}
+		},
+		"node_modules/gulp-eslint-new/node_modules/vinyl": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-3.0.0.tgz",
+			"integrity": "sha512-rC2VRfAVVCGEgjnxHUnpIVh3AGuk62rP3tqVrn+yab0YH7UULisC085+NYH+mnqf3Wx4SpSi1RQMwudL89N03g==",
+			"dev": true,
+			"dependencies": {
+				"clone": "^2.1.2",
+				"clone-stats": "^1.0.0",
+				"remove-trailing-separator": "^1.1.0",
+				"replace-ext": "^2.0.0",
+				"teex": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/gulp-eslint-new/node_modules/vinyl-fs": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-4.0.0.tgz",
+			"integrity": "sha512-7GbgBnYfaquMk3Qu9g22x000vbYkOex32930rBnc3qByw6HfMEAoELjCjoJv4HuEQxHAurT+nvMHm6MnJllFLw==",
+			"dev": true,
+			"dependencies": {
+				"fs-mkdirp-stream": "^2.0.1",
+				"glob-stream": "^8.0.0",
+				"graceful-fs": "^4.2.11",
+				"iconv-lite": "^0.6.3",
+				"is-valid-glob": "^1.0.0",
+				"lead": "^4.0.0",
+				"normalize-path": "3.0.0",
+				"resolve-options": "^2.0.0",
+				"stream-composer": "^1.0.2",
+				"streamx": "^2.14.0",
+				"to-through": "^3.0.0",
+				"value-or-function": "^4.0.0",
+				"vinyl": "^3.0.0",
+				"vinyl-sourcemap": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/gulp-eslint-new/node_modules/vinyl-sourcemap": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-2.0.0.tgz",
+			"integrity": "sha512-BAEvWxbBUXvlNoFQVFVHpybBbjW1r03WhohJzJDSfgrrK5xVYIDTan6xN14DlyImShgDRv2gl9qhM6irVMsV0Q==",
+			"dev": true,
+			"dependencies": {
+				"convert-source-map": "^2.0.0",
+				"graceful-fs": "^4.2.10",
+				"now-and-later": "^3.0.0",
+				"streamx": "^2.12.5",
+				"vinyl": "^3.0.0",
+				"vinyl-contents": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/gulp-if": {
@@ -5177,6 +5447,18 @@
 			"dev": true,
 			"engines": {
 				"node": ">=10.17.0"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"dev": true,
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/ieee754": {
@@ -5766,9 +6048,9 @@
 			}
 		},
 		"node_modules/istanbul-lib-instrument/node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
@@ -7541,9 +7823,9 @@
 			}
 		},
 		"node_modules/make-dir/node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
@@ -8116,9 +8398,9 @@
 			}
 		},
 		"node_modules/normalize-package-data/node_modules/semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver"
@@ -8851,6 +9133,12 @@
 				}
 			]
 		},
+		"node_modules/queue-tick": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+			"integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
+			"dev": true
+		},
 		"node_modules/react-is": {
 			"version": "18.2.0",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -9450,6 +9738,12 @@
 				"ret": "~0.1.10"
 			}
 		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
+		},
 		"node_modules/sass": {
 			"version": "1.63.4",
 			"resolved": "https://registry.npmjs.org/sass/-/sass-1.63.4.tgz",
@@ -9600,9 +9894,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.5.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-			"integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -10056,6 +10350,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/stream-composer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/stream-composer/-/stream-composer-1.0.2.tgz",
+			"integrity": "sha512-bnBselmwfX5K10AH6L4c8+S5lgZMWI7ZYrz2rvYjCPB2DIMC4Ig8OpxGpNJSxRZ58oti7y1IcNvjBAz9vW5m4w==",
+			"dev": true,
+			"dependencies": {
+				"streamx": "^2.13.2"
+			}
+		},
 		"node_modules/stream-exhaust": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
@@ -10067,6 +10370,16 @@
 			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
 			"integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
 			"dev": true
+		},
+		"node_modules/streamx": {
+			"version": "2.15.5",
+			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.5.tgz",
+			"integrity": "sha512-9thPGMkKC2GctCzyCUjME3yR03x2xNo0GPKGkRw2UMYN+gqWa9uqpyNWhmsNCutU5zHmkUum0LsCRQTXUgUCAg==",
+			"dev": true,
+			"dependencies": {
+				"fast-fifo": "^1.1.0",
+				"queue-tick": "^1.0.1"
+			}
 		},
 		"node_modules/string_decoder": {
 			"version": "1.1.1",
@@ -10178,6 +10491,15 @@
 			"dependencies": {
 				"es6-iterator": "^2.0.1",
 				"es6-symbol": "^3.1.1"
+			}
+		},
+		"node_modules/teex": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+			"integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+			"dev": true,
+			"dependencies": {
+				"streamx": "^2.12.5"
 			}
 		},
 		"node_modules/ternary-stream": {
@@ -10791,6 +11113,35 @@
 				"node": ">= 0.10"
 			}
 		},
+		"node_modules/vinyl-contents": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/vinyl-contents/-/vinyl-contents-2.0.0.tgz",
+			"integrity": "sha512-cHq6NnGyi2pZ7xwdHSW1v4Jfnho4TEGtxZHw01cmnc8+i7jgR6bRnED/LbrKan/Q7CvVLbnvA5OepnhbpjBZ5Q==",
+			"dev": true,
+			"dependencies": {
+				"bl": "^5.0.0",
+				"vinyl": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/vinyl-contents/node_modules/vinyl": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-3.0.0.tgz",
+			"integrity": "sha512-rC2VRfAVVCGEgjnxHUnpIVh3AGuk62rP3tqVrn+yab0YH7UULisC085+NYH+mnqf3Wx4SpSi1RQMwudL89N03g==",
+			"dev": true,
+			"dependencies": {
+				"clone": "^2.1.2",
+				"clone-stats": "^1.0.0",
+				"remove-trailing-separator": "^1.1.0",
+				"replace-ext": "^2.0.0",
+				"teex": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
 		"node_modules/vinyl-fs": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
@@ -10943,9 +11294,9 @@
 			}
 		},
 		"node_modules/word-wrap": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"

--- a/system/shadowdark.mjs
+++ b/system/shadowdark.mjs
@@ -70,6 +70,7 @@ Hooks.once("init", () => {
 	CONFIG.Actor.documentClass = documents.ActorSD;
 	CONFIG.Item.documentClass = documents.ItemSD;
 	CONFIG.DiceSD = dice.DiceSD;
+	CONFIG.Combat.documentClass = documents.EncounterSD;
 
 	// TODO: V11 Compatability legacyTransferral
 	//   Update to use the designed interface as specified here, once implemented into core

--- a/system/src/documents/EncounterSD.mjs
+++ b/system/src/documents/EncounterSD.mjs
@@ -1,0 +1,72 @@
+export default class EncounterSD extends Combat {
+	async rollInitiative(ids, options = {}) {
+		console.log(ids)
+		const combatants = ids.flatMap((id) => this.combatants.get(id) ?? []);
+		console.log(combatants)
+		const npcs = []
+		const pcs = []
+		for (const combatant of combatants) {
+			console.log(combatant.actor.name)
+			if (combatant.actor.type === 'Player') pcs.push(combatant)
+			else if (combatant.actor.type === 'NPC') npcs.push(combatant)
+		}
+	console.log(npcs)
+	console.log(pcs)
+
+		npcs.sort((a, b) => b.getRollData().initiativeBonus - a.getRollData().initiativeBonus)
+		console.log(npcs)
+
+		const rollResults = await Promise.all(
+			pcs.map(async (combatant) => {
+				const data = combatant.actor
+				const rollData = combatant.actor.getRollData()
+				const parts = [`${rollData.initiativeFormula}+${rollData.initiativeBonus}`]
+				const result = (await CONFIG.DiceSD._roll(parts, data)).roll.total
+				return {actor: data, initiative: result, formula: parts[0]}
+			})
+		)
+		let npcLeader
+
+		if (npcs.length > 0) {
+			npcLeader = npcs[0].actor
+			console.log('npc leader')
+			console.log(npcLeader)
+			const npcRollData = npcLeader.getRollData()
+			const npcParts = [`${npcRollData.initiativeFormula}+${npcRollData.initiativeBonus}`]
+			const npcRollResult = (await CONFIG.DiceSD._roll(npcParts, npcLeader)).roll.total
+			rollResults.push({actor: npcLeader, initiative: npcRollResult, formula: npcParts[0]})
+		}
+
+		rollResults.sort((a,b) => b.initiative - a.initiative)
+		console.log('roll results')
+		console.log(rollResults)
+
+		const firstActor = rollResults[0].actor
+		const firstInitiative = rollResults[0].initiative
+		const players = [game.users.activeGM, ...game.users.players]
+		console.log(players)
+		const firstIndex = (firstActor.type === 'NPC') ?
+			players.findIndex((p) => p === game.users.activeGM) :
+			players.findIndex((p) => p?.character === firstActor)
+		console.log(firstIndex)
+		for (let i = 0; i < firstIndex; i++) {
+			players.push(players.shift())
+		}
+		console.log(players)
+		console.log(players[0])
+		for (let i = 0; i < players.length; i++) {
+			console.log(i)
+			if (players[i].active){
+				if (players[i] === game.users.activeGM && npcLeader) {
+					console.log(npcLeader)
+					super.setInitiative(combatants.find((c) => c.actor.id === npcLeader.id).id, firstInitiative - i)
+				}
+				else {
+					if (players[i].character)
+						{console.log(players[i]?.character)
+						super.setInitiative(combatants.find((c) => c.actor.id === players[i]?.character?.id).id, firstInitiative - i)}
+				}
+			}
+		}
+	}
+}

--- a/system/src/documents/EncounterSD.mjs
+++ b/system/src/documents/EncounterSD.mjs
@@ -13,11 +13,12 @@ export default class EncounterSD extends Combat {
 			const rollers = []
 			const npcs = []
 			for (const combatant of this.combatants) {
-				if (combatant.actor.type === 'Player') rollers.push(combatant)
-				else if (combatant.actor.type === 'NPC') npcs.push(combatant)
+				if (combatant.actor.type === "Player") rollers.push(combatant)
+				else if (combatant.actor.type === "NPC") npcs.push(combatant)
 			}
 			if (npcs.length > 0) {
-				npcs.sort((a, b) => b.actor.getRollData().initiativeBonus - a.actor.getRollData().initiativeBonus)
+				npcs.sort((a, b) =>
+					b.actor.getRollData().initiativeBonus - a.actor.getRollData().initiativeBonus)
 				rollers.push(npcs[0])
 			}
 
@@ -30,21 +31,21 @@ export default class EncounterSD extends Combat {
 
 					// Construct chat message data
 					let messageData = foundry.utils.mergeObject({
-					speaker: ((combatant.actor.type === 'NPC') ?
-					null :
-					ChatMessage.getSpeaker({
-						actor: combatant.actor,
-						token: combatant.token,
-						alias: combatant.name
-					})),
-					flavor: game.i18n.format("COMBAT.RollsInitiative", {name: ((combatant.actor.type === 'NPC') ? `${game.i18n.localize("SHADOWDARK.dialog.gm")}` : combatant.name)}),
-					flags: {"core.initiativeRoll": true}
+						speaker: ((combatant.actor.type === "NPC") ?
+							null :
+							ChatMessage.getSpeaker({
+								actor: combatant.actor,
+								token: combatant.token,
+								alias: combatant.name
+							})),
+						flavor: game.i18n.format("COMBAT.RollsInitiative", {name: ((combatant.actor.type === "NPC") ? `${game.i18n.localize("SHADOWDARK.dialog.gm")}` : combatant.name)}),
+						flags: {"core.initiativeRoll": true}
 					}, messageOptions);
 					const rollChatData = await roll.toMessage(messageData, {create: false});
 
 					// If the combatant is hidden, use a private roll unless an alternative rollMode was explicitly requested
 					rollChatData.rollMode = "rollMode" in messageOptions ? messageOptions.rollMode
-					: (combatant.hidden ? CONST.DICE_ROLL_MODES.PRIVATE : chatRollMode );
+						: (combatant.hidden ? CONST.DICE_ROLL_MODES.PRIVATE : chatRollMode );
 
 					// Play 1 sound for the whole rolled set
 					if ( index > 0 ) rollChatData.sound = null;
@@ -57,7 +58,7 @@ export default class EncounterSD extends Combat {
 			// Identify the combatant with the highest initiative
 			const firstCombatant = rollResults.reduce(function(prev, current) {
 				return (prev && prev.prelimInitiative > current.prelimInitiative)
-				? prev : current
+					? prev : current
 			}).combatant
 
 			// Only consider users who have a character fighting in the current combat
@@ -67,7 +68,7 @@ export default class EncounterSD extends Combat {
 			]
 
 			// Rearrange user list so that the first combatant's owner goes first, and the rest follow in a predetermined order
-			const firstIndex = (firstCombatant.actor.type === 'NPC') ?
+			const firstIndex = (firstCombatant.actor.type === "NPC") ?
 				activeUsers.findIndex((p) => p === game.users.activeGM) :
 				activeUsers.findIndex((p) => p?.character === firstCombatant.actor)
 			for (let i = 0; i < firstIndex; i++) {
@@ -101,9 +102,9 @@ export default class EncounterSD extends Combat {
 			// Post a reminder to the chat that clockwise initiative is active
 			let messageData = foundry.utils.mergeObject({
 				flavor: game.i18n.format("SHADOWDARK.chat.clockwise_initiative", {
-					name: ((firstCombatant.actor.type === 'NPC') ?
-					`${game.i18n.localize("USER.RoleGamemaster")}` :
-					firstCombatant.name)
+					name: ((firstCombatant.actor.type === "NPC") ?
+						`${game.i18n.localize("USER.RoleGamemaster")}` :
+						firstCombatant.name)
 				})
 			}, messageOptions);
 			await ChatMessage.implementation.create(messageData);

--- a/system/src/documents/EncounterSD.mjs
+++ b/system/src/documents/EncounterSD.mjs
@@ -1,54 +1,69 @@
 export default class EncounterSD extends Combat {
-	async rollInitiative(ids, options = {}) {
+	async rollInitiative(ids, {formula=null, updateTurn=true, messageOptions={}}={}) {
 		if (game.settings.get("shadowdark", "useClockwiseInitiative")) {
+			super.resetAll()
 			//Structure input data
 			ids = typeof  ids === 'string' ? [ids] : ids
+			const currentId = this.combatant?.id;
 			const chatRollMode = game.settings.get("core", "rollMode");
 
-			const combatants = ids.flatMap((id) => this.combatants.get(id) ?? []) // replace with this.combatants?
-			for (const combatant of combatants) {
-				super.setInitiative(combatant.id, null)
-			}
 			const rollers = []
 			const npcs = []
-			for (const combatant of combatants) {
+			for (const combatant of this.combatants) {
 				if (combatant.actor.type === 'Player') rollers.push(combatant)
 				else if (combatant.actor.type === 'NPC') npcs.push(combatant)
 			}
-
-
-			// npcs.sort((a, b) => b.actor.getRollData().initiativeBonus - a.actor.getRollData().initiativeBonus)
-
-			// const rollResults = await Promise.all(
-			// 	pcs.map(async (combatant) => {
-			// 		const pcActor = combatant.actor
-			// 		const rollData = combatant.actor.getRollData()
-			// 		const parts = [`${rollData.initiativeFormula}+${rollData.initiativeBonus}`]
-			// 		const result = (await CONFIG.DiceSD._roll(parts, pcActor)).roll.total
-			// 		return {id: combatant.id, prelimInitiative: result}
-			// 	})
-			// )
-
-
 			if (npcs.length > 0) {
-				const npcRoller = npcs.reduce(function(prev, current) {
-					return (prev && prev.getRollData().initiativeBonusy > current.getRollData().initiativeBonus)
-					? prev : current
-				})
-				rollers.push(npcRoller)
-				// const npcRollData = npcRoller.getRollData()
-				// const npcParts = [`${npcRollData.initiativeFormula}+${npcRollData.initiativeBonus}`]
-				// const npcRollResult = (await CONFIG.DiceSD._roll(npcParts, npcLeader)).roll.total
-				// rollResults.push({id: npcs[0].id, prelimInitiative: npcRollResult})
+				npcs.sort((a, b) => b.actor.getRollData().initiativeBonus - a.actor.getRollData().initiativeBonus)
+				rollers.push(npcs[0])
 			}
 
+			const messages = [];
+			const rollResults = await Promise.all(
+				rollers.map(async (combatant, index) => {
+					const isNPC = combatant.actor.type === 'NPC'
+					const roll = combatant.getInitiativeRoll(formula)
+					await roll.evaluate({async: true})
 
+					// Construct chat message data
+					let messageData = foundry.utils.mergeObject({
+					speaker: ((isNPC) ?
+					null :
+					ChatMessage.getSpeaker({
+						actor: combatant.actor,
+						token: combatant.token,
+						alias: combatant.name
+					})),
+					flavor: game.i18n.format("COMBAT.RollsInitiative", {name: ((isNPC) ? 'The Gamemaster' : combatant.name)}),
+					flags: {"core.initiativeRoll": true}
+					}, messageOptions);
+					const rollChatData = await roll.toMessage(messageData, {create: false});
 
-			rollResults.sort((a,b) => b.prelimInitiative - a.prelimInitiative)
+					// If the combatant is hidden, use a private roll unless an alternative rollMode was explicitly requested
+					rollChatData.rollMode = "rollMode" in messageOptions ? messageOptions.rollMode
+					: (combatant.hidden ? CONST.DICE_ROLL_MODES.PRIVATE : chatRollMode );
 
-			const firstCombatant = combatants.get(rollResults[0].id)
-			const firstInitiative = rollResults[0].prelimInitiative
-			const activeUsers = [game.users.activeGM, ...(game.users.players.filter((p) => p.active))]
+					// Play 1 sound for the whole rolled set
+					if ( index > 0 ) rollChatData.sound = null;
+					messages.push(rollChatData);
+
+					return {combatant: combatant, prelimInitiative: roll.total}
+				})
+			)
+
+			console.log(rollResults)
+
+			const firstCombatant = rollResults.reduce(function(prev, current) {
+				return (prev && prev.prelimInitiative > current.prelimInitiative)
+				? prev : current
+			}).combatant
+////////////
+
+/////////////
+			const activeUsers = [
+				game.users.activeGM,
+				...(game.users.players.filter((p) => this.combatants.find((c) => c.actor === p.character)))
+			]
 
 			const firstIndex = (firstCombatant.actor.type === 'NPC') ?
 				activeUsers.findIndex((p) => p === game.users.activeGM) :
@@ -56,21 +71,44 @@ export default class EncounterSD extends Combat {
 			for (let i = 0; i < firstIndex; i++) {
 				activeUsers.push(activeUsers.shift())
 			}
+			console.log(firstCombatant)
+			console.log(activeUsers)
 
 			const initiativeOrder = []
 
 			for (const user of activeUsers) {
 				if (user === game.users.activeGM) initiativeOrder.push(...npcs)
 				else {
-					const c = combatants.get(user.character?.id)
+					const c = this.combatants.find((c) => c.actor === user.character)
 					if (c) initiativeOrder.push(c)
 				}
 			}
+			console.log(initiativeOrder)
+
 
 			for (let i = 0; i < initiativeOrder.length; i++) {
-				super.setInitiative(initiativeOrder[i].id, initiativeOrder.size - i)
+				super.setInitiative(initiativeOrder[i].id, initiativeOrder.length - i)
 			}
+
+			// Ensure the turn order remains with the same combatant
+			if ( updateTurn && currentId ) {
+				await this.update({turn: this.turns.findIndex(t => t.id === currentId)});
+			}
+
+			// Create multiple chat messages
+			await ChatMessage.implementation.create(messages);
+						// Construct chat message data
+						let messageData = foundry.utils.mergeObject({
+							// speaker: (ChatMessage.getSpeaker({
+							// 	actor: combatant.actor,
+							// 	token: combatant.token,
+							// 	alias: combatant.name
+							// })),
+							flavor: `Since <strong>${(firstCombatant.actor.type === 'Player' ? firstCombatant.name : 'the Gamemaster')}</strong> rolled highest, they will go first.`,
+							}, messageOptions);
+			await ChatMessage.implementation.create(messageData);
+			return this;
 		}
-		else super.rollInitiative(ids, options)
+		else super.rollInitiative(ids, {formula, updateTurn, messageOptions})
 	}
 }

--- a/system/src/documents/EncounterSD.mjs
+++ b/system/src/documents/EncounterSD.mjs
@@ -1,12 +1,15 @@
 export default class EncounterSD extends Combat {
 	async rollInitiative(ids, {formula=null, updateTurn=true, messageOptions={}}={}) {
+		// Roll clockwise initiative (rulebook page 83) if that setting is selected
 		if (game.settings.get("shadowdark", "useClockwiseInitiative")) {
+			// Clear existing initiatives
 			super.resetAll()
-			//Structure input data
-			ids = typeof  ids === 'string' ? [ids] : ids
+
+			// Structure input data
 			const currentId = this.combatant?.id;
 			const chatRollMode = game.settings.get("core", "rollMode");
 
+			// Initiative is rolled by all PCs and only the NPC with the highest bonus
 			const rollers = []
 			const npcs = []
 			for (const combatant of this.combatants) {
@@ -18,23 +21,23 @@ export default class EncounterSD extends Combat {
 				rollers.push(npcs[0])
 			}
 
+			// Get roll results for all combatants who get to roll initiative
 			const messages = [];
 			const rollResults = await Promise.all(
 				rollers.map(async (combatant, index) => {
-					const isNPC = combatant.actor.type === 'NPC'
 					const roll = combatant.getInitiativeRoll(formula)
 					await roll.evaluate({async: true})
 
 					// Construct chat message data
 					let messageData = foundry.utils.mergeObject({
-					speaker: ((isNPC) ?
+					speaker: ((combatant.actor.type === 'NPC') ?
 					null :
 					ChatMessage.getSpeaker({
 						actor: combatant.actor,
 						token: combatant.token,
 						alias: combatant.name
 					})),
-					flavor: game.i18n.format("COMBAT.RollsInitiative", {name: ((isNPC) ? 'The Gamemaster' : combatant.name)}),
+					flavor: game.i18n.format("COMBAT.RollsInitiative", {name: ((combatant.actor.type === 'NPC') ? `${game.i18n.localize("SHADOWDARK.dialog.gm")}` : combatant.name)}),
 					flags: {"core.initiativeRoll": true}
 					}, messageOptions);
 					const rollChatData = await roll.toMessage(messageData, {create: false});
@@ -51,41 +54,38 @@ export default class EncounterSD extends Combat {
 				})
 			)
 
-			console.log(rollResults)
-
+			// Identify the combatant with the highest initiative
 			const firstCombatant = rollResults.reduce(function(prev, current) {
 				return (prev && prev.prelimInitiative > current.prelimInitiative)
 				? prev : current
 			}).combatant
-////////////
 
-/////////////
+			// Only consider users who have a character fighting in the current combat
 			const activeUsers = [
 				game.users.activeGM,
 				...(game.users.players.filter((p) => this.combatants.find((c) => c.actor === p.character)))
 			]
 
+			// Rearrange user list so that the first combatant's owner goes first, and the rest follow in a predetermined order
 			const firstIndex = (firstCombatant.actor.type === 'NPC') ?
 				activeUsers.findIndex((p) => p === game.users.activeGM) :
 				activeUsers.findIndex((p) => p?.character === firstCombatant.actor)
 			for (let i = 0; i < firstIndex; i++) {
 				activeUsers.push(activeUsers.shift())
 			}
-			console.log(firstCombatant)
-			console.log(activeUsers)
 
+			// Sort combatants according to their owner's position in the clockwise initiative order.
 			const initiativeOrder = []
-
 			for (const user of activeUsers) {
+				// All NPCs go on the GM's turn in order of descending initiative bonus
 				if (user === game.users.activeGM) initiativeOrder.push(...npcs)
 				else {
 					const c = this.combatants.find((c) => c.actor === user.character)
 					if (c) initiativeOrder.push(c)
 				}
 			}
-			console.log(initiativeOrder)
 
-
+			// Set all combatants' initiatives in descending order
 			for (let i = 0; i < initiativeOrder.length; i++) {
 				super.setInitiative(initiativeOrder[i].id, initiativeOrder.length - i)
 			}
@@ -95,20 +95,22 @@ export default class EncounterSD extends Combat {
 				await this.update({turn: this.turns.findIndex(t => t.id === currentId)});
 			}
 
-			// Create multiple chat messages
-			await ChatMessage.implementation.create(messages);
-						// Construct chat message data
-						let messageData = foundry.utils.mergeObject({
-							// speaker: (ChatMessage.getSpeaker({
-							// 	actor: combatant.actor,
-							// 	token: combatant.token,
-							// 	alias: combatant.name
-							// })),
-							flavor: `Since <strong>${(firstCombatant.actor.type === 'Player' ? firstCombatant.name : 'the Gamemaster')}</strong> rolled highest, they will go first.`,
-							}, messageOptions);
+			// Post initiative rolls to chat
+			await ChatMessage.implementation.create(messages)
+
+			// Post a reminder to the chat that clockwise initiative is active
+			let messageData = foundry.utils.mergeObject({
+				flavor: game.i18n.format("SHADOWDARK.chat.clockwise_initiative", {
+					name: ((firstCombatant.actor.type === 'NPC') ?
+					`${game.i18n.localize("USER.RoleGamemaster")}` :
+					firstCombatant.name)
+				})
+			}, messageOptions);
 			await ChatMessage.implementation.create(messageData);
 			return this;
 		}
+
+		// If circular initiative is not selected, use the default Foundry method
 		else super.rollInitiative(ids, {formula, updateTurn, messageOptions})
 	}
 }

--- a/system/src/documents/_module.mjs
+++ b/system/src/documents/_module.mjs
@@ -1,2 +1,3 @@
 export {default as ActorSD} from "./ActorSD.mjs";
 export {default as ItemSD} from "./ItemSD.mjs";
+export {default as EncounterSD} from "./EncounterSD.mjs"

--- a/system/src/settings.mjs
+++ b/system/src/settings.mjs
@@ -166,4 +166,18 @@ export default function registerSystemSettings() {
 		default: false,
 		requiresReload: true,
 	});
+
+	// ----------------------
+	//  INITIATIVE SETTINGS
+	// ----------------------
+	//
+	game.settings.register("shadowdark", "debugEnabled", {
+		name: "SHADOWDARK.settings.use_clockwise_initiative.name",
+		hint: "SHADOWDARK.settings.use_clockwise_initiative.hint",
+		scope: "world",
+		type: Boolean,
+		config: true,
+		default: false,
+		requiresReload: true,
+	});
 }

--- a/system/src/settings.mjs
+++ b/system/src/settings.mjs
@@ -171,7 +171,7 @@ export default function registerSystemSettings() {
 	//  INITIATIVE SETTINGS
 	// ----------------------
 	//
-	game.settings.register("shadowdark", "debugEnabled", {
+	game.settings.register("shadowdark", "useClockwiseInitiative", {
 		name: "SHADOWDARK.settings.use_clockwise_initiative.name",
 		hint: "SHADOWDARK.settings.use_clockwise_initiative.hint",
 		scope: "world",


### PR DESCRIPTION
This creates a setting to enable "clockwise initiative" as described on page 83 of the core rulebook. Rather than all characters acting in descending order of their initiative rolls, the combatant with the highest roll goes first, then all other combatants follow in a fixed order (as though they were sitting around a table, going clockwise). The order is determined by the order of users in the User Configuration menu. All NPCs will act on the "GM's turn," going in descending order of initiative bonus.

By default, this option is disabled, as players will likely expect initiative to work the way it does in other Foundry systems, even though technically this is the way Shadowdark is played RAW.

In order to implement this setting, I had to replace the core Combat class with a new EncounterSD class that extends Combat. I also had to add a few strings to the translation files, like name/description for the setting, and some dialog flavor that isn't supported by the base system.