### PR TITLE
Adds handedness to roll dialog and make versatile weapon rolls more robust

### DIFF
--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -252,8 +252,6 @@ SHADOWDARK.class.wizard: Zauberer
 SHADOWDARK.coins.cp: KM
 SHADOWDARK.coins.gp: GM
 SHADOWDARK.coins.sp: SM
-SHADOWDARK.damage.one_handed: "Einhändiger Schaden:"
-SHADOWDARK.damage.two_handed: "Zweihändiger Schaden:"
 SHADOWDARK.dialog.ability_check.cha: Charismawurf
 SHADOWDARK.dialog.ability_check.con: Konstitutionswurf
 SHADOWDARK.dialog.ability_check.dex: Geschicklichkeitswurf
@@ -637,6 +635,8 @@ SHADOWDARK.roll.critical.failure: Kritische Fehlschlag! ({value})
 SHADOWDARK.roll.critical.success: Kritischer Erfolg! ({value})
 SHADOWDARK.roll.D20: W20-Wurf
 SHADOWDARK.roll.damage: "Schadenswurf:"
+SHADOWDARK.roll.damage1h: "1H Schaden:"
+SHADOWDARK.roll.damage2h: "2H Schaden:"
 SHADOWDARK.roll.disadvantage_title: "{title} mit Nachteil"
 SHADOWDARK.roll.disadvantage: Nachteil
 SHADOWDARK.roll.failure: Fehlschlag! ({value})

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -252,8 +252,6 @@ SHADOWDARK.class.wizard: Wizard
 SHADOWDARK.coins.cp: CP
 SHADOWDARK.coins.gp: GP
 SHADOWDARK.coins.sp: SP
-SHADOWDARK.damage.one_handed: "One-Handed Damage:"
-SHADOWDARK.damage.two_handed: "Two-Handed Damage:"
 SHADOWDARK.dialog.ability_check.cha: Charisma Check
 SHADOWDARK.dialog.ability_check.con: Constitution Check
 SHADOWDARK.dialog.ability_check.dex: Dexterity Check
@@ -637,6 +635,8 @@ SHADOWDARK.roll.critical.failure: Critical Failure! ({value})
 SHADOWDARK.roll.critical.success: Critical Success! ({value})
 SHADOWDARK.roll.D20: Roll D20
 SHADOWDARK.roll.damage: "Damage Roll:"
+SHADOWDARK.roll.damage1h: "1H Damage:"
+SHADOWDARK.roll.damage2h: "2H Damage:"
 SHADOWDARK.roll.disadvantage_title: "{title} with Disadvantage"
 SHADOWDARK.roll.disadvantage: Disadvantage
 SHADOWDARK.roll.failure: Failure! ({value})

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -304,7 +304,7 @@ SHADOWDARK.dialog.item.sell_all: Sell All
 SHADOWDARK.dialog.item.sell: Sell
 SHADOWDARK.dialog.item.use: Use
 SHADOWDARK.dialog.light_source.pick_up.title: Select actor to give lightsource
-SHADOWDARK.dialog.roll_mode_label: Rolling mode
+SHADOWDARK.dialog.roll_mode_label: Rolling Mode
 SHADOWDARK.dialog.roll: Roll
 SHADOWDARK.dialog.scroll.learn_spell_class_warning: "WARNING: This spell is not of the same class as the character, are you sure you wish to try and learn it?"
 SHADOWDARK.dialog.scroll.wrong_class_confirm: Confirm Learn Spell

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -252,8 +252,6 @@ SHADOWDARK.class.wizard: Mago
 SHADOWDARK.coins.cp: PC
 SHADOWDARK.coins.gp: PO
 SHADOWDARK.coins.sp: PP
-SHADOWDARK.damage.one_handed: "Daño a una mano:"
-SHADOWDARK.damage.two_handed: "Daño a dos manos:"
 SHADOWDARK.dialog.ability_check.cha: Prueba de carisma
 SHADOWDARK.dialog.ability_check.con: Prueba de Constitución
 SHADOWDARK.dialog.ability_check.dex: Prueba de destreza
@@ -637,6 +635,8 @@ SHADOWDARK.roll.critical.failure: '¡Pifia! ({value})'
 SHADOWDARK.roll.critical.success: '¡Éxito crítico! ({value})'
 SHADOWDARK.roll.D20: Tirar D20
 SHADOWDARK.roll.damage: "Tirada de Daño:"
+SHADOWDARK.roll.damage1h: "Daño a 1M:"
+SHADOWDARK.roll.damage2h: "Daño a 2M:"
 SHADOWDARK.roll.disadvantage_title: "{title} con ventaja"
 SHADOWDARK.roll.disadvantage: Desventaja
 SHADOWDARK.roll.failure: '¡Fallo! ({value})'

--- a/i18n/fi.yaml
+++ b/i18n/fi.yaml
@@ -252,8 +252,6 @@ SHADOWDARK.class.wizard: Velho
 SHADOWDARK.coins.cp: Kupari
 SHADOWDARK.coins.gp: Kulta
 SHADOWDARK.coins.sp: Hopea
-SHADOWDARK.damage.one_handed: "Yksikätinen vahinko:"
-SHADOWDARK.damage.two_handed: "Kaksikätinen vahinko:"
 SHADOWDARK.dialog.ability_check.cha: Karismaheitto
 SHADOWDARK.dialog.ability_check.con: Sitkeysheitto
 SHADOWDARK.dialog.ability_check.dex: Ketteryysheitto
@@ -637,6 +635,8 @@ SHADOWDARK.roll.critical.failure: Kriittinen epäonnistuminen! ({value})
 SHADOWDARK.roll.critical.success: Kriittinen onnistuminen! ({value})
 SHADOWDARK.roll.D20: Heitä n20
 SHADOWDARK.roll.damage: "Vahinkoheitto:"
+SHADOWDARK.roll.damage1h: "Yksikätinen vahinko:"
+SHADOWDARK.roll.damage2h: "Kaksikätinen vahinko:"
 SHADOWDARK.roll.disadvantage_title: "{title} haitan kanssa"
 SHADOWDARK.roll.disadvantage: Haitta
 SHADOWDARK.roll.failure: Epäonnistui! ({value})

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -252,8 +252,6 @@ SHADOWDARK.class.wizard: Magicien
 SHADOWDARK.coins.cp: PC
 SHADOWDARK.coins.gp: PO
 SHADOWDARK.coins.sp: PA
-SHADOWDARK.damage.one_handed: "Dégâts à une Main :"
-SHADOWDARK.damage.two_handed: "Dégâts à 2 Mains :"
 SHADOWDARK.dialog.ability_check.cha: Test de Charisme
 SHADOWDARK.dialog.ability_check.con: Test de Constitution
 SHADOWDARK.dialog.ability_check.dex: Test de Dextérité
@@ -636,7 +634,9 @@ SHADOWDARK.roll.advantage: Avantage
 SHADOWDARK.roll.critical.failure: Échec Critique ! ({value})
 SHADOWDARK.roll.critical.success: Succès Critique ! ({value})
 SHADOWDARK.roll.D20: Lancez le D20
-SHADOWDARK.roll.damage: "Jet de Dégâts:"
+SHADOWDARK.roll.damage: "Jet de Dégâts :"
+SHADOWDARK.roll.damage1h: "Dégâts à 1M :"
+SHADOWDARK.roll.damage2h: "Dégâts à 2M :"
 SHADOWDARK.roll.disadvantage_title: "{title} avec Désavantage"
 SHADOWDARK.roll.disadvantage: Désavantage
 SHADOWDARK.roll.failure: Échec! ({value})

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -252,8 +252,6 @@ SHADOWDARK.class.wizard: 마법사
 SHADOWDARK.coins.cp: CP
 SHADOWDARK.coins.gp: GP
 SHADOWDARK.coins.sp: SP
-SHADOWDARK.damage.one_handed: "한손 피해:"
-SHADOWDARK.damage.two_handed: "양손 피해"
 SHADOWDARK.dialog.ability_check.cha: 매력 판정
 SHADOWDARK.dialog.ability_check.con: 건강 판정
 SHADOWDARK.dialog.ability_check.dex: 민첩 판정
@@ -637,6 +635,8 @@ SHADOWDARK.roll.critical.failure: 극단적인 실패! ({value})
 SHADOWDARK.roll.critical.success: 극단적인 성공! ({value})
 SHADOWDARK.roll.D20: D20 굴리기
 SHADOWDARK.roll.damage: "피해 굴림:"
+SHADOWDARK.roll.damage1h: "한손 피해:"
+SHADOWDARK.roll.damage2h: "양손 피해:"
 SHADOWDARK.roll.disadvantage_title: "불리함으로 {title}"
 SHADOWDARK.roll.disadvantage: 불리함
 SHADOWDARK.roll.failure: 실패! ({value})

--- a/i18n/pt_BR.yaml
+++ b/i18n/pt_BR.yaml
@@ -252,8 +252,6 @@ SHADOWDARK.class.wizard: Mago
 SHADOWDARK.coins.cp: PC
 SHADOWDARK.coins.gp: PO
 SHADOWDARK.coins.sp: PP
-SHADOWDARK.damage.one_handed: "Dano de Uma Mão:"
-SHADOWDARK.damage.two_handed: "Dano de Duas Mãos:"
 SHADOWDARK.dialog.ability_check.cha: Teste de Carisma
 SHADOWDARK.dialog.ability_check.con: Teste de Constituição
 SHADOWDARK.dialog.ability_check.dex: Verificação de Destreza
@@ -637,6 +635,8 @@ SHADOWDARK.roll.critical.failure: Falha Crítica! ({value})
 SHADOWDARK.roll.critical.success: Sucesso Crítico! ({value})
 SHADOWDARK.roll.D20: Rolar D20
 SHADOWDARK.roll.damage: "Rolagem de Dano:"
+SHADOWDARK.roll.damage1h: "Dano 1M:"
+SHADOWDARK.roll.damage2h: "Dano 2M:"
 SHADOWDARK.roll.disadvantage_title: "{title} com Desvantagem"
 SHADOWDARK.roll.disadvantage: Desvantagem
 SHADOWDARK.roll.failure: Falha! ({value})

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -252,8 +252,6 @@ SHADOWDARK.class.wizard: Волшебник
 SHADOWDARK.coins.cp: МД
 SHADOWDARK.coins.gp: ЗМ
 SHADOWDARK.coins.sp: СМ
-SHADOWDARK.damage.one_handed: "Урон одной рукой:"
-SHADOWDARK.damage.two_handed: "Урон двумя руками:"
 SHADOWDARK.dialog.ability_check.cha: Проверка Харизмы
 SHADOWDARK.dialog.ability_check.con: Проверка Телосложения
 SHADOWDARK.dialog.ability_check.dex: Проверка Ловкости
@@ -637,6 +635,8 @@ SHADOWDARK.roll.critical.failure: Критический провал! ({value})
 SHADOWDARK.roll.critical.success: Критический успех! ({value})
 SHADOWDARK.roll.D20: Бросок D20
 SHADOWDARK.roll.damage: "Бросок урона:"
+SHADOWDARK.roll.damage1h: "Урон одноручным:"
+SHADOWDARK.roll.damage2h: "Урон двуручным:"
 SHADOWDARK.roll.disadvantage_title: "{title} с помехой"
 SHADOWDARK.roll.disadvantage: Помеха
 SHADOWDARK.roll.failure: Провал! ({value})

--- a/i18n/sv.yaml
+++ b/i18n/sv.yaml
@@ -252,8 +252,6 @@ SHADOWDARK.class.wizard: Trollkarl
 SHADOWDARK.coins.cp: KP
 SHADOWDARK.coins.gp: GM
 SHADOWDARK.coins.sp: SM
-SHADOWDARK.damage.one_handed: "Enhandsskada:"
-SHADOWDARK.damage.two_handed: "Tvåhandsskada:"
 SHADOWDARK.dialog.ability_check.cha: Karisma Check
 SHADOWDARK.dialog.ability_check.con: Kondition Check
 SHADOWDARK.dialog.ability_check.dex: Smidighet Check
@@ -637,6 +635,8 @@ SHADOWDARK.roll.critical.failure: Kritiskt misslyckande! ({value})
 SHADOWDARK.roll.critical.success: Kritisk framgång! ({value})
 SHADOWDARK.roll.D20: Rulla D20
 SHADOWDARK.roll.damage: "Skaderull:"
+SHADOWDARK.roll.damage1h: "1H Skada:"
+SHADOWDARK.roll.damage2h: "1H Skada:"
 SHADOWDARK.roll.disadvantage_title: "{title} med nackdel"
 SHADOWDARK.roll.disadvantage: Nackdel
 SHADOWDARK.roll.failure: Misslyckades! ({value})

--- a/scss/base/_dialog.scss
+++ b/scss/base/_dialog.scss
@@ -14,6 +14,15 @@
 		background-color: var(--form-background);
 	}
 
+	.pc-versatile {
+		display: grid;
+		grid-template-columns: 2fr 1fr 1fr;
+		background-color: var(--form-background);
+		.hand {
+			text-align: right;
+		}
+	}
+
 	&.pickup-lightsource {
 		img {
 			width: 50px;

--- a/system/src/chat/hooks.mjs
+++ b/system/src/chat/hooks.mjs
@@ -247,17 +247,15 @@ function applyChatCardDamage(li, multiplier) {
 		roll = message.rolls[0];
 	}
 	else if (_chatMessageIsDamageCard(message)) {
-		const rolls = message?.flags.rolls;
-		const damage = rolls.primaryDamage || rolls.damage;
-		roll = damage.roll;
+		roll = message?.flags.rolls.damage.roll;
 	}
 	else {
 		return;
 	}
 
 	return Promise.all(canvas.tokens.controlled.map(t => {
-	  const a = t.actor;
-	  return a.applyDamage(roll.total, multiplier);
+		const a = t.actor;
+		return a.applyDamage(roll.total, multiplier);
 	}));
 }
 
@@ -281,8 +279,8 @@ function applyChatCardDamageSecondary(li, multiplier) {
 	let roll = message?.flags.rolls.secondaryDamage.roll;
 
 	return Promise.all(canvas.tokens.controlled.map(t => {
-	  const a = t.actor;
-	  return a.applyDamage(roll.total, multiplier);
+		const a = t.actor;
+		return a.applyDamage(roll.total, multiplier);
 	}));
 }
 
@@ -304,7 +302,7 @@ function _chatMessageIsBasicRoll(message) {
  */
 function _chatMessageIsDamageCard(message) {
 	return message?.flags.isRoll
-		&& (message?.flags.rolls?.primaryDamage || message?.flags.rolls?.damage);
+		&& (message?.flags.rolls?.damage);
 }
 
 /**

--- a/system/src/dice/RollSD.mjs
+++ b/system/src/dice/RollSD.mjs
@@ -461,8 +461,6 @@ export default class RollSD extends Roll {
 						data.rolls.damage = await this._roll(oneHandedParts ?? twoHandedParts);
 					}
 			}
-
-
 		}
 
 		return data;

--- a/system/src/dice/RollSD.mjs
+++ b/system/src/dice/RollSD.mjs
@@ -44,6 +44,13 @@ export default class RollSD extends Roll {
 				: game.settings.get("core", "rollMode");
 		}
 
+		if (!options.handedness) {
+			// override with form input
+			options.handedness = $form
+				? this._getHandednessFromForm($form)
+				: undefined;
+		}
+
 		// Roll the Dice
 		data.rolls = {
 			main: await this._rollAdvantage(parts, data, adv),
@@ -89,6 +96,7 @@ export default class RollSD extends Roll {
 			// Weapon? -> Roll Damage dice
 			if (data.item?.isWeapon()) {
 				data.handedness = options.handedness;
+				data.item.system.currentHand = data.handedness; // remember which hand used last
 				data = await this._rollWeapon(data);
 				if (!options.flavor) {
 					if (options.targetToken) {
@@ -491,6 +499,17 @@ export default class RollSD extends Roll {
 		if ($form.find("[name=talent-bonus]").length) bonuses.talentBonus = $form.find("[name=talent-bonus]")?.val();
 		if ($form.find("[name=weapon-backstab]").length) bonuses.backstab = $form.find("[name=weapon-backstab]")?.prop("checked");
 		return bonuses;
+	}
+
+	/**
+	 * Parses a submitted dialog form for weapon handedness
+	 * @param {jQuery} $form 	- Submitted dialog form
+	 * @returns {string}		- Handedness from the dialog form
+	 */
+	static _getHandednessFromForm($form) {
+		const radios = $form.find("[name=weapon-handedness]");
+		if (radios[0].checked) return "1h";
+		if (radios[1].checked) return "2h";
 	}
 
 	/* -------------------------------------------- */

--- a/system/src/documents/ActorSD.mjs
+++ b/system/src/documents/ActorSD.mjs
@@ -1281,12 +1281,10 @@ export default class ActorSD extends Actor {
 			}
 		}
 
-		// Talents & Ability modifiers
+		// Talent/Ability/Property modifiers
 		if (this.type === "Player") {
-
 			// Check to see if we have any extra dice that need to be added to
 			// the damage rolls due to effects
-			//
 			await this.getExtraDamageDiceForWeapon(item, data);
 
 			data.canBackstab = await this.canBackstab();
@@ -1324,6 +1322,15 @@ export default class ActorSD extends Actor {
 				data.talentBonus = bonuses.rangedAttackBonus;
 				data.rangedDamageBonus = bonuses.rangedDamageBonus * damageMultiplier;
 				data.damageParts.push("@rangedDamageBonus");
+			}
+
+			data.isVersatile = await item.isVersatile();
+			// remember handedness
+			if (data.isVersatile) {
+				if (options.handedness) {
+					item.system.currentHand = options.handedness;
+				}
+				data.currentHand = item.system.currentHand;
 			}
 
 			// Check Weapon Mastery & add if applicable

--- a/system/src/macro.mjs
+++ b/system/src/macro.mjs
@@ -48,6 +48,7 @@ export default class ShadowdarkMacro {
 
 	static async rollItemMacro(itemName) {
 		const speaker = ChatMessage.getSpeaker();
+		const options = {fastForward: event.shiftKey}
 
 		// Active actor, or inactive actor + token on scene allowed
 		if (!(speaker.actor && speaker.scene)) {
@@ -117,7 +118,7 @@ export default class ShadowdarkMacro {
 					})
 				);
 			}
-			actor.castSpell(items[0]._id);
+			actor.castSpell(items[0]._id, options);
 		}
 
 		// Use class ability
@@ -130,16 +131,16 @@ export default class ShadowdarkMacro {
 					})
 				);
 			}
-			actor.useAbility(items[0]._id);
+			actor.useAbility(items[0]._id, options);
 		}
 
 		// Roll weapon attack
 		else if (items[0].type === "Weapon") {
-			actor.rollAttack(items[0]._id);
+			actor.rollAttack(items[0]._id, options);
 		}
 
 		else if (items[0].type === "Potion") {
-			actor.usePotion(items[0]._id);
+			actor.usePotion(items[0]._id, options);
 		}
 
 		// Show basic item

--- a/system/templates/chat/item-card.hbs
+++ b/system/templates/chat/item-card.hbs
@@ -19,9 +19,11 @@
 		{{/if}}
 	</header>
 
-	<div class="card-content">
-		{{{data.item.system.description}}}
-	</div>
+	{{#unless isFocusRoll}}
+		<div class="card-content">
+			{{{data.item.system.description}}}
+		</div>
+	{{/unless}}
 
 	<div class="d20-roll card-attack-rolls">
 		<div
@@ -46,9 +48,11 @@
 
 	{{#if isSpell}}
 		{{#ifEq data.rolls.main.critical "success"}}
-			<div class="card-spell-critical">
-				<p>{{localize "SHADOWDARK.chat.item_roll.double_numerical"}}</p>
-			</div>
+			{{#unless isFocusRoll}}
+				<div class="card-spell-critical">
+					<p>{{localize "SHADOWDARK.chat.item_roll.double_numerical"}}</p>
+				</div>
+			{{/unless}}
 		{{/ifEq}}
 		{{#ifEq data.rolls.main.critical "failure"}}
 			<div class="card-spell-critical">

--- a/system/templates/chat/item-card.hbs
+++ b/system/templates/chat/item-card.hbs
@@ -19,11 +19,9 @@
 		{{/if}}
 	</header>
 
-	{{#unless isFocusRoll}}
-		<div class="card-content">
-			{{{data.item.system.description}}}
-		</div>
-	{{/unless}}
+	<div class="card-content">
+		{{{data.item.system.description}}}
+	</div>
 
 	<div class="d20-roll card-attack-rolls">
 		<div
@@ -48,11 +46,9 @@
 
 	{{#if isSpell}}
 		{{#ifEq data.rolls.main.critical "success"}}
-			{{#unless isFocusRoll}}
-				<div class="card-spell-critical">
-					<p>{{localize "SHADOWDARK.chat.item_roll.double_numerical"}}</p>
-				</div>
-			{{/unless}}
+			<div class="card-spell-critical">
+				<p>{{localize "SHADOWDARK.chat.item_roll.double_numerical"}}</p>
+			</div>
 		{{/ifEq}}
 		{{#ifEq data.rolls.main.critical "failure"}}
 			<div class="card-spell-critical">
@@ -67,13 +63,30 @@
 	{{#if isWeapon}}
 		{{#ifNeq data.rolls.main.critical "failure"}}
 			<div class="card-damage-rolls">
-				<div
-					class="card-damage-roll-single blindable"
-					data-blind="{{data.rolls.main.blind}}"
-				>
-					<h3>{{localize "SHADOWDARK.roll.damage"}}</h3>
-					{{{data.rolls.damage.renderedHTML}}}
-				</div>
+				{{#if data.rolls.secondaryDamage}}
+					<div
+						class="card-damage-roll blindable"
+						data-blind="{{data.rolls.main.blind}}"
+					>
+						<h3>{{localize "SHADOWDARK.roll.damage1h"}}</h3>
+						{{{data.rolls.damage.renderedHTML}}}
+					</div>
+					<div
+						class="card-damage-roll blindable"
+						data-blind="{{data.rolls.main.blind}}"
+					>
+						<h3>{{localize "SHADOWDARK.roll.damage2h"}}</h3>
+						 {{{data.rolls.secondaryDamage.renderedHTML}}}
+					</div>
+				{{else}}
+					<div
+						class="card-damage-roll-single blindable"
+						data-blind="{{data.rolls.main.blind}}"
+					>
+						<h3>{{damageRollName}}</h3>
+						{{{data.rolls.damage.renderedHTML}}}
+					</div>
+				{{/if}}
 			</div>
 		{{/ifNeq}}
 	{{/if}}
@@ -87,7 +100,7 @@
 						data-blind="{{data.rolls.main.blind}}"
 					>
 						<h3>{{localize "SHADOWDARK.roll.damage"}}</h3>
-						{{{data.rolls.primaryDamage.renderedHTML}}}
+						{{{data.rolls.damage.renderedHTML}}}
 					</div>
 				</div>
 			{{/ifNeq}}

--- a/system/templates/dialog/roll-item-dialog.hbs
+++ b/system/templates/dialog/roll-item-dialog.hbs
@@ -33,6 +33,37 @@
     <hr />
     {{/if}}
 
+    {{#if data.isVersatile}}
+    <div class="dialog-item pc-versatile">
+      <div>{{localize "SHADOWDARK.weapon.properties.versatile"}}</div>
+      <div class="hand">
+        {{localize "SHADOWDARK.item.weapon_damage.oneHanded_short"}}
+        <input
+		  type="radio"
+		  id="1h"
+		  name="weapon-handedness"
+		  value="1h"
+		  {{#ifEq data.item.system.currentHand "1h"}}
+		    checked
+		  {{/ifEq}}
+		>
+      </div>
+      <div class="hand">
+        {{localize "SHADOWDARK.item.weapon_damage.twoHanded_short"}}
+        <input
+		  type="radio"
+		  id="2h"
+		  name="weapon-handedness"
+		  value="2h"
+		  {{#ifEq data.item.system.currentHand "2h"}}
+		    checked
+		  {{/ifEq}}
+		>
+      </div>
+    </div>
+    <hr />
+    {{/if}}
+
     <div class="form-group">
       <label>{{localize "SHADOWDARK.dialog.roll_mode_label"}}</label>
       <select name="rollMode">


### PR DESCRIPTION
Adds a radio selection menu to the roll dialog for versatile weapons to choose 1H or 2H.

Adds back the "split" damage card, which is only presented if a versatile weapon is used without specifying the attack's handedness (e.g. from the macro bar). This makes the system more robust to future UI changes or third-party modules that access the rollAttack() function. 

Allows fast forwarding of macros by shift-clicking.

Fixes #1047.