### PR TITLE
NPC initiative should sort on abilities.dex.mod

### DIFF
--- a/system/src/documents/EncounterSD.mjs
+++ b/system/src/documents/EncounterSD.mjs
@@ -39,7 +39,7 @@ export default class EncounterSD extends foundry.documents.Combat {
 
 		if (npcs.length > 0) {
 			npcs.sort((a, b) =>
-				b.actor.getRollData().initiativeBonus - a.actor.getRollData().initiativeBonus);
+				b.actor.getRollData().abilities.dex.mod - a.actor.getRollData().abilities.dex.mod);
 			rollers.push(npcs[0]);
 		}
 


### PR DESCRIPTION
`initiativeBonus` doesn't exist as a property: correct property is `abilities.dex.mod`. Bug and fix can be confirmed by rolling initiative for faster and slower NPCs before and after:

## Before
![before-fix](https://github.com/user-attachments/assets/ef1c5e48-9ba1-4193-bc82-24bcd749edbd)


## After
![after-fix](https://github.com/user-attachments/assets/07dad62c-fd6c-46e9-a656-fd744016f97b)
