### PR TITLE
Remove repeated description in Alarm spell

### DIFF
--- a/data/packs/spells.db/alarm__dBBfp7KpHXBcSEjg.json
+++ b/data/packs/spells.db/alarm__dBBfp7KpHXBcSEjg.json
@@ -10,7 +10,7 @@
 		"class": [
 			"Compendium.shadowdark.classes.Item.035nuVkU9q2wtMPs"
 		],
-		"description": "<p>You touch one object, such as a door threshold, setting a magical alarm on it.</p><p>If any creature you do not designate while casting the spell touches or crosses past the object, a magical bell sounds in your head.</p><p>If any creature you do not designate while casting the spell touches or crosses past the object, a magical bell sounds in your head.</p>",
+		"description": "<p>You touch one object, such as a door threshold, setting a magical alarm on it.</p><p>If any creature you do not designate while casting the spell touches or crosses past the object, a magical bell sounds in your head.</p>",
 		"duration": {
 			"type": "days",
 			"value": "1"


### PR DESCRIPTION
Removes the repeated paragraph in the description of the Alarm spell.

Addresses issue Muttley/foundryvtt-shadowdark#1130.