### PR TITLE
fixes #983 - Shadowdarkling bug

### DIFF
--- a/system/assets/mappings/map-shadowdarkling.json
+++ b/system/assets/mappings/map-shadowdarkling.json
@@ -57,7 +57,7 @@
 		"Plus1MagicalDabbler": "Compendium.shadowdark.talents.Item.x4xTNUsimUpO3JBt",
 		"Plus1ToCastingSpells": "Compendium.shadowdark.talents.Item.0WmG5j0Wv685YTqO",
 		"Plus1ToDamage": "Compendium.shadowdark.talents.Item.38PGv4JtkfDumLDu",
-		"Plus1ToHit_Melee and ranged attacks": "Compendium.shadowdark.talents.Item.0yk16c9qcJ9vCekD",
+		"Plus1ToHit_Melee and ranged attacks": "Compendium.shadowdark.talents.Item.WSm6JESNoyFBnkW2",
 		"Plus1ToHit_Melee attacks": "Compendium.shadowdark.talents.Item.93QoQQ6cI7xa4TCm",
 		"Plus1ToHit_Ranged attacks": "Compendium.shadowdark.talents.Item.Y3Ytsye5zrP43w70",
 		"Plus1ToHitAndDamage_Melee attacks": "Compendium.shadowdark.talents.Item.0yk16c9qcJ9vCekD",


### PR DESCRIPTION
Release notes

*[#983] Fixed a bug when importing "+1 to melee and range attacks" talent from shadowdarklings.