### PR TITLE
Correct inconsistent typography in "sundering" properties

### DIFF
--- a/data/packs/class-abilities.db/demonic_possession__dsFmHTTuERiQePky.json
+++ b/data/packs/class-abilities.db/demonic_possession__dsFmHTTuERiQePky.json
@@ -9,7 +9,7 @@
 	"system": {
 		"ability": "",
 		"dc": 10,
-		"description": "<p><span style=\"font-family: Signika, sans-serif\">3/day, gain a +1 bonus to your damage rolls that lasts 3 rounds.</span></p><p style=\"box-sizing: border-box; user-select: text; margin: 0px; border-bottom: unset; min-height: 1rem; color: rgb(25, 24, 19); font-family: Signika, sans-serif; font-size: 18px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgba(0, 0, 0, 0.04); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; text-align: start\"></p><p style=\"box-sizing: border-box; user-select: text; margin: 0px; border-bottom: unset; color: rgb(25, 24, 19); font-family: Signika, sans-serif; font-size: 18px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgba(0, 0, 0, 0.04); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; text-align: start\"><span style=\"font-family: Signika, sans-serif\">In addition, add half your level to the damage bonus (round down).</span></p>",
+		"description": "<p>3/day, gain a +1 bonus to your damage rolls that lasts 3 rounds.</p><p>In addition, add half your level to the damage bonus (round down).</p>",
 		"group": "Knight of St. Ydris",
 		"limitedUses": true,
 		"loseOnFailure": false,

--- a/data/packs/monsters.db/ambush__MCM2UX1jwTiz6Af0.json
+++ b/data/packs/monsters.db/ambush__MCM2UX1jwTiz6Af0.json
@@ -7,7 +7,7 @@
 	"img": "icons/svg/item-bag.svg",
 	"name": "Ambush",
 	"system": {
-		"description": "<p><span style=\"font-family: Signika, sans-serif\">Deal an extra die of damage when undetected.</span></p>",
+		"description": "<p>Deal an extra die of damage when undetected.</p>",
 		"magicItem": false,
 		"source": {
 			"page": 0,

--- a/data/packs/monsters.db/bewilder__3tGrbD7V4Kzh69WJ.json
+++ b/data/packs/monsters.db/bewilder__3tGrbD7V4Kzh69WJ.json
@@ -7,7 +7,7 @@
 	"img": "icons/svg/item-bag.svg",
 	"name": "Bewilder",
 	"system": {
-		"description": "<p><span style=\"font-family: Signika, sans-serif\">Creatures within near that see the cave brute's eyes, [[check 12 cha]] at start of their turn or dazed and no action.</span></p>",
+		"description": "<p>Creatures within near that see the cave brute's eyes, [[check 12 cha]] at start of their turn or dazed and no action.</p>",
 		"magicItem": false,
 		"source": {
 			"page": 0,

--- a/data/packs/monsters.db/camouflage__pFMLvvf8uJ0g1g3S.json
+++ b/data/packs/monsters.db/camouflage__pFMLvvf8uJ0g1g3S.json
@@ -7,7 +7,7 @@
 	"img": "icons/svg/item-bag.svg",
 	"name": "Camouflage",
 	"system": {
-		"description": "<p><span style=\"font-family: Signika, sans-serif\">Hard to see in cave terrain or rocks.</span></p>",
+		"description": "<p>Hard to see in cave terrain or rocks.</p>",
 		"magicItem": false,
 		"source": {
 			"page": 0,

--- a/data/packs/monsters.db/deathtouch__wis_spell___decpoSp0qogWhTIt.json
+++ b/data/packs/monsters.db/deathtouch__wis_spell___decpoSp0qogWhTIt.json
@@ -7,7 +7,7 @@
 	"img": "icons/svg/item-bag.svg",
 	"name": "Deathtouch (WIS Spell)",
 	"system": {
-		"description": "<p><span style=\"font-family: Signika, sans-serif\">DC 12. 2d4 damage to one creature within close.</span></p>",
+		"description": "<p>DC 12. 2d4 damage to one creature within close.</p>",
 		"magicItem": false,
 		"source": {
 			"page": 0,

--- a/data/packs/monsters.db/engulf__RnlzBMWYWCNLB80N.json
+++ b/data/packs/monsters.db/engulf__RnlzBMWYWCNLB80N.json
@@ -7,7 +7,7 @@
 	"img": "icons/svg/item-bag.svg",
 	"name": "Engulf",
 	"system": {
-		"description": "<p><span style=\"font-family: Signika, sans-serif\">Absorbs paralyzed creatures in close range into its body, automatically hitting with touch attack on its turn.</span></p>",
+		"description": "<p>Absorbs paralyzed creatures in close range into its body, automatically hitting with touch attack on its turn.</p>",
 		"magicItem": false,
 		"source": {
 			"page": 0,

--- a/data/packs/monsters.db/golem__oySxFnphWlWj2S0x.json
+++ b/data/packs/monsters.db/golem__oySxFnphWlWj2S0x.json
@@ -7,7 +7,7 @@
 	"img": "icons/svg/item-bag.svg",
 	"name": "Golem",
 	"system": {
-		"description": "<p><span style=\"font-family: Signika, sans-serif\">Immune to damage from fire, cold, electricity, or non-magical sources.</span></p>",
+		"description": "<p>Immune to damage from fire, cold, electricity, or non-magical sources.</p>",
 		"magicItem": false,
 		"source": {
 			"page": 0,

--- a/data/packs/monsters.db/keen_senses__ZSuJd7G2g3jX3P6B.json
+++ b/data/packs/monsters.db/keen_senses__ZSuJd7G2g3jX3P6B.json
@@ -7,7 +7,7 @@
 	"img": "icons/svg/item-bag.svg",
 	"name": "Keen Senses",
 	"system": {
-		"description": "<p><span style=\"font-family: Signika, sans-serif\">Can't be surprised.</span></p>",
+		"description": "<p>Can't be surprised.</p>",
 		"magicItem": false,
 		"source": {
 			"page": 0,

--- a/data/packs/monsters.db/life_drain__jhamHxRRpeqem41U.json
+++ b/data/packs/monsters.db/life_drain__jhamHxRRpeqem41U.json
@@ -7,7 +7,7 @@
 	"img": "icons/svg/item-bag.svg",
 	"name": "Life Drain",
 	"system": {
-		"description": "<p><span style=\"font-family: Signika, sans-serif\">1d4 CON damage. Death if reduced to 0 CON.</span></p>",
+		"description": "<p>1d4 CON damage. Death if reduced to 0 CON.</p>",
 		"magicItem": false,
 		"source": {
 			"page": 0,

--- a/data/packs/monsters.db/rubbery__tksSsqnnEL96jIKF.json
+++ b/data/packs/monsters.db/rubbery__tksSsqnnEL96jIKF.json
@@ -7,7 +7,7 @@
 	"img": "icons/svg/item-bag.svg",
 	"name": "Rubbery",
 	"system": {
-		"description": "<p><span style=\"font-family: Signika, sans-serif\">Half damage from stabbing weapons.</span></p>",
+		"description": "<p>Half damage from stabbing weapons.</p>",
 		"magicItem": false,
 		"source": {
 			"page": 0,

--- a/data/packs/monsters.db/slow__WCgeRKkVzpcLQ4h9.json
+++ b/data/packs/monsters.db/slow__WCgeRKkVzpcLQ4h9.json
@@ -7,7 +7,7 @@
 	"img": "icons/svg/item-bag.svg",
 	"name": "Slow",
 	"system": {
-		"description": "<p><span style=\"font-family: Signika, sans-serif\">Far range, one target. [[check 15 con]] or speed halved 1d4 rounds.</span></p>",
+		"description": "<p>Far range, one target. [[check 15 con]] or speed halved 1d4 rounds.</p>",
 		"magicItem": false,
 		"source": {
 			"page": 0,

--- a/data/packs/monsters.db/stone_meld__MJOkTSVNf817bqhs.json
+++ b/data/packs/monsters.db/stone_meld__MJOkTSVNf817bqhs.json
@@ -7,7 +7,7 @@
 	"img": "icons/svg/item-bag.svg",
 	"name": "Stone Meld",
 	"system": {
-		"description": "<p><span style=\"font-family: Signika, sans-serif\">2/day, underground only. Turn invisible for 3 rounds.</span></p>",
+		"description": "<p>2/day, underground only. Turn invisible for 3 rounds.</p>",
 		"magicItem": false,
 		"source": {
 			"page": 0,

--- a/data/packs/monsters.db/toxin__jjIo6W6eWnU2jog0.json
+++ b/data/packs/monsters.db/toxin__jjIo6W6eWnU2jog0.json
@@ -7,7 +7,7 @@
 	"img": "icons/svg/item-bag.svg",
 	"name": "Toxin",
 	"system": {
-		"description": "<p><span style=\"font-family: Signika, sans-serif\">[[check 15 con]] or paralyzed 1d4 rounds.</span></p>",
+		"description": "<p>[[check 15 con]] or paralyzed 1d4 rounds.</p>",
 		"magicItem": false,
 		"source": {
 			"page": 0,

--- a/data/packs/properties.db/sundering__Op1yKvM7uq5pdopr.json
+++ b/data/packs/properties.db/sundering__Op1yKvM7uq5pdopr.json
@@ -7,7 +7,7 @@
 	"img": "icons/sundries/documents/document-torn-diagram-tan.webp",
 	"name": "Sundering",
 	"system": {
-		"description": "<p><span style=\"font-family: Signika, sans-serif\">When you are hit with a melee attack, you may choose to destroy this weapon or armor to negate all damage from the attack.</span></p>",
+		"description": "<p>When you are hit with a melee attack, you may choose to destroy this weapon or armor to negate all damage from the attack.</p>",
 		"itemType": "weapon",
 		"predefinedEffects": "",
 		"source": {

--- a/data/packs/properties.db/sundering__bAzl6RH1PW95ZkFE.json
+++ b/data/packs/properties.db/sundering__bAzl6RH1PW95ZkFE.json
@@ -7,7 +7,7 @@
 	"img": "icons/sundries/documents/document-torn-diagram-tan.webp",
 	"name": "Sundering",
 	"system": {
-		"description": "<p><span style=\"font-family: Signika, sans-serif\">When you are hit with a melee attack, you may choose to destroy this weapon or armor to negate all damage from the attack.</span></p>",
+		"description": "<p>When you are hit with a melee attack, you may choose to destroy this weapon or armor to negate all damage from the attack.</p>",
 		"itemType": "armor",
 		"predefinedEffects": "",
 		"source": {

--- a/data/packs/quickstart-adventures.db/the_lost_citadel_of_the_scarlet_minotaur__0qbqDCsioL4HWVvW.json
+++ b/data/packs/quickstart-adventures.db/the_lost_citadel_of_the_scarlet_minotaur__0qbqDCsioL4HWVvW.json
@@ -11328,7 +11328,7 @@
 					"gp": 40,
 					"sp": 0
 				},
-				"description": "<p><span style=\"font-family: Signika, sans-serif\">An ivory egg shot with grey veins inside.</span></p>",
+				"description": "<p>An ivory egg shot with grey veins inside.</p>",
 				"equipped": false,
 				"isAmmunition": false,
 				"isPhysical": true,
@@ -11531,7 +11531,7 @@
 					"gp": 80,
 					"sp": 0
 				},
-				"description": "<p><span style=\"font-family: Signika, sans-serif\">Contained in a bronze tube adorned with jade dragons.</span></p><p>@UUID[Compendium.shadowdark.spells.ItN82uLU3PhJFLNm]{Burning Hands}</p>",
+				"description": "<p>Contained in a bronze tube adorned with jade dragons.</p><p>@UUID[Compendium.shadowdark.spells.ItN82uLU3PhJFLNm]{Burning Hands}</p>",
 				"equipped": false,
 				"isAmmunition": false,
 				"isPhysical": true,
@@ -11623,7 +11623,7 @@
 					"oneHanded": "d8",
 					"twoHanded": ""
 				},
-				"description": "<p><span style=\"font-family: Signika, sans-serif\">Silvered longsword with half-moon pommel.</span></p>",
+				"description": "<p>Silvered longsword with half-moon pommel.</p>",
 				"equipped": false,
 				"isAmmunition": false,
 				"isPhysical": true,

--- a/data/packs/spell-effects.db/spell_effect__blind__SOkcvkzrGMGQKhmk.json
+++ b/data/packs/spell-effects.db/spell_effect__blind__SOkcvkzrGMGQKhmk.json
@@ -9,7 +9,7 @@
 	"name": "Spell Effect: Blind",
 	"system": {
 		"category": "effect",
-		"description": "<p><span style=\"font-family: Signika, sans-serif\">The creature is blind and has disadvantage on tasks requiring sight.</span></p>",
+		"description": "<p>The creature is blind and has disadvantage on tasks requiring sight.</p>",
 		"duration": {
 			"type": "focus",
 			"value": 1

--- a/data/packs/spell-effects.db/spell_effect__bogboil__VOx6yLlQ23XwVvuG.json
+++ b/data/packs/spell-effects.db/spell_effect__bogboil__VOx6yLlQ23XwVvuG.json
@@ -9,7 +9,7 @@
 	"name": "Spell Effect: Bogboil",
 	"system": {
 		"category": "effect",
-		"description": "<p><span style=\"font-family: Signika, sans-serif\">A creature stuck in the web can’t move and must succeed on a Strength check opposed by the casters spellcasting check to free itself.</span></p>",
+		"description": "<p>A creature stuck in the web can’t move and must succeed on a Strength check opposed by the caster’s spellcasting check to free itself.</p>",
 		"duration": {
 			"type": "rounds",
 			"value": "5"

--- a/data/packs/spell-effects.db/spell_effect__charm_person__Z0YwWUGs3WYC6OGn.json
+++ b/data/packs/spell-effects.db/spell_effect__charm_person__Z0YwWUGs3WYC6OGn.json
@@ -9,7 +9,7 @@
 	"name": "Spell Effect: Charm Person",
 	"system": {
 		"category": "effect",
-		"description": "<p><span style=\"font-family: Signika, sans-serif\">The humanoid regards the caster as a friend for the duration.</span><br class=\"Apple-interchange-newline\"><span style=\"font-family: Signika, sans-serif\">The effect ends if you or your allies do anything harmful to the target.</span></p>",
+		"description": "<p>The humanoid regards the caster as a friend for the duration.<br class=\"Apple-interchange-newline\">The effect ends if you or your allies do anything harmful to the target.</p>",
 		"duration": {
 			"type": "days",
 			"value": "1"

--- a/data/packs/spell-effects.db/spell_effect__cleansing_weapon__7hKYL9hdnsvCUM9c.json
+++ b/data/packs/spell-effects.db/spell_effect__cleansing_weapon__7hKYL9hdnsvCUM9c.json
@@ -12,7 +12,7 @@
 			"meleeDamageBonus": "1d4"
 		},
 		"category": "effect",
-		"description": "<p><span style=\"font-family: Signika, sans-serif\">One weapon you touch is wreathed in purifying flames. It deals an additional [[/r 1d4]] damage ([[/r 1d6]] vs. undead) for the duration.</span></p>",
+		"description": "<p>One weapon you touch is wreathed in purifying flames. It deals an additional [[/r 1d4]] damage ([[/r 1d6]] vs. undead) for the duration.</p>",
 		"duration": {
 			"type": "rounds",
 			"value": "5"

--- a/data/packs/spell-effects.db/spell_effect__detect_magic__74WjFjHmUmLAiNGC.json
+++ b/data/packs/spell-effects.db/spell_effect__detect_magic__74WjFjHmUmLAiNGC.json
@@ -9,7 +9,7 @@
 	"name": "Spell Effect: Detect Magic",
 	"system": {
 		"category": "effect",
-		"description": "<p><span style=\"font-family: Signika, sans-serif\">You can sense the presence of magic within near range for the spell's duration. If you focus for two rounds, you discern its general properties. Full barriers block this spell.</span></p>",
+		"description": "<p>You can sense the presence of magic within near range for the spell's duration. If you focus for two rounds, you discern its general properties. Full barriers block this spell.</p>",
 		"duration": {
 			"type": "focus",
 			"value": 1

--- a/data/packs/spell-effects.db/spell_effect__protection_from_evil__H7v5Izebo8O45DXB.json
+++ b/data/packs/spell-effects.db/spell_effect__protection_from_evil__H7v5Izebo8O45DXB.json
@@ -9,7 +9,7 @@
 	"name": "Spell Effect: Protection From Evil",
 	"system": {
 		"category": "effect",
-		"description": "<p><span style=\"font-family: Signika, sans-serif\">Chaotic beings have disadvantage on attack rolls and hostile spellcasting checks against the target. These beings also can’t possess, compel, or beguile it.</span></p>",
+		"description": "<p>Chaotic beings have disadvantage on attack rolls and hostile spellcasting checks against the target. These beings also can’t possess, compel, or beguile it.</p>",
 		"duration": {
 			"type": "focus",
 			"value": 1

--- a/data/packs/spell-effects.db/spell_effect__sleep__FrFilluk4S5VaWut.json
+++ b/data/packs/spell-effects.db/spell_effect__sleep__FrFilluk4S5VaWut.json
@@ -9,7 +9,7 @@
 	"name": "Spell Effect: Sleep",
 	"system": {
 		"category": "effect",
-		"description": "<p><span style=\"font-family: Signika, sans-serif\">Injury or vigorous shaking wakes the creature.</span></p>",
+		"description": "<p>Injury or vigorous shaking wakes the creature.</p>",
 		"duration": {
 			"type": "unlimited",
 			"value": 1

--- a/data/packs/spell-effects.db/spell_effect__web__28PPFz1MYTsfPwzh.json
+++ b/data/packs/spell-effects.db/spell_effect__web__28PPFz1MYTsfPwzh.json
@@ -9,7 +9,7 @@
 	"name": "Spell Effect: Web",
 	"system": {
 		"category": "effect",
-		"description": "<p><span style=\"font-family: Signika, sans-serif\">A creature stuck in the web can’t move and must succeed on a Strength check opposed by the casters spellcasting check to free itself.</span></p>",
+		"description": "<p>A creature stuck in the web can’t move and must succeed on a Strength check opposed by the casters spellcasting check to free itself.</p>",
 		"duration": {
 			"type": "rounds",
 			"value": "5"

--- a/data/packs/spell-effects.db/spell_effect__zone_of_truth__cL5aPfXcad9FtHoK.json
+++ b/data/packs/spell-effects.db/spell_effect__zone_of_truth__cL5aPfXcad9FtHoK.json
@@ -9,7 +9,7 @@
 	"name": "Spell Effect: Zone of Truth",
 	"system": {
 		"category": "effect",
-		"description": "<p><span style=\"font-family: Signika, sans-serif\">Can’t utter a deliberate lie when within range from source.</span></p>",
+		"description": "<p>Can’t utter a deliberate lie when within range from source.</p>",
 		"duration": {
 			"type": "focus",
 			"value": 1


### PR DESCRIPTION
Corrects the inconsistent use of the "Signika" font in the descriptions for the armor and weapon "sundering" properties.

Addresses issue #1129.

# Note

I see that the same issue appears in quite a number of places throughout the compendiums. I'm guessing that this was either an artefact of text conversion from PDF, or of manual copy-and-pasting. Assuming it is not a deliberate choice, I'd be happy to clean all these instances out, either as part of this PR, or in separate PRs addressing the following categories. Let me know.

- Demonic possession class ability
- Numerous monsters
- Numerous spell effects
- Lost Citadel of the Scarlet Minotaur
