### PR TITLE
Fix "Apply Damage" and "Apply Healing" buttons not appearing 

### DIFF
--- a/system/src/chat/hooks.mjs
+++ b/system/src/chat/hooks.mjs
@@ -247,7 +247,9 @@ function applyChatCardDamage(li, multiplier) {
 		roll = message.rolls[0];
 	}
 	else if (_chatMessageIsDamageCard(message)) {
-		roll = message?.flags.rolls.primaryDamage.roll;
+		const rolls = message?.flags.rolls;
+		const damage = rolls.primaryDamage || rolls.damage;
+		roll = damage.roll;
 	}
 	else {
 		return;
@@ -302,7 +304,7 @@ function _chatMessageIsBasicRoll(message) {
  */
 function _chatMessageIsDamageCard(message) {
 	return message?.flags.isRoll
-		&& (message?.flags.rolls?.primaryDamage);
+		&& (message?.flags.rolls?.primaryDamage || message?.flags.rolls?.damage);
 }
 
 /**


### PR DESCRIPTION
Fixes #1039 

When the change from "versatile" damage to "1handed" vs "2handed" damage happened (df2c3bef28558530ec6200cbed5a76faea429c13), the check for whether to display the "apply damage" button wasn't updated, so it only worked for monsters (who didn't have the change away from `primaryDamage`). 

This PR just updates the check so that either type of damage satisfies (either `damage` or `primaryDamage`)

![image](https://github.com/user-attachments/assets/89a0d80c-628e-4ea5-949b-c4a91201bcb1)
