### PR TITLE
Improve support for dynamic token rings and HP adjustment

### DIFF
--- a/system/src/config.mjs
+++ b/system/src/config.mjs
@@ -561,6 +561,12 @@ SHADOWDARK.TALENT_CLASSES = {
 	patronBoon: "SHADOWDARK.talent.class.patronBoon",
 };
 
+SHADOWDARK.TOKEN_HP_COLORS = {
+	damage: 0xFF0000,
+	healing: 0x00FF00,
+	defeated: 0x000000,
+};
+
 SHADOWDARK.WEAPON_BASE_DAMAGE = {
 	d2: "1d2",
 	d4: "1d4",

--- a/system/src/hooks/targeting.mjs
+++ b/system/src/hooks/targeting.mjs
@@ -10,6 +10,17 @@ export const TargetingHooks = {
 			if (game.user.targets.size > 1 && !user.isGM) {
 				game.user.updateTokenTargets([token.id]);
 			}
+
+			// if a token has a dynamic ring configured, flash using the user's color
+			if (token.document.ring.enabled) {
+				const color = Color.from(user.color);
+				token.ring.flashColor(color,
+					{
+						duration: 500,
+						easing: token.ring.constructor.easeTwoPeaks,
+					}
+				);
+			}
 		});
 	},
 };


### PR DESCRIPTION
Since the Shadowdark system is the beneficiary of support from the Pathfinder token collection (and that I personally use dynamic token rings in my games), I think it would be nice to support the features of dynamic token rings and offer more token features present in comparable systems.

This PR includes the following:
* Red and green flashes when the HP of a token increases or decreases respectively.
* Dynamic rings flash with targeting user's color.
* A small amount of text floats off tokens to indicate the amount of damage or healing applied; the size of the text scaling with the amount changed relative to the token's max HP. This is generally beneficial because it helps ensure that healing and damage are being properly applied for all sides of the table.