### PR TITLE
Ensure 0 level NPCs have at least 1 HP

### DIFF
--- a/system/src/models/NpcSD.mjs
+++ b/system/src/models/NpcSD.mjs
@@ -208,7 +208,7 @@ export default class NpcSD extends ActorBaseSD {
 
 		const conBonus = shadowdark.dice.formatBonus(this.abilities.con.mod);
 		const level = this.level.value ?? 1;
-		const formula = `${level}d8${conBonus}`;
+		const formula = level ? `${level}d8${conBonus}` : `1${conBonus}`;
 
 		const config = {
 			actorId: this.parent.id,


### PR DESCRIPTION
After applying the #1245 fix, I noticed dragging a Kobold onto the canvas left it with 0 HP. Rat (another 0-level creature) had 1, due to its CON modifier. 

The issue is that the formula `${level}d8${conBonus}` passes 0d8+CON for 0-level monsters. Providing a fallback for level 0 (minimum 1 HP + CON modifier according to p. 189 of the SD manual) addresses this in my experimentation.