### PR TITLE
Targeting for weapon attacks

### DIFF
--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -648,6 +648,8 @@ SHADOWDARK.settings.debugEnabled.hint: Aktivieren oder deaktivieren Sie zusätzl
 SHADOWDARK.settings.debugEnabled.name: Debug aktivieren/deaktivieren
 SHADOWDARK.settings.effect_panel.show_passive.hint: Wenn aktiviert, wird das Effekt-Panel auch aktive Effekte von Talenten und Gegenständen anzeigen
 SHADOWDARK.settings.effect_panel.show_passive.name: Alle aktiven Effekte anzeigen
+SHADOWDARK.settings.enable_targeting.hint: Automatically calculate whether an attack hits based on the AC of targeted tokens
+SHADOWDARK.settings.enable_targeting.name: Enable Attack Targeting
 SHADOWDARK.settings.migrateSystemCompendiums.hint: Führe Datenmigration auf den eingebauten Shadowdark RPG-Systemkompendien aus (modifiziere dies nicht, wenn du nicht weißt, was du tust)
 SHADOWDARK.settings.migrateSystemCompendiums.name: Systemkompendien migrieren
 SHADOWDARK.settings.module_art.hint: Konfigurieren Sie, welche Modul bereitgestellte Darstellung verwendet werden soll

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -170,6 +170,7 @@ SHADOWDARK.chat.hp_roll.apply_to_max: Zu Max HP hinzufügen
 SHADOWDARK.chat.item_roll.double_numerical: Verdoppele einen beliebigen numerischen Wert!
 SHADOWDARK.chat.item_roll.mishap: Würfle auf die entsprechenden Ungeschickstabelle!
 SHADOWDARK.chat.item_roll.title: Angirffswurf mit {name}
+SHADOWDARK.chat.item_roll.title_vs: Attack roll with {name} vs {target}
 SHADOWDARK.chat.item_roll.wand_mishap: Der Zauberstab bricht und stoppt dauerhaft zu funktionieren
 SHADOWDARK.chat.light_source.expired: "{name}s {lightSource} ist abgelaufen"
 SHADOWDARK.chat.light_source.remaining: Minuten verbleibend

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -648,6 +648,10 @@ SHADOWDARK.settings.debugEnabled.hint: Enable or Disable additional debug loggin
 SHADOWDARK.settings.debugEnabled.name: Enable/Disable Debug
 SHADOWDARK.settings.effect_panel.show_passive.hint: If checked, the Effect Panel will also show active effects from talents and items
 SHADOWDARK.settings.effect_panel.show_passive.name: Show All Active Effects
+SHADOWDARK.settings.enable_targeting.hint: Automatically calculate whether an attack hits based on the AC of targeted tokens
+SHADOWDARK.settings.enable_targeting.name: Enable Attack Targeting
+SHADOWDARK.settings.enable_targeting.hint: Automatically calculate whether an attack hits based on the AC of targeted tokens
+SHADOWDARK.settings.enable_targeting.name: Enable Attack Targeting
 SHADOWDARK.settings.migrateSystemCompendiums.hint: Perform data migration on the built in Shadowdark RPG system compendiums (don't modify this unless you know what you are doing)
 SHADOWDARK.settings.migrateSystemCompendiums.name: Migrate System Compendiums
 SHADOWDARK.settings.module_art.hint: Configure which module-provided art should be used

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -650,8 +650,6 @@ SHADOWDARK.settings.effect_panel.show_passive.hint: If checked, the Effect Panel
 SHADOWDARK.settings.effect_panel.show_passive.name: Show All Active Effects
 SHADOWDARK.settings.enable_targeting.hint: Automatically calculate whether an attack hits based on the AC of targeted tokens
 SHADOWDARK.settings.enable_targeting.name: Enable Attack Targeting
-SHADOWDARK.settings.enable_targeting.hint: Automatically calculate whether an attack hits based on the AC of targeted tokens
-SHADOWDARK.settings.enable_targeting.name: Enable Attack Targeting
 SHADOWDARK.settings.migrateSystemCompendiums.hint: Perform data migration on the built in Shadowdark RPG system compendiums (don't modify this unless you know what you are doing)
 SHADOWDARK.settings.migrateSystemCompendiums.name: Migrate System Compendiums
 SHADOWDARK.settings.module_art.hint: Configure which module-provided art should be used

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -170,6 +170,7 @@ SHADOWDARK.chat.hp_roll.apply_to_max: Add to Max HP
 SHADOWDARK.chat.item_roll.double_numerical: Double any one numerical value!
 SHADOWDARK.chat.item_roll.mishap: Roll on the appropriate Mishap table!
 SHADOWDARK.chat.item_roll.title: Attack roll with {name}
+SHADOWDARK.chat.item_roll.title_vs: Attack roll with {name} vs {target}
 SHADOWDARK.chat.item_roll.wand_mishap: The wand breaks and permanently ceases to work
 SHADOWDARK.chat.light_source.expired: "{name}'s {lightSource} expired"
 SHADOWDARK.chat.light_source.remaining: minutes remaining

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -648,6 +648,8 @@ SHADOWDARK.settings.debugEnabled.hint: Enable or Disable additional debug loggin
 SHADOWDARK.settings.debugEnabled.name: Enable/Disable Debug
 SHADOWDARK.settings.effect_panel.show_passive.hint: If checked, the Effect Panel will also show active effects from talents and items
 SHADOWDARK.settings.effect_panel.show_passive.name: Show All Active Effects
+SHADOWDARK.settings.enable_targeting.hint: Automatically calculate whether an attack hits based on the AC of targeted tokens
+SHADOWDARK.settings.enable_targeting.name: Enable Attack Targeting
 SHADOWDARK.settings.migrateSystemCompendiums.hint: Perform data migration on the built in Shadowdark RPG system compendiums (don't modify this unless you know what you are doing)
 SHADOWDARK.settings.migrateSystemCompendiums.name: Migrate System Compendiums
 SHADOWDARK.settings.module_art.hint: Configurar qué arte proporcionado por el módulo debe ser utilizado

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -170,6 +170,7 @@ SHADOWDARK.chat.hp_roll.apply_to_max: Añadir a PV máximos
 SHADOWDARK.chat.item_roll.double_numerical: '¡Duplica cualquier valor numérico!'
 SHADOWDARK.chat.item_roll.mishap: '¡Tira en la tabla de pifias apropiada!'
 SHADOWDARK.chat.item_roll.title: Tirada de ataque con {name}
+SHADOWDARK.chat.item_roll.title_vs: Attack roll with {name} vs {target}
 SHADOWDARK.chat.item_roll.wand_mishap: La varita se rompe y deja de funcionar permanentemente
 SHADOWDARK.chat.light_source.expired: "{name} de {lightSource} se apagó"
 SHADOWDARK.chat.light_source.remaining: minutos restantes

--- a/i18n/fi.yaml
+++ b/i18n/fi.yaml
@@ -170,6 +170,7 @@ SHADOWDARK.chat.hp_roll.apply_to_max: Lisää osumapisteidesi maksimimäärään
 SHADOWDARK.chat.item_roll.double_numerical: Tuplaa yksi numeerinen arvo!
 SHADOWDARK.chat.item_roll.mishap: Heitä noppaa sopivaa loihtimisen tapahturmataulua vasten!
 SHADOWDARK.chat.item_roll.title: Hyökkäysheitto käyttäen {name}
+SHADOWDARK.chat.item_roll.title_vs: Attack roll with {name} vs {target}
 SHADOWDARK.chat.item_roll.wand_mishap: Taikasauva meni hajalle ja pysyvästi lakkasi toimimasta
 SHADOWDARK.chat.light_source.expired: "Hahmon {name} {lightSource} valonlähde paloi loppuun tai vanhentui"
 SHADOWDARK.chat.light_source.remaining: minuuttia jäljellä

--- a/i18n/fi.yaml
+++ b/i18n/fi.yaml
@@ -648,6 +648,8 @@ SHADOWDARK.settings.debugEnabled.hint: Ota käyttöön tai poista käytöstä yl
 SHADOWDARK.settings.debugEnabled.name: Debuggaus päälle/pois
 SHADOWDARK.settings.effect_panel.show_passive.hint: Jos valittu, efektipaneeli näyttää myös aktiivisia efektejä lahjakkuuksista ja esineistä
 SHADOWDARK.settings.effect_panel.show_passive.name: Näytä kaikki aktiiviset efektit
+SHADOWDARK.settings.enable_targeting.hint: Automatically calculate whether an attack hits based on the AC of targeted tokens
+SHADOWDARK.settings.enable_targeting.name: Enable Attack Targeting
 SHADOWDARK.settings.migrateSystemCompendiums.hint: Datamigraatio sisäänrakennettuihin Shadowdark RPG compendiumeihin (älä koske tähän jos et tiedä mitä teet)
 SHADOWDARK.settings.migrateSystemCompendiums.name: Datamigraatio compendiumeille
 SHADOWDARK.settings.module_art.hint: Määritä minkä moduulin tuottamaa taidetta käytetään

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -170,6 +170,7 @@ SHADOWDARK.chat.hp_roll.apply_to_max: Ajouter aux PV Max
 SHADOWDARK.chat.item_roll.double_numerical: Double n'importe quelle valeur numérique !
 SHADOWDARK.chat.item_roll.mishap: Jetez sur la table des mésaventures appropriée !
 SHADOWDARK.chat.item_roll.title: Jet d'Attaque avec {name}
+SHADOWDARK.chat.item_roll.title_vs: Attack roll with {name} vs {target}
 SHADOWDARK.chat.item_roll.wand_mishap: La baguette se casse et cesse définitivement de fonctionner
 SHADOWDARK.chat.light_source.expired: "Le/la {lightSource} de {name} s'est éteint(e)"
 SHADOWDARK.chat.light_source.remaining: minutes restantes

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -648,6 +648,8 @@ SHADOWDARK.settings.debugEnabled.hint: Enable or Disable additional debug loggin
 SHADOWDARK.settings.debugEnabled.name: Enable/Disable Debug
 SHADOWDARK.settings.effect_panel.show_passive.hint: If checked, the Effect Panel will also show active effects from talents and items
 SHADOWDARK.settings.effect_panel.show_passive.name: Show All Active Effects
+SHADOWDARK.settings.enable_targeting.hint: Automatically calculate whether an attack hits based on the AC of targeted tokens
+SHADOWDARK.settings.enable_targeting.name: Enable Attack Targeting
 SHADOWDARK.settings.migrateSystemCompendiums.hint: Perform data migration on the built in Shadowdark RPG system compendiums (don't modify this unless you know what you are doing)
 SHADOWDARK.settings.migrateSystemCompendiums.name: Migrate System Compendiums
 SHADOWDARK.settings.module_art.hint: Configure which module-provided art should be used

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -648,6 +648,8 @@ SHADOWDARK.settings.debugEnabled.hint: Enable or Disable additional debug loggin
 SHADOWDARK.settings.debugEnabled.name: Enable/Disable Debug
 SHADOWDARK.settings.effect_panel.show_passive.hint: If checked, the Effect Panel will also show active effects from talents and items
 SHADOWDARK.settings.effect_panel.show_passive.name: Show All Active Effects
+SHADOWDARK.settings.enable_targeting.hint: Automatically calculate whether an attack hits based on the AC of targeted tokens
+SHADOWDARK.settings.enable_targeting.name: Enable Attack Targeting
 SHADOWDARK.settings.migrateSystemCompendiums.hint: Perform data migration on the built in Shadowdark RPG system compendiums (don't modify this unless you know what you are doing)
 SHADOWDARK.settings.migrateSystemCompendiums.name: Migrate System Compendiums
 SHADOWDARK.settings.module_art.hint: 어떤 모듈에서 제공하는 아트워크를 사용할지 설정합니다

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -170,6 +170,7 @@ SHADOWDARK.chat.hp_roll.apply_to_max: 최대 HP에 추가
 SHADOWDARK.chat.item_roll.double_numerical: 숫자로 된 값 하나에 2를 곱하세요!
 SHADOWDARK.chat.item_roll.mishap: 적절한 사고 표를 보고 주사위를 굴리세요!
 SHADOWDARK.chat.item_roll.title: '{name} 로 명중 굴림'
+SHADOWDARK.chat.item_roll.title_vs: Attack roll with {name} vs {target}
 SHADOWDARK.chat.item_roll.wand_mishap: 마법봉이 부서졌으며 영구적으로 효과를 잃었습니다
 SHADOWDARK.chat.light_source.expired: "{name} 의 {lightSource} 가 다 됐습니다"
 SHADOWDARK.chat.light_source.remaining: 분 남았습니다

--- a/i18n/pt_BR.yaml
+++ b/i18n/pt_BR.yaml
@@ -648,6 +648,8 @@ SHADOWDARK.settings.debugEnabled.hint: Ativar ou desativar o registro de depura�
 SHADOWDARK.settings.debugEnabled.name: Ativar/Desativar Depuração
 SHADOWDARK.settings.effect_panel.show_passive.hint: Se marcado, o Painel de Efeitos também mostrará efeitos ativos de talentos e itens
 SHADOWDARK.settings.effect_panel.show_passive.name: Mostrar Todos os Efeitos Ativos
+SHADOWDARK.settings.enable_targeting.hint: Automatically calculate whether an attack hits based on the AC of targeted tokens
+SHADOWDARK.settings.enable_targeting.name: Enable Attack Targeting
 SHADOWDARK.settings.migrateSystemCompendiums.hint: Execute a migração de dados no compêndio do sistema de RPG Shadowdark (não modifique isso a menos que saiba o que está fazendo)
 SHADOWDARK.settings.migrateSystemCompendiums.name: Migrar Compêndios do Sistema
 SHADOWDARK.settings.module_art.hint: Configurar qual arte fornecida por módulo deve ser usada

--- a/i18n/pt_BR.yaml
+++ b/i18n/pt_BR.yaml
@@ -170,6 +170,7 @@ SHADOWDARK.chat.hp_roll.apply_to_max: Adicionar aos PV máximos
 SHADOWDARK.chat.item_roll.double_numerical: Dobre qualquer valor numérico!
 SHADOWDARK.chat.item_roll.mishap: Role na tabela de Contratempos apropriada!
 SHADOWDARK.chat.item_roll.title: Rolagem de ataque com {name}
+SHADOWDARK.chat.item_roll.title_vs: Attack roll with {name} vs {target}
 SHADOWDARK.chat.item_roll.wand_mishap: A varinha quebra e para de funcionar permanentemente
 SHADOWDARK.chat.light_source.expired: "{lightSource} de {name} expirou"
 SHADOWDARK.chat.light_source.remaining: minutos restantes

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -648,6 +648,8 @@ SHADOWDARK.settings.debugEnabled.hint: Включить или отключит�
 SHADOWDARK.settings.debugEnabled.name: Включить/Отключить отладку
 SHADOWDARK.settings.effect_panel.show_passive.hint: Если отмечено, Панель эффектов также будет показывать активные эффекты от талантов и предметов
 SHADOWDARK.settings.effect_panel.show_passive.name: Показывать все активные эффекты
+SHADOWDARK.settings.enable_targeting.hint: Automatically calculate whether an attack hits based on the AC of targeted tokens
+SHADOWDARK.settings.enable_targeting.name: Enable Attack Targeting
 SHADOWDARK.settings.migrateSystemCompendiums.hint: Выполнить миграцию данных для встроенных сборников системы Shadowdark RPG (не изменяйте, если не знаете, что делаете)
 SHADOWDARK.settings.migrateSystemCompendiums.name: Мигрировать системные сборники
 SHADOWDARK.settings.module_art.hint: Настройте, какие изображения, предоставленные модулями, следует использовать

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -170,6 +170,7 @@ SHADOWDARK.chat.hp_roll.apply_to_max: Добавить к максимуму О�
 SHADOWDARK.chat.item_roll.double_numerical: Удвойте любое одно числовое значение!
 SHADOWDARK.chat.item_roll.mishap: Бросьте по соответствующей таблице неудач!
 SHADOWDARK.chat.item_roll.title: Бросок атаки с {name}
+SHADOWDARK.chat.item_roll.title_vs: Attack roll with {name} vs {target}
 SHADOWDARK.chat.item_roll.wand_mishap: Жезл ломается и навсегда перестает работать
 SHADOWDARK.chat.light_source.expired: "{name}'s {lightSource} истёк"
 SHADOWDARK.chat.light_source.remaining: минут осталось

--- a/i18n/sv.yaml
+++ b/i18n/sv.yaml
@@ -648,6 +648,8 @@ SHADOWDARK.settings.debugEnabled.hint: Aktivera eller inaktivera ytterligare fel
 SHADOWDARK.settings.debugEnabled.name: Aktivera/inaktivera felsökning
 SHADOWDARK.settings.effect_panel.show_passive.hint: If checked, the Effect Panel will also show active effects from talents and items
 SHADOWDARK.settings.effect_panel.show_passive.name: Show All Active Effects
+SHADOWDARK.settings.enable_targeting.hint: Automatically calculate whether an attack hits based on the AC of targeted tokens
+SHADOWDARK.settings.enable_targeting.name: Enable Attack Targeting
 SHADOWDARK.settings.migrateSystemCompendiums.hint: Utför datamigrering på inbyggda Shadowdark RPG system kompendier (ändra inte detta om du inte vet vad du gör)
 SHADOWDARK.settings.migrateSystemCompendiums.name: Migrera systemkompendier
 SHADOWDARK.settings.module_art.hint: Konfigurera vilken moduls konst ska användas

--- a/i18n/sv.yaml
+++ b/i18n/sv.yaml
@@ -170,6 +170,7 @@ SHADOWDARK.chat.hp_roll.apply_to_max: Lägg till på max KP
 SHADOWDARK.chat.item_roll.double_numerical: Dubbla valfritt numeriskt värde!
 SHADOWDARK.chat.item_roll.mishap: Rulla på lämplig felkast-tabell!
 SHADOWDARK.chat.item_roll.title: Attackerar med {name}
+SHADOWDARK.chat.item_roll.title_vs: Attack roll with {name} vs {target}
 SHADOWDARK.chat.item_roll.wand_mishap: Trollstaven bryts och upphör att fungera permanent
 SHADOWDARK.chat.light_source.expired: "{name}s {lightSource} slocknade"
 SHADOWDARK.chat.light_source.remaining: minuter kvar

--- a/system/src/chat/hooks.mjs
+++ b/system/src/chat/hooks.mjs
@@ -130,7 +130,6 @@ async function chatCardButtonAction(app, html, data) {
 	const weaponAttackButton = html.find("button[data-action=roll-attack]");
 	weaponAttackButton.on("click", ev => {
 		ev.preventDefault();
-		const itemId = $(ev.currentTarget).data("item-id");
 		const actorId = $(ev.currentTarget).data("actor-id");
 		const actor = game.actors.get(actorId);
 

--- a/system/src/chat/hooks.mjs
+++ b/system/src/chat/hooks.mjs
@@ -130,6 +130,7 @@ async function chatCardButtonAction(app, html, data) {
 	const weaponAttackButton = html.find("button[data-action=roll-attack]");
 	weaponAttackButton.on("click", ev => {
 		ev.preventDefault();
+		const itemId = $(ev.currentTarget).data("item-id");
 		const actorId = $(ev.currentTarget).data("actor-id");
 		const actor = game.actors.get(actorId);
 

--- a/system/src/dice/RollSD.mjs
+++ b/system/src/dice/RollSD.mjs
@@ -91,12 +91,23 @@ export default class RollSD extends Roll {
 				data.handedness = options.handedness;
 				data = await this._rollWeapon(data);
 				if (!options.flavor) {
-					options.flavor = game.i18n.format(
-						"SHADOWDARK.chat.item_roll.title",
-						{
-							name: data.item.name,
-						}
-					);
+					if (options.targetToken) {
+						options.flavor = game.i18n.format(
+							"SHADOWDARK.chat.item_roll.title_vs",
+							{
+								name: data.item.name,
+								target: options.targetToken.actor.name,
+							}
+						);
+					}
+					else {
+						options.flavor = game.i18n.format(
+							"SHADOWDARK.chat.item_roll.title",
+							{
+								name: data.item.name,
+							}
+						);
+					}
 				}
 			}
 

--- a/system/src/dice/RollSD.mjs
+++ b/system/src/dice/RollSD.mjs
@@ -63,12 +63,23 @@ export default class RollSD extends Roll {
 				data = await this._rollNpcAttack(data);
 			}
 			if (!options.flavor) {
-				options.flavor = game.i18n.format(
-					"SHADOWDARK.chat.item_roll.title",
-					{
-						name: data.item.name,
-					}
-				);
+				if (options.targetToken) {
+					options.flavor = game.i18n.format(
+						"SHADOWDARK.chat.item_roll.title_vs",
+						{
+							name: data.item.name,
+							target: options.targetToken.actor.name,
+						}
+					);
+				}
+				else {
+					options.flavor = game.i18n.format(
+						"SHADOWDARK.chat.item_roll.title",
+						{
+							name: data.item.name,
+						}
+					);
+				}
 			}
 			return this._renderRoll(data, adv, options);
 		}

--- a/system/src/documents/ActorSD.mjs
+++ b/system/src/documents/ActorSD.mjs
@@ -1213,9 +1213,21 @@ export default class ActorSD extends Actor {
 		return await CONFIG.DiceSD.RollDialog(parts, data, options);
 	}
 
-
 	async rollAttack(itemId, options={}) {
 		const item = this.items.get(itemId);
+
+		if (game.settings.get("shadowdark", "enableTargeting")) {
+			if (!options.targetToken && game.user.targets.size > 0) {
+				const promises = [];
+				for (const target of game.user.targets.values()) {
+					promises.push(this.rollAttack(itemId, { ...options, targetToken: target }));
+				}
+				return await Promise.all(promises);
+			}
+			else if (options.targetToken) {
+				options.target = options.targetToken.actor.system.attributes.ac.value;
+			}
+		}
 
 		const ammunition = item.availableAmmunition();
 

--- a/system/src/hooks.mjs
+++ b/system/src/hooks.mjs
@@ -5,6 +5,7 @@ import { EffectHooks } from "./hooks/effects.mjs";
 import { EffectPanelHooks } from "./hooks/effect-panel.mjs";
 import { LightSourceTrackerHooks } from "./hooks/light-source-tracker.mjs";
 import { NPCHooks } from "./hooks/npc.mjs";
+import { TargetingHooks } from "./hooks/targeting.mjs";
 import { SDAppsButtons } from "./hooks/sd-apps-buttons.mjs";
 import { hotbarHooks } from "./hooks/hotbar.mjs";
 
@@ -16,6 +17,7 @@ export const HooksSD = {
 			EffectHooks,
 			LightSourceTrackerHooks,
 			NPCHooks,
+			TargetingHooks,
 			hotbarHooks,
 		];
 

--- a/system/src/hooks/targeting.mjs
+++ b/system/src/hooks/targeting.mjs
@@ -1,0 +1,15 @@
+export const TargetingHooks = {
+	attach: () => {
+		Hooks.on("targetToken", async (user, token, targeted) => {
+			// return early if targeting is disabled
+			if (!game.settings.get("shadowdark", "enableTargeting")) return;
+			// return early if we are removing a target
+			if (!targeted) return;
+
+			// only GMs are allowed to have more than one target
+			if (game.user.targets.size > 1 && !user.isGM) {
+				game.user.updateTokenTargets([token.id]);
+			}
+		});
+	},
+};

--- a/system/src/settings.mjs
+++ b/system/src/settings.mjs
@@ -160,6 +160,18 @@ export default function registerSystemSettings() {
 		type: Boolean,
 	});
 
+	// ------------------
+	//  ATTACK TARGETING
+	// ------------------
+	game.settings.register("shadowdark", "enableTargeting", {
+		hint: "SHADOWDARK.settings.enable_targeting.hint",
+		name: "SHADOWDARK.settings.enable_targeting.name",
+		scope: "world",
+		config: true,
+		default: true,
+		type: Boolean,
+	});
+
 	// ----------------------
 	//  INITIATIVE SETTINGS
 	// ----------------------

--- a/system/src/sheets/ActorSheetSD.mjs
+++ b/system/src/sheets/ActorSheetSD.mjs
@@ -292,7 +292,6 @@ export default class ActorSheetSD extends ActorSheet {
 	}
 
 	async _onRollAttack(event) {
-		console.log("### _onRollAttack", event);
 		event.preventDefault();
 
 		const itemId = $(event.currentTarget).data("item-id");
@@ -303,6 +302,7 @@ export default class ActorSheetSD extends ActorSheet {
 			attackType,
 			handedness,
 		};
+
 
 		// skip roll prompt if shift clicked
 		if (event.shiftKey) {

--- a/system/src/sheets/ActorSheetSD.mjs
+++ b/system/src/sheets/ActorSheetSD.mjs
@@ -292,6 +292,7 @@ export default class ActorSheetSD extends ActorSheet {
 	}
 
 	async _onRollAttack(event) {
+		console.log("### _onRollAttack", event);
 		event.preventDefault();
 
 		const itemId = $(event.currentTarget).data("item-id");
@@ -309,6 +310,7 @@ export default class ActorSheetSD extends ActorSheet {
 		}
 
 		this.actor.rollAttack(itemId, options);
+
 	}
 
 	async _onToggleLost(event) {


### PR DESCRIPTION
This intends to fix #897. 

It doesn't apply damage automatically, however it will tell you whether you hit your target or not. 

Considerations:

- If multiple targets are selected, it will roll multiple attacks. This is so that the GM can do multiple attacks at once. Players are not able to select multiple targets.
- I've not yet worked out how to not roll the damage if the attack fails. This seems like it would ultimately be the ideal outcome, but I think this PR provides an incremental improvement without it either way. 

## Screenshots

![image](https://github.com/user-attachments/assets/b86d049e-28eb-4a56-8c25-ff8bc9e46427)

![image](https://github.com/user-attachments/assets/736592bb-8907-4a7d-99db-4fe22c51abdd)
*Note that in the targeted example, the target is named, and the success/failure VS their AC 
is given, but the actual AC is not*

![image](https://github.com/user-attachments/assets/153e532b-bb86-4bb6-9ba3-cedc72d94c79)
*The new "Enable Attack Targeting" setting*