### PR TITLE
Update map-light-sources.json

### DIFF
--- a/system/assets/mappings/map-light-sources.json
+++ b/system/assets/mappings/map-light-sources.json
@@ -10,7 +10,7 @@
 				"reverse": false,
 				"type": "torch"
 			},
-			"attentuation": 0.5,
+			"attenuation": 0.5,
 			"bright": 15,
 			"color": "#d1c846",
 			"coloration": 1,
@@ -36,7 +36,7 @@
 				"reverse": false,
 				"type": null
 			},
-			"attentuation": 0.5,
+			"attenuation": 0.5,
 			"bright": 60,
 			"color": null,
 			"coloration": 1,
@@ -62,7 +62,7 @@
 				"reverse": false,
 				"type": null
 			},
-			"attentuation": 0.5,
+			"attenuation": 0.5,
 			"bright": 30,
 			"color": null,
 			"coloration": 1,
@@ -88,7 +88,7 @@
 				"reverse": false,
 				"type": "torch"
 			},
-			"attentuation": 0.5,
+			"attenuation": 0.5,
 			"bright": 5,
 			"color": "#d1c846",
 			"coloration": 1,


### PR DESCRIPTION
fixed a typo with the word "attenuation" which prevented the attenuation parameter to work properly