### PR TITLE
Implemented rolls for NPC special attacks

### DIFF
--- a/data/packs/monsters.db/life_drain__FmrC0mHGUBAGpc5P.json
+++ b/data/packs/monsters.db/life_drain__FmrC0mHGUBAGpc5P.json
@@ -11,7 +11,7 @@
 			"num": "1"
 		},
 		"bonuses": {
-			"attackBonus": 0
+			"attackBonus": 3
 		},
 		"description": "<p><span class=\"fontstyle2\">1d4 CON damage. Death if reduced to 0 CON.</span></p>",
 		"predefinedEffects": "",

--- a/data/packs/monsters.db/poison_web__8ITOtBo5399EG3Fl.json
+++ b/data/packs/monsters.db/poison_web__8ITOtBo5399EG3Fl.json
@@ -11,7 +11,7 @@
 			"num": "1"
 		},
 		"bonuses": {
-			"attackBonus": null
+			"attackBonus": 2
 		},
 		"description": "<p>One target stuck in place and [[/r 1d4]] damage/round. DC 12 DEX on turn to escape.</p>",
 		"predefinedEffects": "",

--- a/system/src/dice/RollSD.mjs
+++ b/system/src/dice/RollSD.mjs
@@ -57,9 +57,11 @@ export default class RollSD extends Roll {
 			return this._renderRoll(data, adv, options);
 		}
 
-		// Roll damage for NPCs
-		if (data.actor?.type === "NPC" && data.item.type === "NPC Attack") {
-			data = await this._rollNpcAttack(data);
+		// Roll damage for NPCs attack types
+		if (data.item.type === "NPC Attack" || data.item.type === "NPC Special Attack") {
+			if (data.item.type === "NPC Attack") {
+				data = await this._rollNpcAttack(data);
+			}
 			if (!options.flavor) {
 				options.flavor = game.i18n.format(
 					"SHADOWDARK.chat.item_roll.title",

--- a/system/templates/chat/item-card.hbs
+++ b/system/templates/chat/item-card.hbs
@@ -92,7 +92,7 @@
 	{{/if}}
 
 	{{#if isNPC}}
-		{{#unless isSpell}}
+		{{#ifEq data.item.type "NPC Attack"}}
 			{{#ifNeq data.rolls.main.critical "failure"}}
 				<div class="card-damage-rolls">
 					<div
@@ -104,7 +104,7 @@
 					</div>
 				</div>
 			{{/ifNeq}}
-		{{/unless}}
+		{{/ifEq}}
 	{{/if}}
 
 	{{#if data.item.system.damage.special}}

--- a/system/templates/partials/npc-special-attack.hbs
+++ b/system/templates/partials/npc-special-attack.hbs
@@ -1,5 +1,8 @@
-<a class="rollable" data-action="item-use-ability" data-item-id="{{itemId}}">
-	<i class="fas fa-comment"></i>
+<a class="rollable"
+	data-action="{{#if attackBonus}}item-attack{{else}}item-use-ability{{/if}}"
+	data-item-id="{{itemId}}"
+>
+	<i class="fas {{#if attackBonus}}fa-dice-d20{{else}}fa-comment{{/if}}"></i>
 	<b style="font-size:16px">
 		{{{numAttacks}}} {{attackName}}
 	</b>


### PR DESCRIPTION
bug fix:
[#757] NPC special attacks with an attack bonus set will now roll for attack