### PR TITLE
Make monster importer range parsing more thorough and accurate

### DIFF
--- a/system/src/apps/MonsterImporterSD.mjs
+++ b/system/src/apps/MonsterImporterSD.mjs
@@ -204,22 +204,35 @@ export default class MonsterImporterSD extends FormApplication {
 			},
 		};
 
+		// Take a chance at finding the range in the description
+		const potentialRange = parsedSpell[2].toLowerCase();
 		const descStr = (`${parsedSpell[2]}.  ${parsedSpell[4]}`).toLowerCase();
 
-		// Take a chance at finding the range in the description
-		if (descStr.includes(" self.")) {
-			spellObj.system.range = "self";
+		for (const range of ["self", "far", "near", "close"]) {
+			if (potentialRange.includes(range)) {
+				spellObj.system.range = range;
+				break;
+			}
 		}
-		else if (descStr.includes(" close.")) {
-			spellObj.system.range = "close";
+		if (!spellObj.system.range) {
+			for (const range of ["far", "near", "close"]) {
+				if (descStr.includes(`in ${range}`) || descStr.includes(`${range} range`)) {
+					spellObj.system.range = range;
+					break;
+				}
+			}
 		}
-		else if (descStr.includes(" near ") || descStr.includes(" near.") || descStr.includes(" near-sized ")) {
-			spellObj.system.range = "near";
+		if (!spellObj.system.range) {
+			for (const word of parsedSpell[4].toLowerCase().split(" ")) {
+				for (const range of ["self", "far", "near", "close"]) {
+					if (word.includes(`${range}.`) || word.includes(`${range},`) || word.includes(`${range}-`)) {
+						spellObj.system.range = range;
+						break;
+					}
+				}
+				if (spellObj.system.range) break;
+			}
 		}
-		else if (descStr.includes(" far ") || descStr.includes(" far.")) {
-			spellObj.system.range = "far";
-		}
-
 
 		// Take a chance at finding a round duration in the description
 		const roundsDuration = parsedSpell[4].match(/(\d|\dd\d) rounds?/);


### PR DESCRIPTION
Addresses #616. More thoroughly and methodically sorts through the stat block of each spell to find the range.

First checks if there is a range listed before the spell DC (which is not always the case, frustratingly).

Then checks if the string "in [range]" is present to account for expressions like "an enemy within near" or "all enemies in near." It's important to check this first because some spells call out "a near-sized cube within far," which should show as far instead of near.

Then checks to find the earliest occurrence of a range word with punctuation.

I've tested this on every published monster (rulebook, Cursed Scrolls, and Monster Monday), and it seems to behave as expected. I've attached the results of the rulebook.
[npc spell ranges.csv](https://github.com/Muttley/foundryvtt-shadowdark/files/13610225/npc.spell.ranges.csv)
