### PR TITLE
Allow monster importer to handle static (non-dice-roll) damage

### DIFF
--- a/system/src/apps/MonsterImporterSD.mjs
+++ b/system/src/apps/MonsterImporterSD.mjs
@@ -140,7 +140,7 @@ export default class MonsterImporterSD extends FormApplication {
 				attackObj.system.damage.value = diceStr[1] + diceStr[2];
 			}
 			else {
-				// TODO no way to set static damage: attackObj.system.damage.value = diceStr[1]
+				attackObj.system.damage = { value: diceStr[1] };
 			}
 
 			// parse remaining string parts for +dmg or feature
@@ -207,16 +207,16 @@ export default class MonsterImporterSD extends FormApplication {
 		const descStr = (`${parsedSpell[2]}.  ${parsedSpell[4]}`).toLowerCase();
 
 		// Take a chance at finding the range in the description
-		if (descStr.includes(" self.")) {
+		if (descStr.includes(" self.") || descStr.includes(" self,")) {
 			spellObj.system.range = "self";
 		}
-		else if (descStr.includes(" close.")) {
+		else if (descStr.includes(" close.") || descStr.includes(" close,")) {
 			spellObj.system.range = "close";
 		}
-		else if (descStr.includes(" near ") || descStr.includes(" near.") || descStr.includes(" near-sized ")) {
+		else if (descStr.includes(" near ") || descStr.includes(" near,") || descStr.includes(" near.") || descStr.includes(" near-sized ")) {
 			spellObj.system.range = "near";
 		}
-		else if (descStr.includes(" far ") || descStr.includes(" far.")) {
+		else if (descStr.includes(" far ") || descStr.includes(" far,") || descStr.includes(" far.")) {
 			spellObj.system.range = "far";
 		}
 

--- a/system/src/apps/MonsterImporterSD.mjs
+++ b/system/src/apps/MonsterImporterSD.mjs
@@ -207,16 +207,16 @@ export default class MonsterImporterSD extends FormApplication {
 		const descStr = (`${parsedSpell[2]}.  ${parsedSpell[4]}`).toLowerCase();
 
 		// Take a chance at finding the range in the description
-		if (descStr.includes(" self.") || descStr.includes(" self,")) {
+		if (descStr.includes(" self.")) {
 			spellObj.system.range = "self";
 		}
-		else if (descStr.includes(" close.") || descStr.includes(" close,")) {
+		else if (descStr.includes(" close.")) {
 			spellObj.system.range = "close";
 		}
-		else if (descStr.includes(" near ") || descStr.includes(" near,") || descStr.includes(" near.") || descStr.includes(" near-sized ")) {
+		else if (descStr.includes(" near ") || descStr.includes(" near.") || descStr.includes(" near-sized ")) {
 			spellObj.system.range = "near";
 		}
-		else if (descStr.includes(" far ") || descStr.includes(" far,") || descStr.includes(" far.")) {
+		else if (descStr.includes(" far ") || descStr.includes(" far.")) {
 			spellObj.system.range = "far";
 		}
 


### PR DESCRIPTION
Addresses #622. All I had to do was create a new object for attackObj.system.damage in the static damage case (the "else"). @PrototypeESBU, is there any reason you can see this wouldn't work? I've tested this code with every monster in the rulebook and didn't get any errors.

```
Fairy

Miniature fey folk with fluttering moth or butterfly wings.

AC 13, HP 4, ATK 1 needle +3 (1 + poison), MV near (fly), S -2, D +3, C +0, I +1, W +0, Ch +1, AL N, LV 1

Poison. DC 12 CON or fall into deep sleep for 1d4 hours.
```

Becomes

![image](https://github.com/Muttley/foundryvtt-shadowdark/assets/15185224/c1c767ab-0419-4d4e-8bcc-614e51e2222d)

![image](https://github.com/Muttley/foundryvtt-shadowdark/assets/15185224/945bc087-f6f6-4b85-91e4-3e3a77ab8508)
