### PR TITLE
fix scroll icon appearing on spells learned from scrolls

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Details for how to get started hacking on the system can be found in the [Wiki](
 
 **foundryvtt-shadowdark** is an independent product published under the Shadowdark RPG Third-Party License and is not affiliated with The Arcane Library, LLC. Shadowdark RPG © 2023 The Arcane Library, LLC.
 
+The software code that makes up the core of this system is published under the MIT license (see LICENSE.txt).
+
 The [Arcane Library][1] logo, and additional [Shadowdark RPG][1] images included within **foundryvtt-shadowdark** are used with the kind permission of Kelsey Dionne and [Arcane Library][1].
 
 [1]: https://www.thearcanelibrary.com

--- a/README.md
+++ b/README.md
@@ -99,8 +99,6 @@ Details for how to get started hacking on the system can be found in the [Wiki](
 
 **foundryvtt-shadowdark** is an independent product published under the Shadowdark RPG Third-Party License and is not affiliated with The Arcane Library, LLC. Shadowdark RPG © 2023 The Arcane Library, LLC.
 
-The software code that makes up the core of this system is published under the MIT license (see LICENSE.txt).
-
 The [Arcane Library][1] logo, and additional [Shadowdark RPG][1] images included within **foundryvtt-shadowdark** are used with the kind permission of Kelsey Dionne and [Arcane Library][1].
 
 [1]: https://www.thearcanelibrary.com

--- a/system/src/documents/ActorSD.mjs
+++ b/system/src/documents/ActorSD.mjs
@@ -110,7 +110,7 @@ export default class ActorSD extends Actor {
 		if (success) {
 			const spell = {
 				type: "Spell",
-				img: item.img,
+				img: item.system.spellImg,
 				name: item.system.spellName,
 				system: {
 					class: item.system.class,

--- a/system/src/sheets/PlayerSheetSD.mjs
+++ b/system/src/sheets/PlayerSheetSD.mjs
@@ -437,6 +437,7 @@ export default class PlayerSheetSD extends ActorSheetSD {
 		else {
 			delete itemData.system.lost;
 			itemData.system.magicItem = true;
+			itemData.system.spellImg = spell.img;
 			itemData.system.spellName = spell.name;
 		}
 


### PR DESCRIPTION
Fixes #715.

Learned spells now show the original spell's icon (if the scroll was created after this commit). If not, it shows the generic magic icon:
![image](https://github.com/Muttley/foundryvtt-shadowdark/assets/15185224/704a6d9f-8031-4453-8c49-c84d3ef3c88a)
(Acid Arrow is an "old" scroll, Knock and Hold Person were made after this commit).

In the long run, is there a reason not to include the entire spell object as a property of the scroll? That way the original spell's ID and other properties could be accessed via the scroll item.