### PR TITLE
Correct handaxe price to 2gp

### DIFF
--- a/data/packs/gear.db/handaxe__3DxwBvjceq0FxcsC.json
+++ b/data/packs/gear.db/handaxe__3DxwBvjceq0FxcsC.json
@@ -23,7 +23,7 @@
 		"canBeEquipped": true,
 		"cost": {
 			"cp": 0,
-			"gp": 5,
+			"gp": 2,
 			"sp": 0
 		},
 		"damage": {


### PR DESCRIPTION
Changes the price of a handaxe from 5gp to 2gp.

Addresses issue Muttley/foundryvtt-shadowdark#1107.