### PR TITLE
Fixed black text on black background in journal header

### DIFF
--- a/scss/base/_journal.scss
+++ b/scss/base/_journal.scss
@@ -9,7 +9,7 @@
 
 .system-shadowdark .journal-sheet .journal-header input[type="text"] {
 	background: none;
-	color: white;
+	color: var(--color-text-primary);
 	border: none;
 	border-radius: 0;
 }


### PR DESCRIPTION
Fixed black text on black background in journal title editor

<img width="422" height="130" alt="Screenshot 2025-11-13 205603" src="https://github.com/user-attachments/assets/8ff32985-f7b3-4374-a775-df0641479ae0" />
