### PR TITLE
Convert uuid check from String to Boolean in Selector subclasses

### DIFF
--- a/system/src/apps/CompendiumItemSelectors/AncestrySelector.mjs
+++ b/system/src/apps/CompendiumItemSelectors/AncestrySelector.mjs
@@ -17,7 +17,7 @@ export default class AncestrySelector extends CompendiumItemSelector {
 	async getUuids() {
 		const uuid = this.object?.system?.ancestry;
 
-		return uuid !== "" ? [uuid] : [];
+		return uuid ? [uuid] : [];
 	}
 
 	async saveUuids(uuids) {

--- a/system/src/apps/CompendiumItemSelectors/BackgroundSelector.mjs
+++ b/system/src/apps/CompendiumItemSelectors/BackgroundSelector.mjs
@@ -17,7 +17,7 @@ export default class BackgroundSelector extends CompendiumItemSelector {
 	async getUuids() {
 		const uuid = this.object?.system?.background;
 
-		return uuid !== "" ? [uuid] : [];
+		return uuid ? [uuid] : [];
 	}
 
 	async saveUuids(uuids) {

--- a/system/src/apps/CompendiumItemSelectors/ClassSelector.mjs
+++ b/system/src/apps/CompendiumItemSelectors/ClassSelector.mjs
@@ -17,7 +17,7 @@ export default class ClassSelector extends CompendiumItemSelector {
 	async getUuids() {
 		const uuid = this.object?.system?.class;
 
-		return uuid !== "" ? [uuid] : [];
+		return uuid ? [uuid] : [];
 	}
 
 	async saveUuids(uuids) {

--- a/system/src/apps/CompendiumItemSelectors/DeitySelector.mjs
+++ b/system/src/apps/CompendiumItemSelectors/DeitySelector.mjs
@@ -25,7 +25,7 @@ export default class DeitySelector extends CompendiumItemSelector {
 	async getUuids() {
 		const uuid = this.object?.system?.deity;
 
-		return uuid !== "" ? [uuid] : [];
+		return uuid ? [uuid] : [];
 	}
 
 	async saveUuids(uuids) {

--- a/system/src/apps/CompendiumItemSelectors/PatronSelector.mjs
+++ b/system/src/apps/CompendiumItemSelectors/PatronSelector.mjs
@@ -18,7 +18,7 @@ export default class PatronSelector extends CompendiumItemSelector {
 	async getUuids() {
 		const uuid = this.object?.system?.patron;
 
-		return uuid !== "" ? [uuid] : [];
+		return uuid ? [uuid] : [];
 	}
 
 	async saveUuids(uuids) {


### PR DESCRIPTION
After creating an empty Player sheet, clicking the edit button on Class, Background, Deity, or Ancestry (or Patron, if Class = Warlock) fields does not open the popup: it disappears after the Loading popup. 

Because the field is empty, `uuid` will be `null`: it will then be wrapped in an array and returned, since it will not be equal to `""`. This fails in `getCurrentItems()`. Fix is to convert checks to Boolean.
