### PR TITLE
Persist selected rollMode from dialog form back to config

### DIFF
--- a/system/src/apps/RollDialogSD.mjs
+++ b/system/src/apps/RollDialogSD.mjs
@@ -199,6 +199,10 @@ export default class RollDialogSD extends foundry.applications.api.HandlebarsApp
 				this.config.ammunitionOptions.find(x => x._id === formData.ammunitionId);
 		}
 
+		if (formData.rollMode !== undefined) {
+			this.config.rollMode = formData.rollMode;
+		}
+
 		this.result = formData;
 		this.submitted = true;
 


### PR DESCRIPTION
**Note:** This bug can't be reproduced from an end user perspective (i.e. without going into the debugger) unless #1239 is applied first, since the behaviour that fix addresses will obscure what's happening here.

This fix adds the selected roll mode in the roll dialog to the submit data, so it can pass it back to override the global roll mode for the attack.