### PR TITLE
Fixes #995 Character class not importing from shadowdarklings

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+# v3.x.x
+
+## Bugfixes
+- [#993] The add Treasure dialog prompt not rendering correctly
+- [#995] Shadowdarkling importer not importing character class
+---
+
 # v3.3.0
 
 ## Enhancements

--- a/system/src/apps/ShadowdarklingImporterSD.mjs
+++ b/system/src/apps/ShadowdarklingImporterSD.mjs
@@ -380,6 +380,7 @@ export default class ShadowdarklingImporterSD extends FormApplication {
 		// Load Class
 		this.classList = await shadowdark.compendiums.classes(false);
 		const classObj = await this._findItem(json.class, "Class");
+		this.importedActor.system.class = classObj?.uuid ?? "";
 
 		// Load fixed ancestry talents
 		if (ancestry) {


### PR DESCRIPTION
A line of code that sets class was erroneously removed in this commit: https://github.com/Muttley/foundryvtt-shadowdark/commit/335f2e17ade03212935be1277dee9cb4364e7160#diff-6e97c6c9c82ded32fbadb2ed5e2510488b35e29cbcbf83c434533ad125f8f1bdL385 