### PR TITLE
Active Effects improvements

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -585,8 +585,8 @@ SHADOWDARK.roll.spell_casting_check: Spellcasting Check
 SHADOWDARK.roll.success: Success! ({value})
 SHADOWDARK.settings.debugEnabled.hint: Enable or Disable additional debug logging
 SHADOWDARK.settings.debugEnabled.name: Enable/Disable Debug
-SHADOWDARK.settings.effect_panel.show_passive.hint: If checked the Effect Panel will show talents and other passive effects
-SHADOWDARK.settings.effect_panel.show_passive.name: Show passive effects in panel
+SHADOWDARK.settings.effect_panel.show_passive.hint: If checked, the Effect Panel will also show active effects from talents and items
+SHADOWDARK.settings.effect_panel.show_passive.name: Show All Active Effects
 SHADOWDARK.settings.migrateSystemCompendiums.hint: Perform data migration on the built in Shadowdark RPG system compendiums (don't modify this unless you know what you are doing)
 SHADOWDARK.settings.migrateSystemCompendiums.name: Migrate System Compendiums
 SHADOWDARK.settings.module_art.hint: Configure which module-provided art should be used

--- a/system/shadowdark.mjs
+++ b/system/shadowdark.mjs
@@ -71,10 +71,7 @@ Hooks.once("init", () => {
 	CONFIG.DiceSD = dice.DiceSD;
 	CONFIG.Combat.documentClass = documents.EncounterSD;
 
-	// TODO: V11 Compatability legacyTransferral
-	//   Update to use the designed interface as specified here, once implemented into core
-	//   https://github.com/foundryvtt/foundryvtt/issues/9185
-	if (game.version.split(".")[0] >= 11) CONFIG.ActiveEffect.legacyTransferral = true;
+	CONFIG.ActiveEffect.legacyTransferral = false;
 
 	registerHandlebarsHelpers();
 	registerSystemSettings();

--- a/system/src/apps/EffectPanelSD.mjs
+++ b/system/src/apps/EffectPanelSD.mjs
@@ -119,7 +119,7 @@ export default class EffectPanelSD extends Application {
 			});
 
 		expiredEffects.forEach(e => {
-			const i = this._controller._getSource(e);
+			const i = fromUuidSync(e.parent.uuid);
 			i.delete();
 		});
 	}
@@ -157,53 +157,37 @@ export class EffectPanelControllerSD {
 	get _actorEffects() {
 		const actor = this._actor;
 		if (!actor) return [];
-
-		// TODO: V11 Compatability legacyTransferral
-		//   Update to use the designed interface as specified here, once implemented into core
-		//   https://github.com/foundryvtt/foundryvtt/issues/9185
-		const sortedEffects = actor.effects
+		const sortedEffects = actor.appliedEffects
 			.map(effect => {
-				const src = this._getSource(effect);
-				if (!src) return false;
-				const effectData = effect.clone({}, { keepId: true});
 
-				// Set the effect and origin name
-				effectData.effectName = effect.name ?? effect.label;
-				effectData.originName = src.name;
+				if (effect.parent.type === "Effect") {
 
-				// Set the effect category
-				effectData.category = src.system.category;
+					const effectData = effect.clone({}, { keepId: true});
+					// Set the effect and origin name
+					effectData.parentName = effect.parent.name;
+					if (effectData.parentName !== effect.name) {
+						effectData.effectName = effect.name;
+					}
 
-				// Duration
-				effectData.remainingDuration = src.remainingDuration;
-				effectData.rounds = (src.system.duration?.type === "rounds")
-				 ? src.system.duration.value
-				 : 0;
-				effectData.isExpired = effectData.remainingDuration.expired;
+					// Set the effect category
+					effectData.category = effect.parent.system.category;
 
-				effectData.infinite = effectData.remainingDuration.remaining === Infinity;
+					// Duration
+					effectData.remainingDuration = effect.parent.remainingDuration;
+					effectData.rounds = (effect.parent.system.duration?.type === "rounds")
+						? effect.parent.system.duration.value
+						: 0;
+					effectData.isExpired = effectData.remainingDuration.expired;
+					effectData.infinite = effectData.remainingDuration.remaining === Infinity;
+					effectData.temporary = !effectData.infinite;
 
-				// Set the talent type if available
-				effectData.talentType = (src.system.talentClass)
-					? src.system.talentClass
-					: false;
-
-				// Determine if the talent is temporary
-				if (effectData.talentType) {
-					effectData.temporary = false;
-					effectData.hidden = false;
+					// is item hidden
+					effectData.hidden = !effect.parent.system.effectPanel.show ?? false;
+					return effectData;
 				}
 				else {
-					effectData.temporary = true;
-					effectData.hidden = !src.system.effectPanel?.show ?? false;
+					return false;
 				}
-
-				return effectData;
-			})
-			.sort((a, b) => {
-				if (a.temporary) return -1;
-				if (b.temporary) return 1;
-				return 0;
 			});
 
 		return sortedEffects;
@@ -251,21 +235,6 @@ export class EffectPanelControllerSD {
 	}
 
 	/**
-	 * Tries to get the item the effect originates from.
-	 * @param {ActiveEffect} effect - Effect to get source from
-	 * @returns {ItemSD|false}
-	 */
-	_getSource(effect) {
-		if (!effect.origin) return false;
-		try {
-			return fromUuidSync(effect.origin);
-		}
-		catch(Error) {
-			return false;
-		}
-	}
-
-	/**
 	 * Gets the top level position as stored for the user
 	 * @returns {string}
 	 */
@@ -299,14 +268,8 @@ export class EffectPanelControllerSD {
 	async onIconRightClick(event) {
 		const $target = $(event.currentTarget);
 		const actor = this._actor;
-		// TODO: V11 Compatability legacyTransferral
-		//   Update to use the designed interface as specified here, once implemented into core
-		//   https://github.com/foundryvtt/foundryvtt/issues/9185
-		const effect = actor?.effects.get($target[0].dataset.effectId ?? "");
-
-		if (!effect) return;
-
-		const sourceItem = this._getSource(effect);
+		const sourceItem = actor.items.get($target[0].dataset.effectId);
+		if (!sourceItem) return;
 
 		// TODO: Consider allowing default behavior to just delete effect item in settings.
 		return Dialog.confirm({
@@ -334,14 +297,8 @@ export class EffectPanelControllerSD {
 	async onIconClick(event) {
 		const $target = $(event.currentTarget);
 		const actor = this._actor;
-		// TODO: V11 Compatability legacyTransferral
-		//   Update to use the designed interface as specified here, once implemented into core
-		//   https://github.com/foundryvtt/foundryvtt/issues/9185
-		const effect = actor?.effects.get($target[0].dataset.effectId ?? "");
-
-		if (!effect) return;
-
-		const sourceItem = this._getSource(effect);
+		const sourceItem = actor.items.get($target[0].dataset.effectId);
+		if (!sourceItem) return;
 
 		if (event.ctrlKey || event.metaKey) {
 			sourceItem?.sheet.render(true);

--- a/system/src/sheets/ItemSheetSD.mjs
+++ b/system/src/sheets/ItemSheetSD.mjs
@@ -536,6 +536,9 @@ export default class ItemSheetSD extends ItemSheet {
 			event.target?.parentElement.id === "effect-duration";
 
 		if (durationTarget && durationClassName) {
+			if (event.target.name === "system.duration.value") {
+				this.item.system.duration.value = event.target.value;
+			}
 			await this._onUpdateDurationEffect();
 		}
 

--- a/system/templates/apps/effect-panel.hbs
+++ b/system/templates/apps/effect-panel.hbs
@@ -50,10 +50,12 @@
 			</div>
 
 			<h2>
+				{{#if effect.category}}
 				<em>
 					{{localize "SHADOWDARK.apps.effect_panel.right_click_to_remove"}}
 				</em>
-			</h3>
+				{{/if}}
+			</h2>
 		</div>
 
 		<div

--- a/system/templates/apps/effect-panel.hbs
+++ b/system/templates/apps/effect-panel.hbs
@@ -25,7 +25,10 @@
 	<div class="effect-item">
 		<div class="effect-info">
 			<h1>
-				{{effect.effectName}} ({{effect.originName}})
+				{{effect.parentName}}
+				{{#if effect.effectName}}
+					({{effect.effectName}})
+				{{/if}}
 			</h1>
 
 			<div class="tags">
@@ -55,7 +58,7 @@
 
 		<div
 			class="icon"
-			data-effect-id="{{effect.id}}"
+			data-effect-id="{{effect.parent.id}}"
 			style="background-image: url({{activeEffectIcon effect}});"
 		>
 			{{#if effect.temporary}}


### PR DESCRIPTION
Drop Legacy Active Effect Transferal method, and moves to the now default way of managing Active Effects on items.

Release notes:
[693] Changes made to active effects on actors will now take effects immediately
[332] implemented v11 method of working with Active Effects