### PR TITLE
Localizes npc spells tab and character creator sidebar menu

### DIFF
--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -55,6 +55,8 @@ SHADOWDARK.apps.character-generator.gear: Ausrüstung
 SHADOWDARK.apps.character-generator.gold: Gold
 SHADOWDARK.apps.character-generator.name: Name des Charakters
 SHADOWDARK.apps.character-generator.see_details: Details anzeigen
+SHADOWDARK.apps.character-generator.sidebar_create: Create
+SHADOWDARK.apps.character-generator.sidebar_import: Import
 SHADOWDARK.apps.character-generator.starting_gear: Startausrüstung
 SHADOWDARK.apps.character-generator.success: Charakter erstellt
 SHADOWDARK.apps.character-generator.title: Charaktergenerator

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -514,6 +514,9 @@ SHADOWDARK.item.npc_attack_damage_formula: Schadensformel
 SHADOWDARK.item.npc_attack_special: Spezial
 SHADOWDARK.item.npc_attack_type: Typ
 SHADOWDARK.item.npc_attack.num_damage_dice: Anz. Schadenswürfel
+SHADOWDARK.item.npc.spell_ability: Zauber-Fähigkeit
+SHADOWDARK.item.npc.spell_bonus: Zauberbonus
+SHADOWDARK.item.npc.spell_count: Number of Castings
 SHADOWDARK.item.potion.label: Trank
 SHADOWDARK.item.properties.label: Gegenstandseigenschaften
 SHADOWDARK.item.scroll.label: Schriftrolle

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -55,6 +55,8 @@ SHADOWDARK.apps.character-generator.gear: Gear
 SHADOWDARK.apps.character-generator.gold: Gold
 SHADOWDARK.apps.character-generator.name: Character Name
 SHADOWDARK.apps.character-generator.see_details: See Details
+SHADOWDARK.apps.character-generator.sidebar_create: Create
+SHADOWDARK.apps.character-generator.sidebar_import: Import
 SHADOWDARK.apps.character-generator.starting_gear: Starting Gear
 SHADOWDARK.apps.character-generator.success: Character created
 SHADOWDARK.apps.character-generator.title: Character Generator

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -514,6 +514,9 @@ SHADOWDARK.item.npc_attack_damage_formula: Damage Formula
 SHADOWDARK.item.npc_attack_special: Attack Features
 SHADOWDARK.item.npc_attack_type: Type
 SHADOWDARK.item.npc_attack.num_damage_dice: Num. Damage Dice
+SHADOWDARK.item.npc.spell_ability: Spellcasting Ability
+SHADOWDARK.item.npc.spell_bonus: Spellcasting Bonus
+SHADOWDARK.item.npc.spell_count: Number of Castings
 SHADOWDARK.item.potion.label: Potion
 SHADOWDARK.item.properties.label: Item Properties
 SHADOWDARK.item.scroll.label: Scroll

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -55,6 +55,8 @@ SHADOWDARK.apps.character-generator.gear: Equipo
 SHADOWDARK.apps.character-generator.gold: Oro
 SHADOWDARK.apps.character-generator.name: Nombre del personaje
 SHADOWDARK.apps.character-generator.see_details: See Details
+SHADOWDARK.apps.character-generator.sidebar_create: Crear
+SHADOWDARK.apps.character-generator.sidebar_import: Importar
 SHADOWDARK.apps.character-generator.starting_gear: Starting Gear
 SHADOWDARK.apps.character-generator.success: Personaje creado
 SHADOWDARK.apps.character-generator.title: Generador de personaje

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -228,7 +228,7 @@ SHADOWDARK.class.language_choices.prompt: Seleccionar idioma...
 SHADOWDARK.class.languages.label: Idiomas de clase
 SHADOWDARK.class.priest: Clérigo
 SHADOWDARK.class.ranger: Explorador
-SHADOWDARK.class.spellcasting_ability.label: Aptitud Mágica
+SHADOWDARK.class.spellcasting_ability.label: Habilidad de Hechizo
 SHADOWDARK.class.spellcasting_class.label: Clase de hechizo
 SHADOWDARK.class.spellcasting.base_difficulty.label: Spellcasting Base DC
 SHADOWDARK.class.spells_Known.label: Spells Known by Spell Tier
@@ -514,6 +514,9 @@ SHADOWDARK.item.npc_attack_damage_formula: Damage Formula
 SHADOWDARK.item.npc_attack_special: Especial
 SHADOWDARK.item.npc_attack_type: Tipo
 SHADOWDARK.item.npc_attack.num_damage_dice: Número de dados de daño
+SHADOWDARK.item.npc.spell_ability: Habilidad de Hechizo
+SHADOWDARK.item.npc.spell_bonus: Bonus de Hechizo
+SHADOWDARK.item.npc.spell_count: Número de Hechizos
 SHADOWDARK.item.potion.label: Poción
 SHADOWDARK.item.properties.label: Item Properties
 SHADOWDARK.item.scroll.label: Pergamino
@@ -832,7 +835,7 @@ SHADOWDARK.talent.type.advantage.hp: Ventaja de tirada de PV
 SHADOWDARK.talent.type.advantage.initiative: Ventaja de iniciativa
 SHADOWDARK.talent.type.advantage.spell: Ventaja de lanzamiento de hechizo
 SHADOWDARK.talent.type.advantage.title: Bonus de ventaja
-SHADOWDARK.talent.type.armor_bonus: Bono de CA de armadura
+SHADOWDARK.talent.type.armor_bonus: Bonus de CA de armadura
 SHADOWDARK.talent.type.armor_mastery: Maestría de armaduras
 SHADOWDARK.talent.type.backstab_die: Dado extra de puñalada
 SHADOWDARK.talent.type.bonus_caster_classes: Bonus Spellcasting Class
@@ -841,7 +844,7 @@ SHADOWDARK.talent.type.melee_attack_bonus: Bonus de Ataque Cuerpo a Cuerpo
 SHADOWDARK.talent.type.melee_damage_bonus: Bonus de daño cuerpo a cuerpo
 SHADOWDARK.talent.type.ranged_attack_bonus: Bonus de ataque a distancia
 SHADOWDARK.talent.type.ranged_damage_bonus: Bonus de daño a distancia
-SHADOWDARK.talent.type.spell_bonus: Bonus de lanzamiento de hechizo
+SHADOWDARK.talent.type.spell_bonus: Bonus de hechizo
 SHADOWDARK.talent.type.stoneSkinTalent: Stone Skin Talent
 SHADOWDARK.talent.type.title: Tipo(s) de talento
 SHADOWDARK.talent.type.weapon_mastery: Maestría de armas

--- a/i18n/fi.yaml
+++ b/i18n/fi.yaml
@@ -514,6 +514,9 @@ SHADOWDARK.item.npc_attack_damage_formula: Vahingon laskukaava
 SHADOWDARK.item.npc_attack_special: Erikoiskyky
 SHADOWDARK.item.npc_attack_type: Tyyppi
 SHADOWDARK.item.npc_attack.num_damage_dice: Vahinkonoppien määrä
+SHADOWDARK.item.npc.spell_ability: Loihtimiskyky
+SHADOWDARK.item.npc.spell_bonus: Loihtimisbonus
+SHADOWDARK.item.npc.spell_count: Number of Castings
 SHADOWDARK.item.potion.label: Rohto/Taikajuoma
 SHADOWDARK.item.properties.label: Tavaran ominaisuudet
 SHADOWDARK.item.scroll.label: Loitsukäärö

--- a/i18n/fi.yaml
+++ b/i18n/fi.yaml
@@ -55,6 +55,8 @@ SHADOWDARK.apps.character-generator.gear: Varusteet
 SHADOWDARK.apps.character-generator.gold: Kulta
 SHADOWDARK.apps.character-generator.name: Hahmon nimi
 SHADOWDARK.apps.character-generator.see_details: Näytä tiedot
+SHADOWDARK.apps.character-generator.sidebar_create: Create
+SHADOWDARK.apps.character-generator.sidebar_import: Import
 SHADOWDARK.apps.character-generator.starting_gear: Aloitusvarustus
 SHADOWDARK.apps.character-generator.success: Hahmo luotu
 SHADOWDARK.apps.character-generator.title: Hahmogeneraattori

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -55,6 +55,8 @@ SHADOWDARK.apps.character-generator.gear: Équipement
 SHADOWDARK.apps.character-generator.gold: Or
 SHADOWDARK.apps.character-generator.name: Nom du Personnage
 SHADOWDARK.apps.character-generator.see_details: Voir les détails
+SHADOWDARK.apps.character-generator.sidebar_create: Create
+SHADOWDARK.apps.character-generator.sidebar_import: Import
 SHADOWDARK.apps.character-generator.starting_gear: Équipement de départ
 SHADOWDARK.apps.character-generator.success: Personnage créé
 SHADOWDARK.apps.character-generator.title: Générateur de personnage

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -514,6 +514,9 @@ SHADOWDARK.item.npc_attack_damage_formula: Formule de dégâts
 SHADOWDARK.item.npc_attack_special: Spécial
 SHADOWDARK.item.npc_attack_type: Type
 SHADOWDARK.item.npc_attack.num_damage_dice: Nombre de Dés de Dégâts
+SHADOWDARK.item.npc.spell_ability: Caractéristique d'incantation
+SHADOWDARK.item.npc.spell_bonus: Bonus pour jet d'Incantation
+SHADOWDARK.item.npc.spell_count: Number of Castings
 SHADOWDARK.item.potion.label: Potion
 SHADOWDARK.item.properties.label: Propriétés de l'Objet
 SHADOWDARK.item.scroll.label: Parchemin

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -55,6 +55,8 @@ SHADOWDARK.apps.character-generator.gear: Gear
 SHADOWDARK.apps.character-generator.gold: Gold
 SHADOWDARK.apps.character-generator.name: Character Name
 SHADOWDARK.apps.character-generator.see_details: See Details
+SHADOWDARK.apps.character-generator.sidebar_create: Create
+SHADOWDARK.apps.character-generator.sidebar_import: Import
 SHADOWDARK.apps.character-generator.starting_gear: Starting Gear
 SHADOWDARK.apps.character-generator.success: Character created
 SHADOWDARK.apps.character-generator.title: Character Generator

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -514,6 +514,9 @@ SHADOWDARK.item.npc_attack_damage_formula: Damage Formula
 SHADOWDARK.item.npc_attack_special: 공격 재주
 SHADOWDARK.item.npc_attack_type: 유형
 SHADOWDARK.item.npc_attack.num_damage_dice: 피해 주사위
+SHADOWDARK.item.npc.spell_ability: 주문시전 능력
+SHADOWDARK.item.npc.spell_bonus: 주문시전 보너스
+SHADOWDARK.item.npc.spell_count: Number of Castings
 SHADOWDARK.item.potion.label: 물약
 SHADOWDARK.item.properties.label: Item Properties
 SHADOWDARK.item.scroll.label: 두루마리

--- a/i18n/pt_BR.yaml
+++ b/i18n/pt_BR.yaml
@@ -55,6 +55,8 @@ SHADOWDARK.apps.character-generator.gear: Equipamento
 SHADOWDARK.apps.character-generator.gold: Ouro
 SHADOWDARK.apps.character-generator.name: Nome do Personagem
 SHADOWDARK.apps.character-generator.see_details: Ver detalhes
+SHADOWDARK.apps.character-generator.sidebar_create: Create
+SHADOWDARK.apps.character-generator.sidebar_import: Import
 SHADOWDARK.apps.character-generator.starting_gear: Equipamento Inicial
 SHADOWDARK.apps.character-generator.success: Personagem criado
 SHADOWDARK.apps.character-generator.title: Gerador de Personagem

--- a/i18n/pt_BR.yaml
+++ b/i18n/pt_BR.yaml
@@ -514,6 +514,9 @@ SHADOWDARK.item.npc_attack_damage_formula: Fórmula de Dano
 SHADOWDARK.item.npc_attack_special: Características de Ataque
 SHADOWDARK.item.npc_attack_type: Tipo
 SHADOWDARK.item.npc_attack.num_damage_dice: Núm. Dados de Dano
+SHADOWDARK.item.npc.spell_ability: Atributo de Conjuração
+SHADOWDARK.item.npc.spell_bonus: Bônus de Conjuração
+SHADOWDARK.item.npc.spell_count: Number of Castings
 SHADOWDARK.item.potion.label: Poção
 SHADOWDARK.item.properties.label: Propriedades do Item
 SHADOWDARK.item.scroll.label: Pergaminho

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -55,6 +55,8 @@ SHADOWDARK.apps.character-generator.gear: Снаряжение
 SHADOWDARK.apps.character-generator.gold: Золото
 SHADOWDARK.apps.character-generator.name: Имя персонажа
 SHADOWDARK.apps.character-generator.see_details: See Details
+SHADOWDARK.apps.character-generator.sidebar_create: Create
+SHADOWDARK.apps.character-generator.sidebar_import: Import
 SHADOWDARK.apps.character-generator.starting_gear: Starting Gear
 SHADOWDARK.apps.character-generator.success: Персонаж создан
 SHADOWDARK.apps.character-generator.title: Генератор персонажей

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -514,6 +514,9 @@ SHADOWDARK.item.npc_attack_damage_formula: Формула урона
 SHADOWDARK.item.npc_attack_special: Особенности атаки
 SHADOWDARK.item.npc_attack_type: Тип
 SHADOWDARK.item.npc_attack.num_damage_dice: Кол-во кубиков урона
+SHADOWDARK.item.npc.spell_ability: Способность колдовства
+SHADOWDARK.item.npc.spell_bonus: Бонус к накладыванию заклинаний
+SHADOWDARK.item.npc.spell_count: Number of Castings
 SHADOWDARK.item.potion.label: Зелье
 SHADOWDARK.item.properties.label: Item Properties
 SHADOWDARK.item.scroll.label: Свиток

--- a/i18n/sv.yaml
+++ b/i18n/sv.yaml
@@ -514,6 +514,9 @@ SHADOWDARK.item.npc_attack_damage_formula: Skadeformel
 SHADOWDARK.item.npc_attack_special: Special
 SHADOWDARK.item.npc_attack_type: Typ
 SHADOWDARK.item.npc_attack.num_damage_dice: Antal skadetärningar
+SHADOWDARK.item.npc.spell_ability: Besvärjelseförmåga
+SHADOWDARK.item.npc.spell_bonus: Bonus för Besvärjelsekast
+SHADOWDARK.item.npc.spell_count: Number of Castings
 SHADOWDARK.item.potion.label: Brygd
 SHADOWDARK.item.properties.label: Item Properties
 SHADOWDARK.item.scroll.label: Pergamentrulle

--- a/i18n/sv.yaml
+++ b/i18n/sv.yaml
@@ -55,6 +55,8 @@ SHADOWDARK.apps.character-generator.gear: Gear
 SHADOWDARK.apps.character-generator.gold: Gold
 SHADOWDARK.apps.character-generator.name: Karaktärsnamn
 SHADOWDARK.apps.character-generator.see_details: See Details
+SHADOWDARK.apps.character-generator.sidebar_create: Create
+SHADOWDARK.apps.character-generator.sidebar_import: Import
 SHADOWDARK.apps.character-generator.starting_gear: Starting Gear
 SHADOWDARK.apps.character-generator.success: Character created
 SHADOWDARK.apps.character-generator.title: Karaktärsgenerator

--- a/system/templates/actors/npc/spells.hbs
+++ b/system/templates/actors/npc/spells.hbs
@@ -45,9 +45,9 @@
 					data-item-type="NPC Spell"
 					data-action="item-create"
 				></a>
-				Spell
+				{{localize "SHADOWDARK.item.spell.label"}}
 			</div>
-			<div class="flex-60-px">DC</div>
+			<div class="flex-60-px">{{localize "SHADOWDARK.class-ability.dc.label"}}</div>
 			<div class="duration">{{localize 'SHADOWDARK.item.spell_duration'}}</div>
 			<div class="range">{{localize 'SHADOWDARK.item.spell_range'}}</div>
 			<div class="actions"></div>

--- a/system/templates/actors/npc/spells.hbs
+++ b/system/templates/actors/npc/spells.hbs
@@ -3,7 +3,7 @@
 	<div class="grid-3-columns" >
 
 		<div class="item-detail">
-			<h3>Number of Attacks</h3>
+			<h3>{{localize "SHADOWDARK.item.npc.spell_count"}}</h3>
 			{{numberInput
 				system.spellcastingAttackNum
 				name="system.spellcastingAttackNum"
@@ -12,7 +12,7 @@
 			}}
 		</div>
 		<div class="item-detail">
-			<h3>Casting Bonus</h3>
+			<h3>{{localize "SHADOWDARK.item.npc.spell_bonus"}}</h3>
 			{{numberInput
 				system.spellcastingBonus
 				name="system.spellcastingBonus"
@@ -21,7 +21,7 @@
 			}}
 		</div>
 		<div class="item-detail">
-			<h3>Casting Ability</h3>
+			<h3>{{localize "SHADOWDARK.item.npc.spell_ability"}}</h3>
 			<select name="system.spellcastingAbility">
 				<option value="">&mdash;</option>
 				{{selectOptions
@@ -33,7 +33,7 @@
 		</div>
 	</div>
 	<br>
-	<div class="SD-banner">Spells</div>
+	<div class="SD-banner">{{localize "SHADOWDARK.sheet.npc.tab.spells"}}</div>
 
 	<ol class="SD-list">
 		<li class="header">

--- a/system/templates/ui/sd-apps-buttons.hbs
+++ b/system/templates/ui/sd-apps-buttons.hbs
@@ -2,14 +2,14 @@
 	<button class="character-generator-button">
 		<i class="fas fa-user-plus"></i>
 		<b class="button-text">
-			Create
+			{{localize SHADOWDARK.apps.character-generator.sidebar_create}}
 		</b>
 	</button>
 
 	<button class="shadowdarkling-import-button">
 		<i class="fas fa-file-import"></i>
 		<b class="button-text">
-			Import
+			{{localize SHADOWDARK.apps.character-generator.sidebar_import}}
 		</b>
 	</button>
 </div>


### PR DESCRIPTION
Fixes #1038

Localizes headings in NPC spells tab. and the "Create, Import" buttons in the sidebar.

Also fixes a few ES translations that were either inconsistent with other translated phrases or were inappropriate for their intended contexts