### PR TITLE
Add all magic items from core rulebook

### DIFF
--- a/data/packs/magic-items.db/alabaster_destrier__T7VGBPF272LjO0jB.json
+++ b/data/packs/magic-items.db/alabaster_destrier__T7VGBPF272LjO0jB.json
@@ -1,0 +1,44 @@
+{
+	"_id": "T7VGBPF272LjO0jB",
+	"_key": "!items!T7VGBPF272LjO0jB",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/environment/creatures/horse-white.webp",
+	"name": "Alabaster Destrier",
+	"system": {
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A smooth, pearly statuette of a running horse.</em></p><p></p><p><strong>Benefit.</strong> Once per day, the wielder can speak the command word to turn the statuette into a @UUID[Compendium.shadowdark.monsters.Actor.5Tp7B3qOMEAdMkJ8]{pegasus} that accepts neutral or lawful riders. The statuette remains in this form for 1 hour.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/amulet_of_secrecy__RQ4nLtB4DgQiTt2d.json
+++ b/data/packs/magic-items.db/amulet_of_secrecy__RQ4nLtB4DgQiTt2d.json
@@ -1,0 +1,44 @@
+{
+	"_id": "RQ4nLtB4DgQiTt2d",
+	"_key": "!items!RQ4nLtB4DgQiTt2d",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/equipment/neck/amulet-carved-stone-eye.webp",
+	"name": "Amulet of Secrecy",
+	"system": {
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A heavy, flat pendant carved with a lidded eye.</em></p><p><strong>Benefit.</strong> You can't be detected by divination magic such as the scrying spell or a Crystal Ball while wearing this amulet.</p><p><strong>Curse.</strong> You constantly have the sensation of being watched.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/amulet_of_vitality__qHyL2dlqQaxwMzKX.json
+++ b/data/packs/magic-items.db/amulet_of_vitality__qHyL2dlqQaxwMzKX.json
@@ -1,0 +1,44 @@
+{
+	"_id": "qHyL2dlqQaxwMzKX",
+	"_key": "!items!qHyL2dlqQaxwMzKX",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/equipment/neck/amulet-geometric-gold-red.webp",
+	"name": "Amulet of Vitality",
+	"system": {
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A gold amulet with a red ruby teardrop at its center.</em></p><p><strong>Benefit.</strong> Your Constitution stat becomes 18 (+4) while wearing this amulet.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/armor_of_saint_terragnis__fKKSAFFX6vVGEzSi.json
+++ b/data/packs/magic-items.db/armor_of_saint_terragnis__fKKSAFFX6vVGEzSi.json
@@ -1,0 +1,48 @@
+{
+	"_id": "fKKSAFFX6vVGEzSi",
+	"_key": "!items!fKKSAFFX6vVGEzSi",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/equipment/chest/breastplate-layered-steel.webp",
+	"name": "Armor of Saint Terragnis",
+	"system": {
+		"ac": {
+			"attribute": "",
+			"base": 18,
+			"modifier": 0
+		},
+		"baseArmor": "plate-mail",
+		"bonuses": {
+			"acBonus": "3"
+		},
+		"broken": false,
+		"canBeEquipped": true,
+		"cost": {
+			"cp": 0,
+			"gp": null,
+			"sp": 0
+		},
+		"description": "<p><em>Golden plate mail carved from head to toe with warrior angels.</em></p><p><strong>Bonus.</strong> +3 plate mail. Only a lawful worshipper of Saint Terragnis can wear this armor.</p><p><strong>Benefit.</strong> Hostile spells that target you are DC 18 to cast. Once per month, you can summon an Avatar of Saint Terragnis (treat as an archangel) to fight by your side for 10 rounds.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"magicItem": true,
+		"predefinedEffects": "",
+		"properties": [
+			"Compendium.shadowdark.properties.Item.WhfSBiji8VG1mMzV",
+			"Compendium.shadowdark.properties.Item.kBLs47xhX1snaDGA"
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 3
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}

--- a/data/packs/magic-items.db/armor_of_the_oni__hcC1kuGgQ2VdnHmj.json
+++ b/data/packs/magic-items.db/armor_of_the_oni__hcC1kuGgQ2VdnHmj.json
@@ -1,0 +1,48 @@
+{
+	"_id": "hcC1kuGgQ2VdnHmj",
+	"_key": "!items!hcC1kuGgQ2VdnHmj",
+	"effects": [
+		"n3Z0tBxloczqrb2w",
+		"neOYG1GjgRxHKIMr"
+	],
+	"folder": null,
+	"img": "icons/equipment/chest/breastplate-banded-steel-gold.webp",
+	"name": "Armor of the Oni",
+	"system": {
+		"ac": {
+			"attribute": "",
+			"base": 16,
+			"modifier": 0
+		},
+		"baseArmor": "plate-mail",
+		"bonuses": {
+			"meleeAttackBonus": "1"
+		},
+		"broken": false,
+		"canBeEquipped": true,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>Black plate mail of lacquered, ironwood panels. The helm's visor is the face of a snarling oni.</em></p><p><strong>Bonus.</strong> +1 plate mail.</p><p><strong>Benefit.</strong> You can speak and understand Diabolic. Your melee weapon attacks deal +1 damage.</p><p><strong>Curse.</strong> You have disadvantage on attacks and spellcasting checks against demons.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"languages": "Compendium.shadowdark.languages.Item.b5yBrLaRIl7ZEWKu",
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}

--- a/data/packs/magic-items.db/bag_of_badgers__DyzDQtoj6Y7Qv1AE.json
+++ b/data/packs/magic-items.db/bag_of_badgers__DyzDQtoj6Y7Qv1AE.json
@@ -1,0 +1,44 @@
+{
+	"_id": "DyzDQtoj6Y7Qv1AE",
+	"_key": "!items!DyzDQtoj6Y7Qv1AE",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/containers/bags/coinpouch-simple-leather-brown.webp",
+	"name": "Bag of Badgers",
+	"system": {
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A gray, fraying sack matted with white, bristly hair.</em></p><p><strong>Benefit.</strong> Once per day, you can reach inside the bag and pull out an angry @UUID[Compendium.shadowdark.monsters.Actor.VM65vWCNjlx5tKTP]{badger}. You can throw the badger up to a near distance. The badger attacks the nearest creature for 3 rounds before waddling away.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/bag_of_devouring__qcVQraEjj6CK0bpf.json
+++ b/data/packs/magic-items.db/bag_of_devouring__qcVQraEjj6CK0bpf.json
@@ -1,0 +1,44 @@
+{
+	"_id": "qcVQraEjj6CK0bpf",
+	"_key": "!items!qcVQraEjj6CK0bpf",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/containers/bags/sack-cloth-purple.webp",
+	"name": "Bag of Devouring",
+	"system": {
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A worn, leather pouch with tight drawstrings.</em></p><p><strong>Curse.</strong> This bag devours and destroys anything placed inside it in 1d6 rounds.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/bead_of_force__FTaL3OmCavdb0AIs.json
+++ b/data/packs/magic-items.db/bead_of_force__FTaL3OmCavdb0AIs.json
@@ -1,0 +1,44 @@
+{
+	"_id": "FTaL3OmCavdb0AIs",
+	"_key": "!items!FTaL3OmCavdb0AIs",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/commodities/gems/pearl-swirl-blue.webp",
+	"name": "Bead of Force",
+	"system": {
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A marble with a blue ring of light glowing softly inside it.</em></p><p><strong>Benefit.</strong> You can throw this bead at one target up to a near distance. If you hit, the target becomes caught in a @UUID[Compendium.shadowdark.spells.Item.B091clRxdPW3SQ4G]{resilient sphere} spell (pg. 69).</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/blade_of_vengeance__SuPwL1LQKe8DdaRq.json
+++ b/data/packs/magic-items.db/blade_of_vengeance__SuPwL1LQKe8DdaRq.json
@@ -1,0 +1,58 @@
+{
+	"_id": "SuPwL1LQKe8DdaRq",
+	"_key": "!items!SuPwL1LQKe8DdaRq",
+	"effects": [
+		"MosrS1dHHXThJ96N"
+	],
+	"folder": null,
+	"img": "icons/weapons/swords/greatsword-crossguard-embossed-gold.webp",
+	"name": "Blade of Vengeance",
+	"system": {
+		"ammoClass": "",
+		"baseWeapon": "bastard-sword",
+		"bonuses": {
+			"attackBonus": "1",
+			"critical": {
+				"failureThreshold": 1,
+				"multiplier": 2,
+				"successThreshold": 20
+			},
+			"damageBonus": 0,
+			"damageMultiplier": 1
+		},
+		"broken": false,
+		"canBeEquipped": true,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"damage": {
+			"numDice": 1,
+			"oneHanded": "d8",
+			"twoHanded": "d10"
+		},
+		"description": "<p><em>A gray blade with a diamond- cut ruby in the pommel. It whistles sharply with each slice.</em></p><p><strong>Bonus.</strong> +2 bastard sword. Cannot be wielded by undead.</p><p><strong>Benefit.</strong> You have advantage on attacks against undead creatures with this sword. You can use the sword to cast @UUID[Compendium.shadowdark.spells.Item.mByUvcHIVEPWscfH]{turn undead }once per day (+4 bonus).</p><p><strong>Personality.</strong> Lawful. Grim, suspicious. Forged as a failsafe against the Witch-Kings if they should fall to darkness, which they did. Demands they be slain.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.qEIYaQ9j2EUmSrx6"
+		],
+		"quantity": 1,
+		"range": "close",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 2
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"type": "melee",
+		"weaponMastery": false
+	},
+	"type": "Weapon"
+}

--- a/data/packs/magic-items.db/boots_of_dancing__rGOliwa8ZiiwiAxJ.json
+++ b/data/packs/magic-items.db/boots_of_dancing__rGOliwa8ZiiwiAxJ.json
@@ -1,0 +1,44 @@
+{
+	"_id": "rGOliwa8ZiiwiAxJ",
+	"_key": "!items!rGOliwa8ZiiwiAxJ",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/equipment/feet/boots-collared-leather.webp",
+	"name": "Boots of Dancing",
+	"system": {
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>Fine, supple boots of sheepskin.</em></p><p><strong>Curse.</strong> As soon as you don these boots, you begin cavorting and dancing uncontrollably. You move randomly each turn and must pass a [[request 15 dex]] check to remove the boots.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/boots_of_hovering__r1cwY7jUars9bs24.json
+++ b/data/packs/magic-items.db/boots_of_hovering__r1cwY7jUars9bs24.json
@@ -1,0 +1,44 @@
+{
+	"_id": "r1cwY7jUars9bs24",
+	"_key": "!items!r1cwY7jUars9bs24",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/skills/movement/feet-winged-boots-brown.webp",
+	"name": "Boots of Hovering",
+	"system": {
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>Brown, sturdy boots polished to a sheen. Small, silver wings adorn the heels.</em></p><p><strong>Benefit.</strong> You can walk on an insubstantial surface for 1 turn at a time. You fall through the surface if you end your turn on it.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/bracers_of_archery__j0WXRAkFtjg9LYKS.json
+++ b/data/packs/magic-items.db/bracers_of_archery__j0WXRAkFtjg9LYKS.json
@@ -1,0 +1,46 @@
+{
+	"_id": "j0WXRAkFtjg9LYKS",
+	"_key": "!items!j0WXRAkFtjg9LYKS",
+	"effects": [
+		"yrS7j3rhCRynCLL6"
+	],
+	"folder": null,
+	"img": "icons/equipment/wrist/bracer-quilted-leather.webp",
+	"name": "Bracers of Archery",
+	"system": {
+		"ac": {
+			"attribute": "",
+			"base": 0,
+			"modifier": 0
+		},
+		"baseArmor": "",
+		"bonuses": {
+			"rangedDamageBonus": "1"
+		},
+		"broken": false,
+		"canBeEquipped": true,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>Leather bracers embossed with soaring hawks.</em></p><p><strong>Benefit.</strong> You deal +1 damage with ranged weapons.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}

--- a/data/packs/magic-items.db/brak_s_book_of_misspells__hVxGqq2Ala8hC0xJ.json
+++ b/data/packs/magic-items.db/brak_s_book_of_misspells__hVxGqq2Ala8hC0xJ.json
@@ -1,0 +1,44 @@
+{
+	"_id": "hVxGqq2Ala8hC0xJ",
+	"_key": "!items!hVxGqq2Ala8hC0xJ",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/sundries/books/book-backed-wood-tan.webp",
+	"name": "Brak's Book of Misspells",
+	"system": {
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A tome bound in ratskin that bears a jagged, glowing rune.</em></p><p><strong>Curse.</strong> This spellbook contains one scroll each of @UUID[Compendium.shadowdark.spells.Item.16XuBF2xjUnoepyp]{acid arrow} (pg. 54), @UUID[Compendium.shadowdark.spells.Item.j2gvzfnMGQwxqgGg]{fireball} (pg. 60), and @UUID[Actor.2xHFafRF1iQUJUHj.Item.vTvKrv5VC2UQnrHM]{sleep} (pg. 71). When a wizard tries to cast or learn a spell from these scrolls, the spell targets the caster on a success.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/circlet_of_wisdom__yE6fl9FlZldHBupD.json
+++ b/data/packs/magic-items.db/circlet_of_wisdom__yE6fl9FlZldHBupD.json
@@ -1,0 +1,50 @@
+{
+	"_id": "yE6fl9FlZldHBupD",
+	"_key": "!items!yE6fl9FlZldHBupD",
+	"effects": [
+		"JGN2W0klkumjFNoV"
+	],
+	"folder": null,
+	"img": "icons/commodities/treasure/crown-gold-laurel-wreath.webp",
+	"name": "Circlet of Wisdom",
+	"system": {
+		"abilities": {
+			"wis": {
+				"base": "18"
+			}
+		},
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/cloak_of_the_bat__2zk5qjIWmN5OqNf5.json
+++ b/data/packs/magic-items.db/cloak_of_the_bat__2zk5qjIWmN5OqNf5.json
@@ -1,0 +1,44 @@
+{
+	"_id": "2zk5qjIWmN5OqNf5",
+	"_key": "!items!2zk5qjIWmN5OqNf5",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/equipment/back/cloak-heavy-black-red.webp",
+	"name": "Cloak of the bat",
+	"system": {
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A leathery, black cloak that has a ragged hem and a hood with pointed ears.</em></p><p><strong>Benefit.</strong> You can fly a near distance as your movement while in a shadowy area.</p><p><strong>Curse.</strong> Each time you use the cloak to fly, roll a d20. On a result of 1, you and your gear turn into a small bat for 3 rounds.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/crystal_ball__lYl5E9urwAHXoqIr.json
+++ b/data/packs/magic-items.db/crystal_ball__lYl5E9urwAHXoqIr.json
@@ -1,0 +1,44 @@
+{
+	"_id": "lYl5E9urwAHXoqIr",
+	"_key": "!items!lYl5E9urwAHXoqIr",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/magic/perception/orb-crystal-ball-scrying.webp",
+	"name": "Crystal Ball",
+	"system": {
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A flawless glass orb with roiling images swirling inside it.</em></p><p><strong>Benefit.</strong> Only wizards can use a Crystal Ball. You can use it to cast the @UUID[Compendium.shadowdark.spells.Item.FrdLzy8cWPcVS2Mz]{scrying} spell (pg. 70). If you fail the spellcasting check to cast scrying, the Crystal Ball ceases to function for a day.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/dagger_of_the_goblin_hero__YITrYmzXxk6Yjxfc.json
+++ b/data/packs/magic-items.db/dagger_of_the_goblin_hero__YITrYmzXxk6Yjxfc.json
@@ -1,0 +1,60 @@
+{
+	"_id": "YITrYmzXxk6Yjxfc",
+	"_key": "!items!YITrYmzXxk6Yjxfc",
+	"effects": [
+		"kUrrVadALCQYuXNm"
+	],
+	"folder": null,
+	"img": "icons/weapons/daggers/dagger-curved-purple.webp",
+	"name": "Dagger of the Goblin Hero",
+	"system": {
+		"ammoClass": "",
+		"baseWeapon": "dagger",
+		"bonuses": {
+			"attackBonus": 0,
+			"critical": {
+				"failureThreshold": 1,
+				"multiplier": 2,
+				"successThreshold": 20
+			},
+			"damageBonus": 0,
+			"damageMultiplier": 1
+		},
+		"broken": false,
+		"canBeEquipped": true,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"damage": {
+			"numDice": 1,
+			"oneHanded": "d4",
+			"twoHanded": ""
+		},
+		"description": "<p><em>A curved dagger with a half- moon notch at the blade's base.</em></p><p><strong>Bonus.</strong> +1 dagger.</p><p><strong>Benefit.</strong> You can speak Goblin. All goblinoid creatures react to you with a friendly attitude.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"languages": "Compendium.shadowdark.languages.Item.NN9wFGgwk49oOQeN",
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.rqQwpoeWEqi0ZcYK",
+			"Compendium.shadowdark.properties.Item.c35ROL1nXwC840kC"
+		],
+		"quantity": 1,
+		"range": "near",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"type": "melee",
+		"weaponMastery": false
+	},
+	"type": "Weapon"
+}

--- a/data/packs/magic-items.db/egg_of_the_cockatrice__LflQgWEekkaKPm8Z.json
+++ b/data/packs/magic-items.db/egg_of_the_cockatrice__LflQgWEekkaKPm8Z.json
@@ -1,0 +1,44 @@
+{
+	"_id": "LflQgWEekkaKPm8Z",
+	"_key": "!items!LflQgWEekkaKPm8Z",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/consumables/eggs/egg-spotted-cyan.webp",
+	"name": "Egg of the Cockatrice",
+	"system": {
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A blue, hard egg as big as a coconut and heavy as a stone.</em></p><p><strong>Benefit.</strong> Once per week, you can speak a command word that causes a @UUID[Compendium.shadowdark.monsters.Actor.xUxKG0CR6Elw1l7h]{cockatrice} to hatch and follow your commands for 5 rounds before flying away. The egg repairs itself over one week.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/flying_carpet__GIRNb0BTURa4wyLH.json
+++ b/data/packs/magic-items.db/flying_carpet__GIRNb0BTURa4wyLH.json
@@ -1,0 +1,44 @@
+{
+	"_id": "GIRNb0BTURa4wyLH",
+	"_key": "!items!GIRNb0BTURa4wyLH",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/commodities/cloth/cloth-bolt-gold-red.webp",
+	"name": "Flying Carpet",
+	"system": {
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A richly woven, red carpet with gold tassels.</em></p><p><strong>Benefit.</strong> The carpet fits two riders (one is the driver). It can fly double near on the driver's turn.</p><p><strong>Personality.</strong> Neutral. Playful, mischievous. Enjoys visiting new places and gets restless without a frequent change in location.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/melee_attack_roll_bonus__neOYG1GjgRxHKIMr.json
+++ b/data/packs/magic-items.db/melee_attack_roll_bonus__neOYG1GjgRxHKIMr.json
@@ -1,0 +1,27 @@
+{
+	"_id": "neOYG1GjgRxHKIMr",
+	"_key": "!items.effects!hcC1kuGgQ2VdnHmj.neOYG1GjgRxHKIMr",
+	"changes": [
+		{
+			"key": "system.bonuses.meleeAttackBonus",
+			"mode": 2,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Melee Attack Roll Bonus",
+	"origin": "Item.WQAnfvteIZallISc",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/permanent_ability__wis___JGN2W0klkumjFNoV.json
+++ b/data/packs/magic-items.db/permanent_ability__wis___JGN2W0klkumjFNoV.json
@@ -1,0 +1,27 @@
+{
+	"_id": "JGN2W0klkumjFNoV",
+	"_key": "!items.effects!yE6fl9FlZldHBupD.JGN2W0klkumjFNoV",
+	"changes": [
+		{
+			"key": "system.abilities.wis.base",
+			"mode": 5,
+			"value": "18"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"img": "icons/skills/melee/strike-axe-blood-red.webp",
+	"name": "Permanent Ability (Wis)",
+	"origin": "Compendium.shadowdark.magic-items.Item.yE6fl9FlZldHBupD",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/ranged_damage_bonus__yrS7j3rhCRynCLL6.json
+++ b/data/packs/magic-items.db/ranged_damage_bonus__yrS7j3rhCRynCLL6.json
@@ -1,0 +1,27 @@
+{
+	"_id": "yrS7j3rhCRynCLL6",
+	"_key": "!items.effects!j0WXRAkFtjg9LYKS.yrS7j3rhCRynCLL6",
+	"changes": [
+		{
+			"key": "system.bonuses.rangedDamageBonus",
+			"mode": 2,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"img": "icons/skills/melee/strike-axe-blood-red.webp",
+	"name": "Ranged Damage Bonus",
+	"origin": "Item.lD298MxRkDjTggZd",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/speak___understand_diabolic__n3Z0tBxloczqrb2w.json
+++ b/data/packs/magic-items.db/speak___understand_diabolic__n3Z0tBxloczqrb2w.json
@@ -1,0 +1,33 @@
+{
+	"_id": "n3Z0tBxloczqrb2w",
+	"_key": "!items.effects!hcC1kuGgQ2VdnHmj.n3Z0tBxloczqrb2w",
+	"changes": [
+		{
+			"key": "system.languages",
+			"mode": 2,
+			"priority": null,
+			"value": "Compendium.shadowdark.languages.Item.b5yBrLaRIl7ZEWKu"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"img": "icons/commodities/tech/cog-steel-grey.webp",
+	"name": "Speak & Understand Diabolic",
+	"origin": "Item.WQAnfvteIZallISc",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/speak_goblin__kUrrVadALCQYuXNm.json
+++ b/data/packs/magic-items.db/speak_goblin__kUrrVadALCQYuXNm.json
@@ -1,0 +1,33 @@
+{
+	"_id": "kUrrVadALCQYuXNm",
+	"_key": "!items.effects!YITrYmzXxk6Yjxfc.kUrrVadALCQYuXNm",
+	"changes": [
+		{
+			"key": "system.languages",
+			"mode": 2,
+			"priority": null,
+			"value": "Compendium.shadowdark.languages.Item.NN9wFGgwk49oOQeN"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"img": "icons/commodities/tech/cog-steel-grey.webp",
+	"name": "Speak Goblin",
+	"origin": "Compendium.shadowdark.magic-items.Item.YITrYmzXxk6Yjxfc",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__MosrS1dHHXThJ96N.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__MosrS1dHHXThJ96N.json
@@ -1,0 +1,27 @@
+{
+	"_id": "MosrS1dHHXThJ96N",
+	"_key": "!items.effects!SuPwL1LQKe8DdaRq.MosrS1dHHXThJ96N",
+	"changes": [
+		{
+			"key": "system.bonuses.attackBonus",
+			"mode": 2,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Weapon Attack Roll Bonus",
+	"origin": "Item.P0NDz7qmT3RsOhz7",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": false,
+	"type": "base"
+}


### PR DESCRIPTION
I'm currently going through alphabetically and adding each of the magic items from the core rulebook. The license, as I read it, allows for these to be added, but we currently only have a few magic items. 

I'll move this PR out of draft state once I've finished importing all magic items. 

- [x] A
- [x] B
- [x] C
- [x] D
- [x] E
- [x] F
- [ ] G
- [ ] H
- [ ] I
- [ ] J
- [ ] K
- [ ] L
- [ ] M
- [ ] N
- [ ] O
- [ ] P
- [ ] Q
- [ ] R
- [ ] S
- [ ] T
- [ ] U
- [ ] V
- [ ] W
- [ ] X
- [ ] Y
- [ ] Z