### PR TITLE
Adds Drag-Ruler support

### DIFF
--- a/system/src/hooks.mjs
+++ b/system/src/hooks.mjs
@@ -7,6 +7,7 @@ import { LightSourceTrackerHooks } from "./hooks/light-source-tracker.mjs";
 import { NPCHooks } from "./hooks/npc.mjs";
 import { ShadowdarklingImport } from "./hooks/shadowdarkling-import.mjs";
 import { hotbarHooks } from "./hooks/hotbar.mjs";
+import { DragRulerHooks } from "./hooks/drag-ruler-support.mjs";
 
 export const HooksSD = {
 	attach: () => {
@@ -42,6 +43,7 @@ export const HooksInitSD = {
 		const listeners = [
 			ShadowdarklingImport,
 			EffectPanelHooks,
+			DragRulerHooks,
 		];
 
 		for (const listener of listeners) {

--- a/system/src/hooks/drag-ruler-support.mjs
+++ b/system/src/hooks/drag-ruler-support.mjs
@@ -1,0 +1,40 @@
+// A plugin for the Drag-Ruler module (https://github.com/manuelVo/foundryvtt-drag-ruler) to
+// translate Shadowdark's close, near, far, etc. movement types to numeric values.
+
+export const DragRulerHooks = {
+	attach: () => {
+		Hooks.once("dragRuler.ready", SpeedProvider => {
+			class ShadowdarkSpeedProvider extends SpeedProvider {
+				get colors() {
+					return [
+						{id: "walk", default: 0x00FF00, name: "shadowdark.speeds.walk"},
+						{id: "dash", default: 0xFFFF00, name: "shadowdark.speeds.dash"},
+					];
+				}
+
+				getRanges(token) {
+					const tokenMove = token.actor.system.move ?? "near";
+
+					const moveTranslation = {
+						close: 5,
+						near: 30,
+						doubleNear: 60,
+						tripleNear: 90,
+						far: 120,
+					};
+
+					const baseSpeedValue = moveTranslation[tokenMove] ?? 30;
+
+					const ranges = [
+						{range: baseSpeedValue, color: "walk"},
+						{range: baseSpeedValue * 2, color: "dash"},
+					];
+
+					return ranges;
+				}
+			}
+
+			dragRuler.registerSystem("shadowdark", ShadowdarkSpeedProvider);
+		});
+	},
+};


### PR DESCRIPTION
Offering a in-system version of the Drag-Ruler support module I made for my own use. For the purposes of Drag-Ruler, this plugin translates the following values:
- `close`: 5 ft.
- `near`: 30 ft.
- `doubleNear`: 60 ft.
- `tripleNear`: 90 ft.
- `far`: 120 ft.

These are the values as I understand them, but some consensus would be a good idea.