### PR TITLE
Update roll to mainRoll in rollHP() config

### DIFF
--- a/system/src/models/NpcSD.mjs
+++ b/system/src/models/NpcSD.mjs
@@ -213,7 +213,7 @@ export default class NpcSD extends ActorBaseSD {
 		const config = {
 			actorId: this.parent.id,
 			title: game.i18n.localize("SHADOWDARK.dialog.hp_roll.title"),
-			roll: {formula},
+			mainRoll: {formula},
 			rollMode: CONST.DICE_ROLL_MODES.PRIVATE,
 		};
 


### PR DESCRIPTION
When game setting **Auto Roll NPC Hit Points** is enabled, dragging an NPC Actor onto the canvas throws `TypeError: Cannot read properties of undefined` in the console and hit points are not generated randomly.

`config` in `rollHP()` sets property `roll`, however `rollFromConfig()` checks for property `mainRoll` on line 219 of `dice.mjs`. `mainRoll` is referenced elsewhere and is the correct name:

```
export async function rollFromConfig(config) {
	if (!config.mainRoll.formula) {
		console.error("Error: missing required config property: mainRoll.formula");
		return false;
	}
...
```