### PR TITLE
Separates kobold from Core Rules, merges it into a new source alongside bard and ranger

### DIFF
--- a/data/packs/ancestries.db/kobold__855WNm4l1T7S8akj.json
+++ b/data/packs/ancestries.db/kobold__855WNm4l1T7S8akj.json
@@ -23,7 +23,7 @@
 		"predefinedEffects": "",
 		"randomWeight": 1,
 		"source": {
-			"title": "core-rules"
+			"title": "kickstarter-stretch-goals"
 		},
 		"talentChoiceCount": 1,
 		"talents": [

--- a/data/packs/ancestries.db/kobold__855WNm4l1T7S8akj.json
+++ b/data/packs/ancestries.db/kobold__855WNm4l1T7S8akj.json
@@ -23,7 +23,7 @@
 		"predefinedEffects": "",
 		"randomWeight": 1,
 		"source": {
-			"title": "kickstarter-stretch-goals"
+			"title": "core-rules"
 		},
 		"talentChoiceCount": 1,
 		"talents": [

--- a/data/packs/class-abilities.db/curative__Ussun0GbRMiJZ8vP.json
+++ b/data/packs/class-abilities.db/curative__Ussun0GbRMiJZ8vP.json
@@ -16,7 +16,7 @@
 		"lost": false,
 		"predefinedEffects": "",
 		"source": {
-			"title": "bard-and-ranger"
+			"title": "kickstarter-stretch-goals"
 		},
 		"uses": {
 			"available": 0,

--- a/data/packs/class-abilities.db/curative__Ussun0GbRMiJZ8vP.json
+++ b/data/packs/class-abilities.db/curative__Ussun0GbRMiJZ8vP.json
@@ -16,7 +16,7 @@
 		"lost": false,
 		"predefinedEffects": "",
 		"source": {
-			"title": "kickstarter-stretch-goals"
+			"title": "bard-and-ranger"
 		},
 		"uses": {
 			"available": 0,

--- a/data/packs/class-abilities.db/fascinate__oCNpE6bnZjPIdOO1.json
+++ b/data/packs/class-abilities.db/fascinate__oCNpE6bnZjPIdOO1.json
@@ -16,7 +16,7 @@
 		"lost": false,
 		"predefinedEffects": "",
 		"source": {
-			"title": "bard-and-ranger"
+			"title": "kickstarter-stretch-goals"
 		},
 		"uses": {
 			"available": 0,

--- a/data/packs/class-abilities.db/fascinate__oCNpE6bnZjPIdOO1.json
+++ b/data/packs/class-abilities.db/fascinate__oCNpE6bnZjPIdOO1.json
@@ -16,7 +16,7 @@
 		"lost": false,
 		"predefinedEffects": "",
 		"source": {
-			"title": "kickstarter-stretch-goals"
+			"title": "bard-and-ranger"
 		},
 		"uses": {
 			"available": 0,

--- a/data/packs/class-abilities.db/foebane__i8PZF77jaVDkCE6n.json
+++ b/data/packs/class-abilities.db/foebane__i8PZF77jaVDkCE6n.json
@@ -16,7 +16,7 @@
 		"lost": false,
 		"predefinedEffects": "",
 		"source": {
-			"title": "bard-and-ranger"
+			"title": "kickstarter-stretch-goals"
 		},
 		"uses": {
 			"available": 0,

--- a/data/packs/class-abilities.db/foebane__i8PZF77jaVDkCE6n.json
+++ b/data/packs/class-abilities.db/foebane__i8PZF77jaVDkCE6n.json
@@ -16,7 +16,7 @@
 		"lost": false,
 		"predefinedEffects": "",
 		"source": {
-			"title": "kickstarter-stretch-goals"
+			"title": "bard-and-ranger"
 		},
 		"uses": {
 			"available": 0,

--- a/data/packs/class-abilities.db/inspire__jg2sUC3nIAI8sT18.json
+++ b/data/packs/class-abilities.db/inspire__jg2sUC3nIAI8sT18.json
@@ -16,7 +16,7 @@
 		"lost": false,
 		"predefinedEffects": "",
 		"source": {
-			"title": "bard-and-ranger"
+			"title": "kickstarter-stretch-goals"
 		},
 		"uses": {
 			"available": 0,

--- a/data/packs/class-abilities.db/inspire__jg2sUC3nIAI8sT18.json
+++ b/data/packs/class-abilities.db/inspire__jg2sUC3nIAI8sT18.json
@@ -16,7 +16,7 @@
 		"lost": false,
 		"predefinedEffects": "",
 		"source": {
-			"title": "kickstarter-stretch-goals"
+			"title": "bard-and-ranger"
 		},
 		"uses": {
 			"available": 0,

--- a/data/packs/class-abilities.db/restorative__3fck7HFRfDywsjQk.json
+++ b/data/packs/class-abilities.db/restorative__3fck7HFRfDywsjQk.json
@@ -16,7 +16,7 @@
 		"lost": false,
 		"predefinedEffects": "",
 		"source": {
-			"title": "bard-and-ranger"
+			"title": "kickstarter-stretch-goals"
 		},
 		"uses": {
 			"available": 0,

--- a/data/packs/class-abilities.db/restorative__3fck7HFRfDywsjQk.json
+++ b/data/packs/class-abilities.db/restorative__3fck7HFRfDywsjQk.json
@@ -16,7 +16,7 @@
 		"lost": false,
 		"predefinedEffects": "",
 		"source": {
-			"title": "kickstarter-stretch-goals"
+			"title": "bard-and-ranger"
 		},
 		"uses": {
 			"available": 0,

--- a/data/packs/class-abilities.db/salve__UzSmg3aLstFcNsUa.json
+++ b/data/packs/class-abilities.db/salve__UzSmg3aLstFcNsUa.json
@@ -16,7 +16,7 @@
 		"lost": false,
 		"predefinedEffects": "",
 		"source": {
-			"title": "bard-and-ranger"
+			"title": "kickstarter-stretch-goals"
 		},
 		"uses": {
 			"available": 0,

--- a/data/packs/class-abilities.db/salve__UzSmg3aLstFcNsUa.json
+++ b/data/packs/class-abilities.db/salve__UzSmg3aLstFcNsUa.json
@@ -16,7 +16,7 @@
 		"lost": false,
 		"predefinedEffects": "",
 		"source": {
-			"title": "kickstarter-stretch-goals"
+			"title": "bard-and-ranger"
 		},
 		"uses": {
 			"available": 0,

--- a/data/packs/class-abilities.db/stimulant__EhaA5tBROfrws1Kx.json
+++ b/data/packs/class-abilities.db/stimulant__EhaA5tBROfrws1Kx.json
@@ -16,7 +16,7 @@
 		"lost": false,
 		"predefinedEffects": "",
 		"source": {
-			"title": "bard-and-ranger"
+			"title": "kickstarter-stretch-goals"
 		},
 		"uses": {
 			"available": 0,

--- a/data/packs/class-abilities.db/stimulant__EhaA5tBROfrws1Kx.json
+++ b/data/packs/class-abilities.db/stimulant__EhaA5tBROfrws1Kx.json
@@ -16,7 +16,7 @@
 		"lost": false,
 		"predefinedEffects": "",
 		"source": {
-			"title": "kickstarter-stretch-goals"
+			"title": "bard-and-ranger"
 		},
 		"uses": {
 			"available": 0,

--- a/data/packs/classes.db/bard__112M28Tvi2ju06BE.json
+++ b/data/packs/classes.db/bard__112M28Tvi2ju06BE.json
@@ -38,7 +38,7 @@
 		},
 		"predefinedEffects": "",
 		"source": {
-			"title": "bard-and-ranger"
+			"title": "kickstarter-stretch-goals"
 		},
 		"spellcasting": {
 			"ability": "cha",

--- a/data/packs/classes.db/bard__112M28Tvi2ju06BE.json
+++ b/data/packs/classes.db/bard__112M28Tvi2ju06BE.json
@@ -38,7 +38,7 @@
 		},
 		"predefinedEffects": "",
 		"source": {
-			"title": "kickstarter-stretch-goals"
+			"title": "bard-and-ranger"
 		},
 		"spellcasting": {
 			"ability": "cha",

--- a/data/packs/talents.db/_1_to_magical_dabbler_rolls__x4xTNUsimUpO3JBt.json
+++ b/data/packs/talents.db/_1_to_magical_dabbler_rolls__x4xTNUsimUpO3JBt.json
@@ -16,7 +16,7 @@
 		"magicItem": false,
 		"predefinedEffects": "",
 		"source": {
-			"title": "kickstarter-stretch-goals"
+			"title": "bard-and-ranger"
 		},
 		"talentClass": "level"
 	},

--- a/data/packs/talents.db/_1_to_magical_dabbler_rolls__x4xTNUsimUpO3JBt.json
+++ b/data/packs/talents.db/_1_to_magical_dabbler_rolls__x4xTNUsimUpO3JBt.json
@@ -16,7 +16,7 @@
 		"magicItem": false,
 		"predefinedEffects": "",
 		"source": {
-			"title": "bard-and-ranger"
+			"title": "kickstarter-stretch-goals"
 		},
 		"talentClass": "level"
 	},

--- a/data/packs/talents.db/bardic_arts__j7nfbsMivwfCVkN0.json
+++ b/data/packs/talents.db/bardic_arts__j7nfbsMivwfCVkN0.json
@@ -11,7 +11,7 @@
 		"level": 1,
 		"predefinedEffects": "",
 		"source": {
-			"title": "kickstarter-stretch-goals"
+			"title": "bard-and-ranger"
 		},
 		"talentClass": "class"
 	},

--- a/data/packs/talents.db/bardic_arts__j7nfbsMivwfCVkN0.json
+++ b/data/packs/talents.db/bardic_arts__j7nfbsMivwfCVkN0.json
@@ -11,7 +11,7 @@
 		"level": 1,
 		"predefinedEffects": "",
 		"source": {
-			"title": "bard-and-ranger"
+			"title": "kickstarter-stretch-goals"
 		},
 		"talentClass": "class"
 	},

--- a/data/packs/talents.db/find_a_random_priest_or_wizard_wand__Myeeux8x1WqytayQ.json
+++ b/data/packs/talents.db/find_a_random_priest_or_wizard_wand__Myeeux8x1WqytayQ.json
@@ -11,7 +11,7 @@
 		"level": 0,
 		"predefinedEffects": "",
 		"source": {
-			"title": "kickstarter-stretch-goals"
+			"title": "bard-and-ranger"
 		},
 		"talentClass": "level"
 	},

--- a/data/packs/talents.db/find_a_random_priest_or_wizard_wand__Myeeux8x1WqytayQ.json
+++ b/data/packs/talents.db/find_a_random_priest_or_wizard_wand__Myeeux8x1WqytayQ.json
@@ -11,7 +11,7 @@
 		"level": 0,
 		"predefinedEffects": "",
 		"source": {
-			"title": "bard-and-ranger"
+			"title": "kickstarter-stretch-goals"
 		},
 		"talentClass": "level"
 	},

--- a/data/packs/talents.db/herbalism__ZjCvQZ7k4hBa9y2I.json
+++ b/data/packs/talents.db/herbalism__ZjCvQZ7k4hBa9y2I.json
@@ -12,7 +12,7 @@
 		"magicItem": false,
 		"predefinedEffects": "",
 		"source": {
-			"title": "bard-and-ranger"
+			"title": "kickstarter-stretch-goals"
 		},
 		"talentClass": "class"
 	},

--- a/data/packs/talents.db/herbalism__ZjCvQZ7k4hBa9y2I.json
+++ b/data/packs/talents.db/herbalism__ZjCvQZ7k4hBa9y2I.json
@@ -12,7 +12,7 @@
 		"magicItem": false,
 		"predefinedEffects": "",
 		"source": {
-			"title": "kickstarter-stretch-goals"
+			"title": "bard-and-ranger"
 		},
 		"talentClass": "class"
 	},

--- a/data/packs/talents.db/herbalism_check_advantage__p4Zh8LNyBp8UwhRD.json
+++ b/data/packs/talents.db/herbalism_check_advantage__p4Zh8LNyBp8UwhRD.json
@@ -12,7 +12,7 @@
 		"magicItem": false,
 		"predefinedEffects": "",
 		"source": {
-			"title": "kickstarter-stretch-goals"
+			"title": "bard-and-ranger"
 		},
 		"talentClass": "level"
 	},

--- a/data/packs/talents.db/herbalism_check_advantage__p4Zh8LNyBp8UwhRD.json
+++ b/data/packs/talents.db/herbalism_check_advantage__p4Zh8LNyBp8UwhRD.json
@@ -12,7 +12,7 @@
 		"magicItem": false,
 		"predefinedEffects": "",
 		"source": {
-			"title": "bard-and-ranger"
+			"title": "kickstarter-stretch-goals"
 		},
 		"talentClass": "level"
 	},

--- a/data/packs/talents.db/improved_presence_dc__gRyFoUtbbnkwcxy9.json
+++ b/data/packs/talents.db/improved_presence_dc__gRyFoUtbbnkwcxy9.json
@@ -11,7 +11,7 @@
 		"level": 0,
 		"predefinedEffects": "",
 		"source": {
-			"title": "kickstarter-stretch-goals"
+			"title": "bard-and-ranger"
 		},
 		"talentClass": "level"
 	},

--- a/data/packs/talents.db/improved_presence_dc__gRyFoUtbbnkwcxy9.json
+++ b/data/packs/talents.db/improved_presence_dc__gRyFoUtbbnkwcxy9.json
@@ -11,7 +11,7 @@
 		"level": 0,
 		"predefinedEffects": "",
 		"source": {
-			"title": "bard-and-ranger"
+			"title": "kickstarter-stretch-goals"
 		},
 		"talentClass": "level"
 	},

--- a/data/packs/talents.db/increased_weapon_damage_die__98HEgBRJSED5epGt.json
+++ b/data/packs/talents.db/increased_weapon_damage_die__98HEgBRJSED5epGt.json
@@ -16,7 +16,7 @@
 		"magicItem": false,
 		"predefinedEffects": "",
 		"source": {
-			"title": "kickstarter-stretch-goals"
+			"title": "bard-and-ranger"
 		},
 		"talentClass": "level"
 	},

--- a/data/packs/talents.db/increased_weapon_damage_die__98HEgBRJSED5epGt.json
+++ b/data/packs/talents.db/increased_weapon_damage_die__98HEgBRJSED5epGt.json
@@ -16,7 +16,7 @@
 		"magicItem": false,
 		"predefinedEffects": "",
 		"source": {
-			"title": "bard-and-ranger"
+			"title": "kickstarter-stretch-goals"
 		},
 		"talentClass": "level"
 	},

--- a/data/packs/talents.db/magical_dabbler__Om7QWre7U4Tbh84B.json
+++ b/data/packs/talents.db/magical_dabbler__Om7QWre7U4Tbh84B.json
@@ -11,7 +11,7 @@
 		"level": 1,
 		"predefinedEffects": "",
 		"source": {
-			"title": "kickstarter-stretch-goals"
+			"title": "bard-and-ranger"
 		},
 		"talentClass": "class"
 	},

--- a/data/packs/talents.db/magical_dabbler__Om7QWre7U4Tbh84B.json
+++ b/data/packs/talents.db/magical_dabbler__Om7QWre7U4Tbh84B.json
@@ -11,7 +11,7 @@
 		"level": 1,
 		"predefinedEffects": "",
 		"source": {
-			"title": "bard-and-ranger"
+			"title": "kickstarter-stretch-goals"
 		},
 		"talentClass": "class"
 	},

--- a/data/packs/talents.db/presence__J4KYu5M32T81yE1f.json
+++ b/data/packs/talents.db/presence__J4KYu5M32T81yE1f.json
@@ -11,7 +11,7 @@
 		"level": 1,
 		"predefinedEffects": "",
 		"source": {
-			"title": "kickstarter-stretch-goals"
+			"title": "bard-and-ranger"
 		},
 		"talentClass": "class"
 	},

--- a/data/packs/talents.db/presence__J4KYu5M32T81yE1f.json
+++ b/data/packs/talents.db/presence__J4KYu5M32T81yE1f.json
@@ -11,7 +11,7 @@
 		"level": 1,
 		"predefinedEffects": "",
 		"source": {
-			"title": "bard-and-ranger"
+			"title": "kickstarter-stretch-goals"
 		},
 		"talentClass": "class"
 	},

--- a/data/packs/talents.db/prolific__3gJPMZ8M4paFtm1n.json
+++ b/data/packs/talents.db/prolific__3gJPMZ8M4paFtm1n.json
@@ -11,7 +11,7 @@
 		"level": 1,
 		"predefinedEffects": "",
 		"source": {
-			"title": "kickstarter-stretch-goals"
+			"title": "bard-and-ranger"
 		},
 		"talentClass": "class"
 	},

--- a/data/packs/talents.db/prolific__3gJPMZ8M4paFtm1n.json
+++ b/data/packs/talents.db/prolific__3gJPMZ8M4paFtm1n.json
@@ -11,7 +11,7 @@
 		"level": 1,
 		"predefinedEffects": "",
 		"source": {
-			"title": "bard-and-ranger"
+			"title": "kickstarter-stretch-goals"
 		},
 		"talentClass": "class"
 	},

--- a/data/packs/talents.db/wayfinder__cUz7U8n0amQd5QQM.json
+++ b/data/packs/talents.db/wayfinder__cUz7U8n0amQd5QQM.json
@@ -12,7 +12,7 @@
 		"magicItem": false,
 		"predefinedEffects": "",
 		"source": {
-			"title": "bard-and-ranger"
+			"title": "kickstarter-stretch-goals"
 		},
 		"talentClass": "class"
 	},

--- a/data/packs/talents.db/wayfinder__cUz7U8n0amQd5QQM.json
+++ b/data/packs/talents.db/wayfinder__cUz7U8n0amQd5QQM.json
@@ -12,7 +12,7 @@
 		"magicItem": false,
 		"predefinedEffects": "",
 		"source": {
-			"title": "kickstarter-stretch-goals"
+			"title": "bard-and-ranger"
 		},
 		"talentClass": "class"
 	},

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -791,7 +791,6 @@ SHADOWDARK.sheet.player.tooltip.use_scroll: Use Scroll
 SHADOWDARK.sheet.player.tooltip.use_wand: Use Wand
 SHADOWDARK.sheet.player.xp: EP
 SHADOWDARK.sheet.special_abilities.label: Special Abilities
-SHADOWDARK.source.bard-and-ranger: "Shadowdark RPG: Bard and Ranger"
 SHADOWDARK.source.core-rules: "Shadowdark RPG: Core Rules"
 SHADOWDARK.source.cursed-scroll-1: Cursed Scroll Vol.1, Diablerie!
 SHADOWDARK.source.cursed-scroll-2: Cursed Scroll Vol.2, Red Sands
@@ -799,6 +798,7 @@ SHADOWDARK.source.cursed-scroll-3: Cursed Scroll Vol.3, Midnight Sun
 SHADOWDARK.source.cursed-scroll-4: Cursed Scroll Vol.4, River of Night
 SHADOWDARK.source.cursed-scroll-5: Cursed Scroll Vol.5, Dwellers in the Deep
 SHADOWDARK.source.cursed-scroll-6: Cursed Scroll Vol.6, City of Masks
+SHADOWDARK.source.kickstarter-stretch-goals: Kickstarter Stretch Goals (Bard, Ranger, and Kobold)
 SHADOWDARK.source.quickstart: "Shadowdark RPG: Quickstart Set"
 SHADOWDARK.spell_caster.priest: Priester
 SHADOWDARK.spell_caster.wizard: Zauberer

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -791,7 +791,6 @@ SHADOWDARK.sheet.player.tooltip.use_scroll: Use Scroll
 SHADOWDARK.sheet.player.tooltip.use_wand: Use Wand
 SHADOWDARK.sheet.player.xp: XP
 SHADOWDARK.sheet.special_abilities.label: Special Abilities
-SHADOWDARK.source.bard-and-ranger: "Shadowdark RPG: Bard and Ranger"
 SHADOWDARK.source.core-rules: "Shadowdark RPG: Core Rules"
 SHADOWDARK.source.cursed-scroll-1: Cursed Scroll Vol.1, Diablerie!
 SHADOWDARK.source.cursed-scroll-2: Cursed Scroll Vol.2, Red Sands
@@ -799,6 +798,7 @@ SHADOWDARK.source.cursed-scroll-3: Cursed Scroll Vol.3, Midnight Sun
 SHADOWDARK.source.cursed-scroll-4: Cursed Scroll Vol.4, River of Night
 SHADOWDARK.source.cursed-scroll-5: Cursed Scroll Vol.5, Dwellers in the Deep
 SHADOWDARK.source.cursed-scroll-6: Cursed Scroll Vol.6, City of Masks
+SHADOWDARK.source.kickstarter-stretch-goals: Kickstarter Stretch Goals (Bard, Ranger, and Kobold)
 SHADOWDARK.source.quickstart: "Shadowdark RPG: Quickstart Set"
 SHADOWDARK.spell_caster.priest: Priest
 SHADOWDARK.spell_caster.wizard: Wizard

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -791,7 +791,6 @@ SHADOWDARK.sheet.player.tooltip.use_scroll: Usar pergamino
 SHADOWDARK.sheet.player.tooltip.use_wand: Usar varita
 SHADOWDARK.sheet.player.xp: EXP
 SHADOWDARK.sheet.special_abilities.label: Special Abilities
-SHADOWDARK.source.bard-and-ranger: "Shadowdark RPG: Bardo y Explorador"
 SHADOWDARK.source.core-rules: "Shadowdark RPG: Reglas Basicas"
 SHADOWDARK.source.cursed-scroll-1: Pergamino Maldito Vol.1, Diablerie!
 SHADOWDARK.source.cursed-scroll-2: Pergamino Maldito Vol.2, Arenas Rojas
@@ -799,6 +798,7 @@ SHADOWDARK.source.cursed-scroll-3: Pergamino Maldito Vol.3, Sol Medianoche
 SHADOWDARK.source.cursed-scroll-4: Cursed Scroll Vol.4, River of Night
 SHADOWDARK.source.cursed-scroll-5: Cursed Scroll Vol.5, Dwellers in the Deep
 SHADOWDARK.source.cursed-scroll-6: Cursed Scroll Vol.6, City of Masks
+SHADOWDARK.source.kickstarter-stretch-goals: Kickstarter Stretch Goals (Bard, Ranger, and Kobold)
 SHADOWDARK.source.quickstart: "Shadowdark RPG: Quickstart Set"
 SHADOWDARK.spell_caster.priest: Clérigo
 SHADOWDARK.spell_caster.wizard: Mago

--- a/i18n/fi.yaml
+++ b/i18n/fi.yaml
@@ -791,7 +791,6 @@ SHADOWDARK.sheet.player.tooltip.use_scroll: Käytä loitsukäärö
 SHADOWDARK.sheet.player.tooltip.use_wand: Käytä taikasauvaa
 SHADOWDARK.sheet.player.xp: Kokemuspisteet
 SHADOWDARK.sheet.special_abilities.label: Special Abilities
-SHADOWDARK.source.bard-and-ranger: "Shadowdark RPG: Trubaduuri ja Samooja"
 SHADOWDARK.source.core-rules: "Shadowdark RPG: Ydinsäännöt"
 SHADOWDARK.source.cursed-scroll-1: Cursed Scroll Vol. 1, Diablerie!
 SHADOWDARK.source.cursed-scroll-2: Cursed Scroll Vol.2, Red Sands
@@ -799,6 +798,7 @@ SHADOWDARK.source.cursed-scroll-3: Cursed Scroll Vol.3, Midnight Sun
 SHADOWDARK.source.cursed-scroll-4: Cursed Scroll Vol.4, River of Night
 SHADOWDARK.source.cursed-scroll-5: Cursed Scroll Vol.5, Dwellers in the Deep
 SHADOWDARK.source.cursed-scroll-6: Cursed Scroll Vol.6, City of Masks
+SHADOWDARK.source.kickstarter-stretch-goals: Kickstarter Stretch Goals (Bard, Ranger, and Kobold)
 SHADOWDARK.source.quickstart: "Shadowdark RPG: Quickstart Set"
 SHADOWDARK.spell_caster.priest: Pappi
 SHADOWDARK.spell_caster.wizard: Velho

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -791,7 +791,6 @@ SHADOWDARK.sheet.player.tooltip.use_scroll: Use Scroll
 SHADOWDARK.sheet.player.tooltip.use_wand: Use Wand
 SHADOWDARK.sheet.player.xp: EXP
 SHADOWDARK.sheet.special_abilities.label: Special Abilities
-SHADOWDARK.source.bard-and-ranger: "Shadowdark RPG: Bard and Ranger"
 SHADOWDARK.source.core-rules: "Shadowdark RPG: Core Rules"
 SHADOWDARK.source.cursed-scroll-1: Cursed Scroll Vol.1, Diablerie!
 SHADOWDARK.source.cursed-scroll-2: Cursed Scroll Vol.2, Red Sands
@@ -799,6 +798,7 @@ SHADOWDARK.source.cursed-scroll-3: Cursed Scroll Vol.3, Midnight Sun
 SHADOWDARK.source.cursed-scroll-4: Cursed Scroll Vol.4, River of Night
 SHADOWDARK.source.cursed-scroll-5: Cursed Scroll Vol.5, Dwellers in the Deep
 SHADOWDARK.source.cursed-scroll-6: Cursed Scroll Vol.6, City of Masks
+SHADOWDARK.source.kickstarter-stretch-goals: Kickstarter Stretch Goals (Bard, Ranger, and Kobold)
 SHADOWDARK.source.quickstart: "Shadowdark RPG: Quickstart Set"
 SHADOWDARK.spell_caster.priest: Prêtre
 SHADOWDARK.spell_caster.wizard: Magicien

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -791,7 +791,6 @@ SHADOWDARK.sheet.player.tooltip.use_scroll: 두루마리 사용
 SHADOWDARK.sheet.player.tooltip.use_wand: 마법봉 사용
 SHADOWDARK.sheet.player.xp: XP
 SHADOWDARK.sheet.special_abilities.label: Special Abilities
-SHADOWDARK.source.bard-and-ranger: "섀도다크 RPG: 바드와 레인저"
 SHADOWDARK.source.core-rules: "섀도다크 RPG: 코어 룰북"
 SHADOWDARK.source.cursed-scroll-1: 커스드 스크롤 Vol.1, 다이어블러리!
 SHADOWDARK.source.cursed-scroll-2: 커스드 스크롤 Vol.2, 레드 샌드
@@ -799,6 +798,7 @@ SHADOWDARK.source.cursed-scroll-3: 커스드 스크롤 Vol.3, 미드나이트 �
 SHADOWDARK.source.cursed-scroll-4: Cursed Scroll Vol.4, River of Night
 SHADOWDARK.source.cursed-scroll-5: Cursed Scroll Vol.5, Dwellers in the Deep
 SHADOWDARK.source.cursed-scroll-6: Cursed Scroll Vol.6, City of Masks
+SHADOWDARK.source.kickstarter-stretch-goals: Kickstarter Stretch Goals (Bard, Ranger, and Kobold)
 SHADOWDARK.source.quickstart: "섀도다크 RPG: 퀵스타트 세트"
 SHADOWDARK.spell_caster.priest: 성직자
 SHADOWDARK.spell_caster.wizard: 마법사

--- a/i18n/pt_BR.yaml
+++ b/i18n/pt_BR.yaml
@@ -791,7 +791,6 @@ SHADOWDARK.sheet.player.tooltip.use_scroll: Usar Pergaminho
 SHADOWDARK.sheet.player.tooltip.use_wand: Usar Varinha
 SHADOWDARK.sheet.player.xp: XP
 SHADOWDARK.sheet.special_abilities.label: Habilidades Especiais
-SHADOWDARK.source.bard-and-ranger: "RPG Shadowdark: Bardo e Patrulheiro"
 SHADOWDARK.source.core-rules: "Shadowdark RPG: Core Rules"
 SHADOWDARK.source.cursed-scroll-1: Cursed Scroll Vol.1, Diablerie!
 SHADOWDARK.source.cursed-scroll-2: Cursed Scroll Vol.2, Red Sands
@@ -799,6 +798,7 @@ SHADOWDARK.source.cursed-scroll-3: Cursed Scroll Vol.3, Midnight Sun
 SHADOWDARK.source.cursed-scroll-4: Cursed Scroll Vol.4, River of Night
 SHADOWDARK.source.cursed-scroll-5: Cursed Scroll Vol.5, Dwellers in the Deep
 SHADOWDARK.source.cursed-scroll-6: Cursed Scroll Vol.6, City of Masks
+SHADOWDARK.source.kickstarter-stretch-goals: Kickstarter Stretch Goals (Bard, Ranger, and Kobold)
 SHADOWDARK.source.quickstart: "Shadowdark RPG: Quickstart Set"
 SHADOWDARK.spell_caster.priest: Clérigo
 SHADOWDARK.spell_caster.wizard: Mago

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -791,7 +791,6 @@ SHADOWDARK.sheet.player.tooltip.use_scroll: Использовать свито�
 SHADOWDARK.sheet.player.tooltip.use_wand: Использовать жезл
 SHADOWDARK.sheet.player.xp: Опыт
 SHADOWDARK.sheet.special_abilities.label: Special Abilities
-SHADOWDARK.source.bard-and-ranger: "Shadowdark НРИ: Бард и Следопыт"
 SHADOWDARK.source.core-rules: "Shadowdark НРИ: Основные правила"
 SHADOWDARK.source.cursed-scroll-1: Проклятый свиток том 1, Дьявольщина!
 SHADOWDARK.source.cursed-scroll-2: Проклятый свиток том 2, Красные пески
@@ -799,6 +798,7 @@ SHADOWDARK.source.cursed-scroll-3: Проклятый свиток том 3, П�
 SHADOWDARK.source.cursed-scroll-4: Cursed Scroll Vol.4, River of Night
 SHADOWDARK.source.cursed-scroll-5: Cursed Scroll Vol.5, Dwellers in the Deep
 SHADOWDARK.source.cursed-scroll-6: Cursed Scroll Vol.6, City of Masks
+SHADOWDARK.source.kickstarter-stretch-goals: Kickstarter Stretch Goals (Bard, Ranger, and Kobold)
 SHADOWDARK.source.quickstart: "Shadowdark НРИ: Набор для быстрого старта"
 SHADOWDARK.spell_caster.priest: Жрец
 SHADOWDARK.spell_caster.wizard: Волшебник

--- a/i18n/sv.yaml
+++ b/i18n/sv.yaml
@@ -791,7 +791,6 @@ SHADOWDARK.sheet.player.tooltip.use_scroll: Använd scroll
 SHADOWDARK.sheet.player.tooltip.use_wand: Använd trollspö
 SHADOWDARK.sheet.player.xp: XP
 SHADOWDARK.sheet.special_abilities.label: Special Abilities
-SHADOWDARK.source.bard-and-ranger: "Shadowdark RPG: Bard och Ranger"
 SHADOWDARK.source.core-rules: "Shadowdark RPG: Kärnregler"
 SHADOWDARK.source.cursed-scroll-1: Cursed Scroll Vol.1, Diablerie!
 SHADOWDARK.source.cursed-scroll-2: Cursed Scroll Vol.2, Red Sands
@@ -799,6 +798,7 @@ SHADOWDARK.source.cursed-scroll-3: Cursed Scroll Vol.3, Midnight Sun
 SHADOWDARK.source.cursed-scroll-4: Cursed Scroll Vol.4, River of Night
 SHADOWDARK.source.cursed-scroll-5: Cursed Scroll Vol.5, Dwellers in the Deep
 SHADOWDARK.source.cursed-scroll-6: Cursed Scroll Vol.6, City of Masks
+SHADOWDARK.source.kickstarter-stretch-goals: Kickstarter Stretch Goals (Bard, Ranger, and Kobold)
 SHADOWDARK.source.quickstart: "Shadowdark RPG: Quickstart Set"
 SHADOWDARK.spell_caster.priest: Präst
 SHADOWDARK.spell_caster.wizard: Trollkarl

--- a/system/src/config.mjs
+++ b/system/src/config.mjs
@@ -140,7 +140,6 @@ SHADOWDARK.RANGES_SHORT = {
 };
 
 SHADOWDARK.OFFICIAL_SOURCES = {
-	"bard-and-ranger": "SHADOWDARK.source.bard-and-ranger",
 	"core-rules": "SHADOWDARK.source.core-rules",
 	"cursed-scroll-1": "SHADOWDARK.source.cursed-scroll-1",
 	"cursed-scroll-2": "SHADOWDARK.source.cursed-scroll-2",
@@ -148,6 +147,7 @@ SHADOWDARK.OFFICIAL_SOURCES = {
 	"cursed-scroll-4": "SHADOWDARK.source.cursed-scroll-4",
 	"cursed-scroll-5": "SHADOWDARK.source.cursed-scroll-5",
 	"cursed-scroll-6": "SHADOWDARK.source.cursed-scroll-6",
+	"kickstarter-stretch-goals": "SHADOWDARK.source.kickstarter-stretch-goals",
 	"quickstart": "SHADOWDARK.source.quickstart",
 };
 

--- a/system/src/config.mjs
+++ b/system/src/config.mjs
@@ -140,6 +140,7 @@ SHADOWDARK.RANGES_SHORT = {
 };
 
 SHADOWDARK.OFFICIAL_SOURCES = {
+	"bard-and-ranger": "SHADOWDARK.source.bard-and-ranger",
 	"core-rules": "SHADOWDARK.source.core-rules",
 	"cursed-scroll-1": "SHADOWDARK.source.cursed-scroll-1",
 	"cursed-scroll-2": "SHADOWDARK.source.cursed-scroll-2",
@@ -147,7 +148,6 @@ SHADOWDARK.OFFICIAL_SOURCES = {
 	"cursed-scroll-4": "SHADOWDARK.source.cursed-scroll-4",
 	"cursed-scroll-5": "SHADOWDARK.source.cursed-scroll-5",
 	"cursed-scroll-6": "SHADOWDARK.source.cursed-scroll-6",
-	"kickstarter-stretch-goals": "SHADOWDARK.source.kickstarter-stretch-goals",
 	"quickstart": "SHADOWDARK.source.quickstart",
 };
 


### PR DESCRIPTION
Addresses #905

Changes the "Bard and Ranger" source into "Kickstarter Stretch Goals (Bard, Ranger, and Kobold)"

Moves bard, ranger, kobold, and related talents/abilities to the new source.