### PR TITLE
Issue 1146: Hide torch time when appropriate

### DIFF
--- a/system/src/sheets/PlayerSheetSD.mjs
+++ b/system/src/sheets/PlayerSheetSD.mjs
@@ -692,6 +692,7 @@ export default class PlayerSheetSD extends ActorSheetSD {
 		this.actor.usePotion(itemId);
 	}
 
+
 	async _sendToggledLightSourceToChat(active, item, options = {}) {
 		const cardData = {
 			active: active,
@@ -701,6 +702,7 @@ export default class PlayerSheetSD extends ActorSheetSD {
 			actor: this,
 			item: item,
 			picked_up: options.picked_up ?? false,
+			showRemainingMins: game.settings.get("shadowdark", "playerShowLightRemaining") > 1,
 		};
 
 		let template = options.template ?? "systems/shadowdark/templates/chat/lightsource-toggle.hbs";

--- a/system/templates/chat/lightsource-toggle.hbs
+++ b/system/templates/chat/lightsource-toggle.hbs
@@ -23,6 +23,7 @@
 			{{/if}}
 		</h3>
 	</header>
+	{{#if showRemainingMins}}
 	<div class="light-source {{#if active}}on{{else}}off{{/if}}">
 		<h4>
 		{{#ifCond timeRemaining '<' 1}}
@@ -32,4 +33,5 @@
 		{{/ifCond}}
 		</h4>
 	</div>
+	{{/if}}
 </div>


### PR DESCRIPTION
I didn't have it show torch time left for GMs because the message is shown to all players, whether or not it's the GM toggling the light source or the player.  Having the isGM check on the template would cause it to render the time left on messages that players could see when the GM toggled a player's light source.  I felt it better to just hide the time left based on the config setting alone.  If the GM wants to see remaining time, they can still hover over the torch dots on the player's inventory sheet (which honors the config setting as well as the current user).