### PR TITLE
Fixes #809: warnings on Foundry v12

### DIFF
--- a/system/system.json
+++ b/system/system.json
@@ -298,10 +298,12 @@
 			]
 		}
 	],
+	"grid": {
+		"distance": 5,
+		"units": "ft"
+	},
 	"socket": true,
-	"gridDistance": 5,
 	"initiative": "@initiativeFormula + @initiativeBonus",
 	"primaryTokenAttribute": "attributes.hp",
-	"gridUnits": "ft",
 	"background": "systems/shadowdark/assets/artwork/GM_Screen_Final_Drawing_Elongated.webp"
 }

--- a/system/system.json
+++ b/system/system.json
@@ -1,7 +1,7 @@
 {
 	"id": "shadowdark",
 	"title": "Shadowdark RPG",
-	"desciption": "A system for playing the Shadowdark RPG from Arcane Library",
+	"description": "A system for playing the Shadowdark RPG from Arcane Library",
 	"version": "2.2.2",
 	"compatibility": {
 		"minimum": "11",


### PR DESCRIPTION
- Fix a typo that resulted in a warning. It sounds like the description probably never worked right.
- Move from the gridDistance and gridUnits fields to grid.distance and grid.units. I can't tell when these were added, so this needs to be tested on Foundry v11 (I only have a v12 system at this point).