### PR TITLE
added nominal ability tabbing

### DIFF
--- a/system/src/handlebars.mjs
+++ b/system/src/handlebars.mjs
@@ -16,6 +16,12 @@ export default function registerHandlebarsHelpers() {
 		return newOjects;
 	});
 
+	Handlebars.registerHelper('calculateAbilityTabIndex', function(index) {
+		const row = Math.floor(index / 2);
+		const col = index % 2;
+		return row + (col === 0 ? 1 : 4); // 1-3 for col 1, 4-6 for col 2
+	});
+
 	Handlebars.registerHelper("concat", function() {
 		let outStr = "";
 		for (let arg in arguments) {

--- a/system/templates/actors/npc/partials/ability-scores.hbs
+++ b/system/templates/actors/npc/partials/ability-scores.hbs
@@ -13,11 +13,13 @@
 				>
 					{{ability.label}}
 				</a>
-				{{numberInput
-					ability.mod
-					name=(concat "system.abilities." id ".mod")
-					class="ability-score" placeholder="0"
-				}}
+				<input
+					name="{{concat "system.abilities." id ".mod"}}"
+					type="number"
+					value="{{ability.mod}}"
+					placeholder="0"
+					tabindex="{{calculateAbilityTabIndex @index}}"
+				>
 			</div>
 
 		{{/each}}

--- a/system/templates/actors/player/abilities/stats.hbs
+++ b/system/templates/actors/player/abilities/stats.hbs
@@ -32,6 +32,7 @@
 							type="number"
 							value="{{ability.total}}"
 							placeholder="10"
+							tabindex="{{calculateAbilityTabIndex @index}}"
 						>
 					{{else}}
 						<span>{{ability.total}}</span>


### PR DESCRIPTION
This new tabbing modifies the old behavior from left-to-right and top-to-bottom tabbing with top-to-bottom then left-to-right without changing the appearance of the NPC and Player sheets.

This is to follow the normal order ability scores are listed in ShadowDark. This is especially useful for when GM's need to manual enter many monsters statistics which are listed in official publications as **S, D, C, I, W, Ch**.