### PR TITLE
Add ability to easily roll spell focus checks

### DIFF
--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -181,6 +181,7 @@ SHADOWDARK.chat.light_source.source.toggle.off: wurde gelöscht
 SHADOWDARK.chat.light_source.source.toggle.on: wurde entzündet
 SHADOWDARK.chat.light_source.went_out: "{name}s {lightSource} ging aus"
 SHADOWDARK.chat.potion_used: "{name} hat einen Trank benutzt"
+SHADOWDARK.chat.spell_focus_check: "Focus Check"
 SHADOWDARK.chat.spell_learn.failure: "{name} konnte nichts von der Schriftrolle lernen"
 SHADOWDARK.chat.spell_learn.success: "{name} hat den {spellName} Zauber erfolgreich gelernt"
 SHADOWDARK.chat.spell_learn.title: Lerne Zauber
@@ -786,6 +787,7 @@ SHADOWDARK.sheet.player.toggle_edit_hp: HP bearbeiten
 SHADOWDARK.sheet.player.toggle_edit_stats: Attribute bearbeiten
 SHADOWDARK.sheet.player.toggle_spell_lost: Zauber verloren
 SHADOWDARK.sheet.player.tooltip.cast_spell: Zauber wirken
+SHADOWDARK.sheet.player.tooltip.focus_on_spell: Focus on Spell
 SHADOWDARK.sheet.player.tooltip.learn_spell: Zauber erlernen
 SHADOWDARK.sheet.player.tooltip.use_class_ability: Klassenfähigkeit verwenden
 SHADOWDARK.sheet.player.tooltip.use_potion: Trank verwenden

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -181,6 +181,7 @@ SHADOWDARK.chat.light_source.source.toggle.off: was doused
 SHADOWDARK.chat.light_source.source.toggle.on: was lit
 SHADOWDARK.chat.light_source.went_out: "{name}'s {lightSource} went out"
 SHADOWDARK.chat.potion_used: "{name} used a Potion"
+SHADOWDARK.chat.spell_focus_check: "Focus Check"
 SHADOWDARK.chat.spell_learn.failure: "{name} failed to learn anything from the scroll"
 SHADOWDARK.chat.spell_learn.success: "{name} successfully learnt the {spellName} spell"
 SHADOWDARK.chat.spell_learn.title: Learning Spell
@@ -786,6 +787,7 @@ SHADOWDARK.sheet.player.toggle_edit_hp: Toggle Edit HP
 SHADOWDARK.sheet.player.toggle_edit_stats: Toggle Edit Stats
 SHADOWDARK.sheet.player.toggle_spell_lost: Toggle Spell Lost
 SHADOWDARK.sheet.player.tooltip.cast_spell: Cast Spell
+SHADOWDARK.sheet.player.tooltip.focus_on_spell: Focus on Spell
 SHADOWDARK.sheet.player.tooltip.learn_spell: Learn Spell
 SHADOWDARK.sheet.player.tooltip.use_class_ability: Use Class Ability
 SHADOWDARK.sheet.player.tooltip.use_potion: Use Potion

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -181,6 +181,7 @@ SHADOWDARK.chat.light_source.source.toggle.off: se apagó
 SHADOWDARK.chat.light_source.source.toggle.on: se encendió
 SHADOWDARK.chat.light_source.went_out: "{name} de {lightSource} se apagó"
 SHADOWDARK.chat.potion_used: "{name} ha usado una poción"
+SHADOWDARK.chat.spell_focus_check: "Focus Check"
 SHADOWDARK.chat.spell_learn.failure: "{name} no ha podido aprender nada del pergamino"
 SHADOWDARK.chat.spell_learn.success: "{name} aprendió correctamente el hechizo {spellName}"
 SHADOWDARK.chat.spell_learn.title: Aprender hechizo
@@ -786,6 +787,7 @@ SHADOWDARK.sheet.player.toggle_edit_hp: Toggle Edit HP
 SHADOWDARK.sheet.player.toggle_edit_stats: Toggle Edit Stats
 SHADOWDARK.sheet.player.toggle_spell_lost: Alternar hechizos perdidos
 SHADOWDARK.sheet.player.tooltip.cast_spell: Lanzar hechizo
+SHADOWDARK.sheet.player.tooltip.focus_on_spell: Focus on Spell
 SHADOWDARK.sheet.player.tooltip.learn_spell: Aprender hechizo
 SHADOWDARK.sheet.player.tooltip.use_class_ability: Use Class Ability
 SHADOWDARK.sheet.player.tooltip.use_potion: Usar poción

--- a/i18n/fi.yaml
+++ b/i18n/fi.yaml
@@ -181,6 +181,7 @@ SHADOWDARK.chat.light_source.source.toggle.off: valonlähde sammui
 SHADOWDARK.chat.light_source.source.toggle.on: valonlähde syttyi
 SHADOWDARK.chat.light_source.went_out: "Hahmon {name} {lightSource} valonlähde sammui"
 SHADOWDARK.chat.potion_used: "{name} käytti rohdon"
+SHADOWDARK.chat.spell_focus_check: "Focus Check"
 SHADOWDARK.chat.spell_learn.failure: "{name} ei oppinut taikakääröstä mitään"
 SHADOWDARK.chat.spell_learn.success: "{name} onnistuneesti oppi {spellName} loitsun"
 SHADOWDARK.chat.spell_learn.title: Opettelee loitsua
@@ -786,6 +787,7 @@ SHADOWDARK.sheet.player.toggle_edit_hp: Osumapisteiden muokkaus päälle/pois
 SHADOWDARK.sheet.player.toggle_edit_stats: Kyvykkyysarvojen muokkaus päälle/pois
 SHADOWDARK.sheet.player.toggle_spell_lost: Merkkaa menetetty loitsu
 SHADOWDARK.sheet.player.tooltip.cast_spell: Loihdi loitsu
+SHADOWDARK.sheet.player.tooltip.focus_on_spell: Focus on Spell
 SHADOWDARK.sheet.player.tooltip.learn_spell: Opettele loitsu
 SHADOWDARK.sheet.player.tooltip.use_class_ability: Käytä hahmoluokan kykyä
 SHADOWDARK.sheet.player.tooltip.use_potion: Käytä rohto

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -181,6 +181,7 @@ SHADOWDARK.chat.light_source.source.toggle.off: a été masqué
 SHADOWDARK.chat.light_source.source.toggle.on: a été allumé
 SHADOWDARK.chat.light_source.went_out: "Les {name} de{lightSource} s'éteint"
 SHADOWDARK.chat.potion_used: "{name} a utilisé une potion"
+SHADOWDARK.chat.spell_focus_check: "Focus Check"
 SHADOWDARK.chat.spell_learn.failure: "{name} n'a pas réussi à apprendre quoi que ce soit du parchemin"
 SHADOWDARK.chat.spell_learn.success: "{name} a bien appris le sort {spellName}"
 SHADOWDARK.chat.spell_learn.title: Apprentissage de Sort
@@ -786,6 +787,7 @@ SHADOWDARK.sheet.player.toggle_edit_hp: Toggle Edit HP
 SHADOWDARK.sheet.player.toggle_edit_stats: Toggle Edit Stats
 SHADOWDARK.sheet.player.toggle_spell_lost: Toggle Spell Lost
 SHADOWDARK.sheet.player.tooltip.cast_spell: Cast Spell
+SHADOWDARK.sheet.player.tooltip.focus_on_spell: Focus on Spell
 SHADOWDARK.sheet.player.tooltip.learn_spell: Learn Spell
 SHADOWDARK.sheet.player.tooltip.use_class_ability: Use Class Ability
 SHADOWDARK.sheet.player.tooltip.use_potion: Use Potion

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -181,6 +181,7 @@ SHADOWDARK.chat.light_source.source.toggle.off: 꺼졌습니다.
 SHADOWDARK.chat.light_source.source.toggle.on: 켜졌습니다
 SHADOWDARK.chat.light_source.went_out: "{name} 의 {lightSource} 가 꺼졌습니다"
 SHADOWDARK.chat.potion_used: "{name} 포션을 사용했습니다"
+SHADOWDARK.chat.spell_focus_check: "Focus Check"
 SHADOWDARK.chat.spell_learn.failure: "{name} 두루마리로 주문 배우기를 실패했습니다"
 SHADOWDARK.chat.spell_learn.success: "{name} 성공적으로 {spellName} 주문을 배웠습니다"
 SHADOWDARK.chat.spell_learn.title: 주문 배우기
@@ -786,6 +787,7 @@ SHADOWDARK.sheet.player.toggle_edit_hp: Toggle Edit HP
 SHADOWDARK.sheet.player.toggle_edit_stats: Toggle Edit Stats
 SHADOWDARK.sheet.player.toggle_spell_lost: 주문 불능 표시
 SHADOWDARK.sheet.player.tooltip.cast_spell: 주문 시전
+SHADOWDARK.sheet.player.tooltip.focus_on_spell: Focus on Spell
 SHADOWDARK.sheet.player.tooltip.learn_spell: 주문 배우기
 SHADOWDARK.sheet.player.tooltip.use_class_ability: 클래스 능력 사용
 SHADOWDARK.sheet.player.tooltip.use_potion: 포션 사용

--- a/i18n/pt_BR.yaml
+++ b/i18n/pt_BR.yaml
@@ -181,6 +181,7 @@ SHADOWDARK.chat.light_source.source.toggle.off: foi apagada
 SHADOWDARK.chat.light_source.source.toggle.on: foi acesa
 SHADOWDARK.chat.light_source.went_out: "{lightSource} de {name} apagou"
 SHADOWDARK.chat.potion_used: "{name} usou uma Poção"
+SHADOWDARK.chat.spell_focus_check: "Focus Check"
 SHADOWDARK.chat.spell_learn.failure: "{name} não conseguiu aprender o pergaminho"
 SHADOWDARK.chat.spell_learn.success: "{name} aprendeu com sucesso a magia {spellName}"
 SHADOWDARK.chat.spell_learn.title: Aprendendo Magia
@@ -786,6 +787,7 @@ SHADOWDARK.sheet.player.toggle_edit_hp: Alternar Edição de PV
 SHADOWDARK.sheet.player.toggle_edit_stats: Alternar Edição de Atributos
 SHADOWDARK.sheet.player.toggle_spell_lost: Alternar Magia Perdida
 SHADOWDARK.sheet.player.tooltip.cast_spell: Conjurar Magia
+SHADOWDARK.sheet.player.tooltip.focus_on_spell: Focus on Spell
 SHADOWDARK.sheet.player.tooltip.learn_spell: Aprender Magia
 SHADOWDARK.sheet.player.tooltip.use_class_ability: Usar Habilidade de Classe
 SHADOWDARK.sheet.player.tooltip.use_potion: Usar Poção

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -181,6 +181,7 @@ SHADOWDARK.chat.light_source.source.toggle.off: был погашен
 SHADOWDARK.chat.light_source.source.toggle.on: был зажжен
 SHADOWDARK.chat.light_source.went_out: "{name}'s {lightSource} погас"
 SHADOWDARK.chat.potion_used: "{name} использовал зелье"
+SHADOWDARK.chat.spell_focus_check: "Focus Check"
 SHADOWDARK.chat.spell_learn.failure: "{name} не удалось ничему научиться из свитка"
 SHADOWDARK.chat.spell_learn.success: "{name} успешно выучил заклинание {spellName}"
 SHADOWDARK.chat.spell_learn.title: Изучение заклинания
@@ -786,6 +787,7 @@ SHADOWDARK.sheet.player.toggle_edit_hp: Переключить редактир�
 SHADOWDARK.sheet.player.toggle_edit_stats: Переключить редактирование характеристик
 SHADOWDARK.sheet.player.toggle_spell_lost: Переключить потерю заклинания
 SHADOWDARK.sheet.player.tooltip.cast_spell: Сотворить заклинание
+SHADOWDARK.sheet.player.tooltip.focus_on_spell: Focus on Spell
 SHADOWDARK.sheet.player.tooltip.learn_spell: Выучить заклинание
 SHADOWDARK.sheet.player.tooltip.use_class_ability: Использовать классовую способность
 SHADOWDARK.sheet.player.tooltip.use_potion: Использовать зелье

--- a/i18n/sv.yaml
+++ b/i18n/sv.yaml
@@ -181,6 +181,7 @@ SHADOWDARK.chat.light_source.source.toggle.off: släcktes
 SHADOWDARK.chat.light_source.source.toggle.on: tändes
 SHADOWDARK.chat.light_source.went_out: "{name}s {lightSource} slocknade"
 SHADOWDARK.chat.potion_used: "{name} använde en brygd"
+SHADOWDARK.chat.spell_focus_check: "Focus Check"
 SHADOWDARK.chat.spell_learn.failure: "{name} misslyckades lära sig något från scrollen"
 SHADOWDARK.chat.spell_learn.success: "{name} lärde sig besvärjelsen {spellName}"
 SHADOWDARK.chat.spell_learn.title: Lär sig besvärjelse
@@ -786,6 +787,7 @@ SHADOWDARK.sheet.player.toggle_edit_hp: Toggle Edit HP
 SHADOWDARK.sheet.player.toggle_edit_stats: Toggle Edit Stats
 SHADOWDARK.sheet.player.toggle_spell_lost: Ange Förlorad
 SHADOWDARK.sheet.player.tooltip.cast_spell: Kasta besvärjelse
+SHADOWDARK.sheet.player.tooltip.focus_on_spell: Focus on Spell
 SHADOWDARK.sheet.player.tooltip.learn_spell: Lär dig besvärjelse
 SHADOWDARK.sheet.player.tooltip.use_class_ability: Använd klassförmåga
 SHADOWDARK.sheet.player.tooltip.use_potion: Använd brygd

--- a/scss/base/_components.scss
+++ b/scss/base/_components.scss
@@ -96,6 +96,10 @@
 		}
 	}
 
+	.tab-spells .SD-list > li .actions {
+		flex: 0 0 90px !important;
+	}
+
 	.SD-list {
 		margin:0px;
 		padding: 0px;

--- a/system/src/dice/RollSD.mjs
+++ b/system/src/dice/RollSD.mjs
@@ -122,6 +122,8 @@ export default class RollSD extends Roll {
 			data.item?.isSpell()
 			&& result
 			&& !result?.rolls?.main?.success
+			// Focus rolls shouldn't lose the spell, unless it is a critical
+			&& (!options.isFocusRoll || result?.rolls?.main?.critical === "failure")
 		) data.item.update({"system.lost": true});
 
 		// Reduce ammo if required

--- a/system/src/dice/RollSD.mjs
+++ b/system/src/dice/RollSD.mjs
@@ -107,7 +107,7 @@ export default class RollSD extends Roll {
 					options.flavor = game.i18n.format(
 						"SHADOWDARK.chat.spell_roll.title",
 						{
-							name: data.item.name,
+							name: options.isFocusRoll ? game.i18n.localize("SHADOWDARK.chat.spell_focus_check") : data.item.name,
 							tier: options.tier,
 							spellDC: options.target,
 						}
@@ -594,6 +594,7 @@ export default class RollSD extends Roll {
 					? options.title : game.i18n.localize("SHADOWDARK.chatcard.default"),
 			isSpell: false,
 			isWeapon: false,
+			isFocusRoll: options.isFocusRoll,
 			isVersatile: false,
 			isRoll: true,
 			isNPC: data.actor?.type === "NPC",

--- a/system/src/sheets/NpcSheetSD.mjs
+++ b/system/src/sheets/NpcSheetSD.mjs
@@ -59,6 +59,10 @@ export default class NpcSheetSD extends ActorSheetSD {
 			event => this._onUseAbility(event)
 		);
 
+		html.find("[data-action='focus-npc-spell']").click(
+			event => this._onCastSpell(event, { isFocusRoll: true })
+		);
+
 		html.find("[data-action='cast-npc-spell']").click(
 			event => this._onCastSpell(event)
 		);
@@ -163,16 +167,16 @@ export default class NpcSheetSD extends ActorSheetSD {
 		this.actor.useAbility(itemId);
 	}
 
-	async _onCastSpell(event) {
+	async _onCastSpell(event, options) {
 		event.preventDefault();
 
 		const itemId = $(event.currentTarget).data("item-id");
 
 		if (event.shiftKey) {
-			this.actor.castNPCSpell(itemId, {fastForward: true});
+			this.actor.castNPCSpell(itemId, {...options, fastForward: true});
 		}
 		else {
-			this.actor.castNPCSpell(itemId);
+			this.actor.castNPCSpell(itemId, options);
 		}
 	}
 

--- a/system/src/sheets/PlayerSheetSD.mjs
+++ b/system/src/sheets/PlayerSheetSD.mjs
@@ -51,6 +51,12 @@ export default class PlayerSheetSD extends ActorSheetSD {
 			event => this._onCastSpell(event)
 		);
 
+		html.find("[data-action='focus-spell']").click(
+			event => {
+				this._onCastSpell(event, { isFocusRoll: true });
+			}
+		);
+
 		html.find("[data-action='create-boon']").click(
 			event => this._onCreateBoon(event)
 		);
@@ -560,15 +566,15 @@ export default class PlayerSheetSD extends ActorSheetSD {
 		this.render();
 	}
 
-	async _onCastSpell(event) {
+	async _onCastSpell(event, options) {
 		event.preventDefault();
 
 		const itemId = $(event.currentTarget).data("item-id");
 		if (event.shiftKey) {
-			this.actor.castSpell(itemId, {fastForward: true});
+			this.actor.castSpell(itemId, {...options, fastForward: true});
 		}
 		else {
-			this.actor.castSpell(itemId);
+			this.actor.castSpell(itemId, options);
 		}
 	}
 

--- a/system/templates/actors/npc/spells.hbs
+++ b/system/templates/actors/npc/spells.hbs
@@ -69,6 +69,15 @@
 			</div>
 			<div class="actions">
 				{{#unless spell.system.lost}}
+					{{#if (eq spell.system.duration.type 'focus')}}
+						<a
+							data-action="focus-npc-spell"
+							data-item-id="{{spell._id}}"
+							data-tooltip="{{localize 'SHADOWDARK.sheet.player.tooltip.focus_on_spell'}}"
+						>
+							<i class="fa-solid fa-brain"></i>
+						</a>
+					{{/if}}
 					<a
 						data-action="cast-npc-spell"
 						data-item-id="{{spell._id}}"

--- a/system/templates/actors/player/spells.hbs
+++ b/system/templates/actors/player/spells.hbs
@@ -29,6 +29,15 @@
 							</div>
 							<div class="actions">
 								{{#unless spell.system.lost}}
+										{{#if (eq spell.system.duration.type 'focus')}}
+											<a
+												data-action="focus-spell"
+												data-item-id="{{spell._id}}"
+												data-tooltip="{{localize 'SHADOWDARK.sheet.player.tooltip.focus_on_spell'}}"
+											>
+												<i class="fa-solid fa-brain"></i>
+											</a>
+										{{/if}}
 										<a
 											data-action="cast-spell"
 											data-item-id="{{spell._id}}"
@@ -87,6 +96,15 @@
 							{{fromConfig "SPELL_RANGES" item.system.range}}
 						</div>
 						<div class="actions">
+							{{#if (eq item.system.duration.type 'focus')}}
+								<a
+									data-action="focus-spell"
+									data-item-id="{{item._id}}"
+									data-tooltip="{{localize 'SHADOWDARK.sheet.player.tooltip.focus_on_spell'}}"
+								>
+									<i class="fa-solid fa-brain"></i>
+								</a>
+							{{/if}}
 							{{#unless item.system.lost}}
 								<a
 									data-action="cast-spell"
@@ -138,6 +156,15 @@
 							{{fromConfig "SPELL_RANGES" item.system.range}}
 						</div>
 						<div class="actions">
+								{{#if (eq item.system.duration.type 'focus')}}
+									<a
+										data-action="focus-spell"
+										data-item-id="{{item._id}}"
+										data-tooltip="{{localize 'SHADOWDARK.sheet.player.tooltip.focus_on_spell'}}"
+									>
+										<i class="fa-solid fa-brain"></i>
+									</a>
+								{{/if}}
 								<a
 									data-action="cast-spell"
 									data-item-id="{{item._id}}"

--- a/system/templates/chat/item-card.hbs
+++ b/system/templates/chat/item-card.hbs
@@ -19,9 +19,11 @@
 		{{/if}}
 	</header>
 
-	<div class="card-content">
-		{{{data.item.system.description}}}
-	</div>
+	{{#unless isFocusRoll}}
+		<div class="card-content">
+			{{{data.item.system.description}}}
+		</div>
+	{{/unless}}
 
 	<div class="d20-roll card-attack-rolls">
 		<div
@@ -46,9 +48,11 @@
 
 	{{#if isSpell}}
 		{{#ifEq data.rolls.main.critical "success"}}
-			<div class="card-spell-critical">
-				<p>{{localize "SHADOWDARK.chat.item_roll.double_numerical"}}</p>
-			</div>
+			{{#unless isFocusRoll}}
+				<div class="card-spell-critical">
+					<p>{{localize "SHADOWDARK.chat.item_roll.double_numerical"}}</p>
+				</div>
+			{{/unless}}
 		{{/ifEq}}
 		{{#ifEq data.rolls.main.critical "failure"}}
 			<div class="card-spell-critical">


### PR DESCRIPTION
There was a [message in the discord](https://discordapp.com/channels/558029475837902851/1119133303514071090/1356773996011589722) asking about adding spell focus rolls so that the spell checks could be rolled without forcing the loss of a spell on a failed focus check. This PR adds a button to both PC and NPC sheets to do that. 

Considerations:

- Critical failures still result in the loss of a spell (as per rules-as-written)
- This code works primarily by hooking into pre-existing functions to cast spells, with minor changes in logic if it is a focus roll. I did this to reduce code duplication, but let me know if the preference would be for brand new functions. 

## Screenshots
![image](https://github.com/user-attachments/assets/3f6b0265-fcf8-4fa8-bdb2-5c7496fa38e2)
*Note that the button only appears on spells with a duration of "Focus"*

![image](https://github.com/user-attachments/assets/e8e04eaa-5e4b-4b51-83f2-7177c88d8670)
*A successful spell focus check*

![image](https://github.com/user-attachments/assets/18aef832-0cb9-4e51-ab5d-6ce12c11a31a)
*A failed spell focus check*

![image](https://github.com/user-attachments/assets/47c669b7-3eef-4ea5-ba7d-8c975266335b)
*A PC with both scrolls & wands*