### PR TITLE
fixes #718 where fixed ancestry languages were being overwritten by fixed class languages

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+# vx.x.x
+
+## Bugfixes
+* [#718] Fixed an issue where the "common" language was not correctly loading in the Character Generator when selecting classes with fixed languages
+
+---
+
 # v1.8.0
 
 ## Bugfixes

--- a/system/src/apps/CharacterGeneratorSD.mjs
+++ b/system/src/apps/CharacterGeneratorSD.mjs
@@ -530,10 +530,7 @@ export default class CharacterGeneratorSD extends FormApplication {
 
 		// set formData form the ancestry object if it exists
 		if (this.ancestry?.system?.languages) {
-			langData.fixed = mergeObject(
-				langData.fixed,
-				this.ancestry.system.languages.fixed
-			);
+			langData.fixed = this.ancestry.system.languages.fixed;
 			langData.ancestry.select = this.ancestry.system.languages.select;
 			langData.common.select += this.ancestry.system.languages.common;
 			langData.rare.select += this.ancestry.system.languages.rare;
@@ -541,10 +538,11 @@ export default class CharacterGeneratorSD extends FormApplication {
 
 		// set formData form the class object if it exists
 		if (this.class?.system?.languages) {
-			langData.fixed = mergeObject(
-				langData.fixed,
-				this.class.system.languages.fixed
-			);
+			// combine both fixed arrays into a set to de-dupe
+			langData.fixed = [...new Set([
+				...langData.fixed,
+				...this.class.system.languages.fixed,
+			])];
 			langData.class.select = this.class.system.languages.select;
 			langData.common.select += this.class.system.languages.common;
 			langData.rare.select += this.class.system.languages.rare;


### PR DESCRIPTION
This would mostly impact custom classes as:
- There are no examples of fixed language classes in the core rules.
- One example in Unnatural Selection
- many examples in cursed scrolls