### PR TITLE
Partial fix for #809: Fix description typo

### DIFF
--- a/system/system.json
+++ b/system/system.json
@@ -1,7 +1,7 @@
 {
 	"id": "shadowdark",
 	"title": "Shadowdark RPG",
-	"desciption": "A system for playing the Shadowdark RPG from Arcane Library",
+	"description": "A system for playing the Shadowdark RPG from Arcane Library",
 	"version": "2.2.2",
 	"compatibility": {
 		"minimum": "11",


### PR DESCRIPTION
It looks like the description for the Shadowdark system never worked right because of a typo. In v12 this also cases a warning. Fix the typo and the description pops up when you hover over the system card in the Foundry interface.