### PR TITLE
Griddistance warning fix

### DIFF
--- a/system/system.json
+++ b/system/system.json
@@ -298,12 +298,12 @@
 			]
 		}
 	],
-    "grid": {
-        "distance": 5,
-        "units": "ft"
-    },
-    "gridDistance": 5,
-    "gridUnits": "ft",
+	"grid": {
+		"distance": 5,
+		"units": "ft"
+	},
+	"gridDistance": 5,
+	"gridUnits": "ft",
 	"socket": true,
 	"initiative": "@initiativeFormula + @initiativeBonus",
 	"primaryTokenAttribute": "attributes.hp",

--- a/system/system.json
+++ b/system/system.json
@@ -298,10 +298,14 @@
 			]
 		}
 	],
+    "grid": {
+        "distance": 5,
+        "units": "ft"
+    },
+    "gridDistance": 5,
+    "gridUnits": "ft",
 	"socket": true,
-	"gridDistance": 5,
 	"initiative": "@initiativeFormula + @initiativeBonus",
 	"primaryTokenAttribute": "attributes.hp",
-	"gridUnits": "ft",
 	"background": "systems/shadowdark/assets/artwork/GM_Screen_Final_Drawing_Elongated.webp"
 }


### PR DESCRIPTION
Fix issue #809 by adding grid.distance and grid.units. We need to keep gridDistance and gridUnits for v11 support, though.