### PR TITLE
Fix isPrivate always being false in RollSD._prepareChatRenderContext

### DIFF
--- a/system/src/dice/RollSD.mjs
+++ b/system/src/dice/RollSD.mjs
@@ -33,7 +33,7 @@ export default class RollSD extends foundry.dice.Roll {
 
 	async _prepareChatRenderContext({flavor, isPrivate=false, ...options}={}) {
 		const context = await super._prepareChatRenderContext(
-			{flavor, isPrivate=false, ...options}={}
+			{flavor, isPrivate, ...options}
 		);
 
 		// context for success or failure


### PR DESCRIPTION
Private rolls in chat messages are public because `isPrivate=false` is always passed to `super._prepareChatContext`. Changing to `isPrivate` preserves the original value.

![rollMode-bug](https://github.com/user-attachments/assets/416fdf83-ef1c-4052-a5b2-5f9ed3b9c113)
