### PR TITLE
Implemented intellisense updates

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,7 @@
 		"node": true,
 		"jquery": true
 	},
-	"ignorePatterns": ["**/*compiled.mjs"],
+	"ignorePatterns": ["**/*compiled.mjs", "foundry/**/*"],
 	"parserOptions": {
 		"requireConfigFile": false,
 		"sourceType": "module",

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ system/packs/
 .env
 *.code-workspace
 shadowdark-compiled*
+
+foundry-config.yaml
+foundry

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "ES2022",
+    "target": "ES2022",
+    "paths": {
+      "@client/*": ["./foundry/client/*"],
+      "@common/*": ["./foundry/common/*"]
+    },
+  },
+  "exclude": ["node_modules", "**/node_modules/*"],
+  "include": ["system/shadowdark.mjs", "foundry/client/client.mjs", "foundry/client/global.d.mts", "foundry/common/primitives/global.d.mts"],
+  "typeAcquisition": {
+    "include": ["jquery"]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
 		"lang": "gulp compileLang",
 		"lint": "gulp lintJs",
 		"notes": "gulp compileNotes",
-		"packs": "gulp compilePacks"
+		"packs": "gulp compilePacks",
+		"createSymlinks": "node ./utils/create-symlinks.mjs"
 	},
 	"devDependencies": {
 		"@rollup/plugin-node-resolve": "^16.0.3",

--- a/utils/create-symlinks.mjs
+++ b/utils/create-symlinks.mjs
@@ -1,0 +1,51 @@
+import * as fs from "fs";
+import yaml from "js-yaml";
+import path from "path";
+
+console.log("Reforging Symlinks");
+
+if (fs.existsSync("foundry-config.yaml")) {
+	let fileRoot = "";
+	try {
+		const fc = await fs.promises.readFile("foundry-config.yaml", "utf-8");
+
+		const foundryConfig = yaml.load(fc);
+
+		// As of 13.338, the Node install is *not* nested but electron installs *are*
+		const nested = fs.existsSync(path.join(foundryConfig.installPath, "resources", "app"));
+
+		if (nested) fileRoot = path.join(foundryConfig.installPath, "resources", "app");
+		else fileRoot = foundryConfig.installPath;
+	}
+	catch(err) {
+		console.error(`Error reading foundry-config.yaml: ${err}`);
+	}
+
+	try {
+		await fs.promises.mkdir("foundry");
+	}
+	catch(e) {
+		if (e.code !== "EEXIST") throw e;
+	}
+
+	// Javascript files
+	for (const p of ["client", "common", "tsconfig.json"]) {
+		try {
+			await fs.promises.symlink(path.join(fileRoot, p), path.join("foundry", p));
+		}
+		catch(e) {
+			if (e.code !== "EEXIST") throw e;
+		}
+	}
+
+	// Language files
+	try {
+		await fs.promises.symlink(path.join(fileRoot, "public", "lang"), path.join("foundry", "lang"));
+	}
+	catch(e) {
+		if (e.code !== "EEXIST") throw e;
+	}
+}
+else {
+	console.log("Foundry config file did not exist.");
+}


### PR DESCRIPTION
For full details of what these changes do, see https://foundryvtt.wiki/en/development/guides/improving-intellisense.

Steps you'll have to do to get them to work:

1. Create a `foundry-config.yaml` file in your root folder with the following content (update to reflect your environment):  
```
installPath: "/path/to/your/foundryvtt"
```
Note: This file is in the .gitignore so you'll have to create it each time you create an environment.

2. run the following command from the terminal:
```
npm run createSymlinks
```

3. Restart your VSCode and intellisense should be working now.

Note: this update has not been tested in a full windows based setup.  These steps were tested for linux or windows/wsl.