### PR TITLE
Coerce itemIndex to Number in CompendiumItemSelector

### DIFF
--- a/system/src/apps/CompendiumItemSelector.mjs
+++ b/system/src/apps/CompendiumItemSelector.mjs
@@ -125,7 +125,7 @@ export default class CompendiumItemSelector extends foundry.appv1.api.FormApplic
 		event.preventDefault();
 		event.stopPropagation();
 
-		let itemIndex = event.currentTarget.dataset.itemIndex;
+		let itemIndex = Number(event.currentTarget.dataset.itemIndex);
 
 		const newItemUuids = [];
 


### PR DESCRIPTION
Can be reproduced when attempting to remove an armor property on an Item sheet. 

![remove-armor-property](https://github.com/user-attachments/assets/cc327de9-a1e6-4d4b-a980-455427136553)

Event data is a String: without explicit conversion, strict equality check against itemIndex on line 133 silently fails.