### PR TITLE
Add roll macro to spells missing it

### DIFF
--- a/data/packs/spells.db/cloud_kill__ssnOQiOeqkdVPHn3.json
+++ b/data/packs/spells.db/cloud_kill__ssnOQiOeqkdVPHn3.json
@@ -10,7 +10,7 @@
 		"class": [
 			"Compendium.shadowdark.classes.Item.035nuVkU9q2wtMPs"
 		],
-		"description": "<p>A putrid cloud of yellow poison fills a near-sized cube within range. It spreads around corners. </p><p></p><p>Creatures inside the cloud are blinded and take 2d6 damage at the beginning of their turns. </p><p></p><p>A creature of LV 9 or less that ends its turn fully inside the cloud dies.</p>",
+		"description": "<p>A putrid cloud of yellow poison fills a near-sized cube within range. It spreads around corners. </p><p></p><p>Creatures inside the cloud are blinded and take [[/r 2d6]] damage at the beginning of their turns. </p><p></p><p>A creature of LV 9 or less that ends its turn fully inside the cloud dies.</p>",
 		"duration": {
 			"type": "rounds",
 			"value": "5"

--- a/data/packs/spells.db/fireball__j2gvzfnMGQwxqgGg.json
+++ b/data/packs/spells.db/fireball__j2gvzfnMGQwxqgGg.json
@@ -10,7 +10,7 @@
 		"class": [
 			"Compendium.shadowdark.classes.Item.035nuVkU9q2wtMPs"
 		],
-		"description": "<p>You hurl a small flame that erupts into a fiery blast. All creatures in a near-sized cube around where the flame lands take 4d6 damage.</p>",
+		"description": "<p>You hurl a small flame that erupts into a fiery blast. All creatures in a near-sized cube around where the flame lands take [[/r 4d6]] damage.</p>",
 		"duration": {
 			"type": "instant",
 			"value": -1

--- a/data/packs/spells.db/lightning_bolt__7uTblEDfklCO1et7.json
+++ b/data/packs/spells.db/lightning_bolt__7uTblEDfklCO1et7.json
@@ -10,7 +10,7 @@
 		"class": [
 			"Compendium.shadowdark.classes.Item.035nuVkU9q2wtMPs"
 		],
-		"description": "<p>You shoot a blue-white ray of lightning from your hands, hitting all creatures in a straight line out to a far distance. </p><p></p><p>Creatures struck by the lightning take 3d6 damage.</p>",
+		"description": "<p>You shoot a blue-white ray of lightning from your hands, hitting all creatures in a straight line out to a far distance. </p><p></p><p>Creatures struck by the lightning take [[/r 3d6]] damage.</p>",
 		"duration": {
 			"type": "instant",
 			"value": -1


### PR DESCRIPTION
Fireball, lightning bolt, and cloud kill are missing associated roll macros for damage.

Thanks for your work! 