### PR TITLE
properly apply item damage bonus

### DIFF
--- a/system/src/documents/ActorSD.mjs
+++ b/system/src/documents/ActorSD.mjs
@@ -1276,7 +1276,7 @@ export default class ActorSD extends Actor {
 		}
 		if (item.system.bonuses.damageBonus) {
 			data.damageParts.push("@itemDamageBonus");
-			data.itemDamageBonus = item.system.bonuses.damageBonus * damageMultiplier;
+			data.itemDamageBonus = parseInt(item.system.bonuses.damageBonus, 10) * damageMultiplier;
 		}
 
 		/* Attach Special Ability if part of the attack.


### PR DESCRIPTION
When an item used by a PC has a generic damage bonus effect, that damage bonus was not getting properly added. In the debugger the resulting damageBonus was `NaN`. This was due to the string value for the item's damage bonus being multiplied with the number value damageMultiplier. I added a parseInt around the item's damage bonus.

I didn't see this same issue in other item bonus paths.