### PR TITLE
Migrate MonsterImporter, ItemImporter, and SpellImporter to v2

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -84,6 +84,7 @@ SHADOWDARK.apps.effect_panel.duration_label.x_years: "{years} Years Remaining"
 SHADOWDARK.apps.effect_panel.right_click_to_remove: "[Right click] Remove effect"
 SHADOWDARK.apps.item-importer.header: Item Importer
 SHADOWDARK.apps.item-importer.import_button: Import Item
+SHADOWDARK.apps.item-importer.placeholder: Paste item text here...
 SHADOWDARK.apps.item-importer.instruction1: 1. Copy item text from source material.
 SHADOWDARK.apps.item-importer.instruction2a: 2. Paste text into this box following the item format shown in the core rules.
 SHADOWDARK.apps.item-importer.instruction2b: Item Name
@@ -105,6 +106,7 @@ SHADOWDARK.apps.level-up.roll_talent: Roll Talent
 SHADOWDARK.apps.level-up.title: Leveling Up
 SHADOWDARK.apps.monster-importer.header: Monster Importer
 SHADOWDARK.apps.monster-importer.import_button: Import Monster
+SHADOWDARK.apps.monster-importer.placeholder: Paste monster text here...
 SHADOWDARK.apps.monster-importer.instruction1: 1. Copy monster text from source material.
 SHADOWDARK.apps.monster-importer.instruction2a: 2. Paste text into the text box following the monster format shown in the core rules. Add a blank line between each ability.
 SHADOWDARK.apps.monster-importer.instruction2b: Monster Name
@@ -142,6 +144,7 @@ SHADOWDARK.apps.spell-book.known: Known
 SHADOWDARK.apps.spell-book.title: Class Spell List
 SHADOWDARK.apps.spell-importer.header: Spell Importer
 SHADOWDARK.apps.spell-importer.import_button: Import Spell
+SHADOWDARK.apps.spell-importer.placeholder: Paste spell text here...
 SHADOWDARK.apps.spell-importer.instruction1: 1. Copy spell text from source material.
 SHADOWDARK.apps.spell-importer.instruction2a: 2. Paste text into this box following the spell format shown in the core rules.
 SHADOWDARK.apps.spell-importer.instruction2b: Spell Name

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -82,6 +82,7 @@ SHADOWDARK.apps.effect_panel.duration_label.x_seconds: "{seconds} Seconds Remain
 SHADOWDARK.apps.effect_panel.duration_label.x_weeks: "{weeks} Weeks Remaining"
 SHADOWDARK.apps.effect_panel.duration_label.x_years: "{years} Years Remaining"
 SHADOWDARK.apps.effect_panel.right_click_to_remove: "[Right click] Remove effect"
+SHADOWDARK.apps.item-importer.header: Item Importer
 SHADOWDARK.apps.item-importer.import_button: Import Item
 SHADOWDARK.apps.item-importer.instruction1: 1. Copy item text from source material.
 SHADOWDARK.apps.item-importer.instruction2a: 2. Paste text into this box following the item format shown in the core rules.
@@ -102,6 +103,7 @@ SHADOWDARK.apps.level-up.prompt: Not all required selections have been made. Con
 SHADOWDARK.apps.level-up.roll_boon: Roll Boon
 SHADOWDARK.apps.level-up.roll_talent: Roll Talent
 SHADOWDARK.apps.level-up.title: Leveling Up
+SHADOWDARK.apps.monster-importer.header: Monster Importer
 SHADOWDARK.apps.monster-importer.import_button: Import Monster
 SHADOWDARK.apps.monster-importer.instruction1: 1. Copy monster text from source material.
 SHADOWDARK.apps.monster-importer.instruction2a: 2. Paste text into the text box following the monster format shown in the core rules. Add a blank line between each ability.
@@ -138,6 +140,7 @@ SHADOWDARK.apps.solodark.roll_prompt: Roll Prompt
 SHADOWDARK.apps.solodark.title: SoloDark
 SHADOWDARK.apps.spell-book.known: Known
 SHADOWDARK.apps.spell-book.title: Class Spell List
+SHADOWDARK.apps.spell-importer.header: Spell Importer
 SHADOWDARK.apps.spell-importer.import_button: Import Spell
 SHADOWDARK.apps.spell-importer.instruction1: 1. Copy spell text from source material.
 SHADOWDARK.apps.spell-importer.instruction2a: 2. Paste text into this box following the spell format shown in the core rules.

--- a/system/src/apps/ItemImporterSD.mjs
+++ b/system/src/apps/ItemImporterSD.mjs
@@ -1,33 +1,38 @@
-export default class ItemImporterSD extends foundry.appv1.api.FormApplication {
+export default class ItemImporterSD extends foundry.applications.api.HandlebarsApplicationMixin(
+	foundry.applications.api.ApplicationV2
+) {
 	/**
 	 * Contains an importer function to import item stat blocks
 	 */
 
-	/** @inheritdoc */
-	static get defaultOptions() {
-		return foundry.utils.mergeObject(super.defaultOptions, {
-			classes: ["item-importer"],
-			width: 300,
-			resizable: false,
-		});
-	}
+	static DEFAULT_OPTIONS = {
+		id: "sd-item-importer",
+		tag: "form",
+		window: {
+			resizable: true,
+			title: "SHADOWDARK.apps.item-importer.title",
+			contentClasses: ["standard-form"],
+		},
+		position: {
+			width: 600,
+			height: 600,
+		},
+		form: {
+			handler: ItemImporterSD._onSubmitForm,
+			closeOnSubmit: false,
+		},
+	};
 
-	/** @inheritdoc */
-	get template() {
-		return "systems/shadowdark/templates/apps/item-importer.hbs";
-	}
+	static PARTS = {
+		form: {
+			template: "systems/shadowdark/templates/apps/item-importer.hbs",
+		},
+	};
 
-	/** @inheritdoc */
-	get title() {
-		const title = game.i18n.localize("SHADOWDARK.apps.item-importer.title");
-		return `${title}`;
-	}
-
-	/** @inheritdoc */
-	async _updateObject(event, formData) {
-		event.preventDefault();
+	/** @override */
+	static async _onSubmitForm(event, form, formData) {
 		try {
-			let newItem = await this._importItem(formData.itemText);
+			let newItem = await this._importItem(formData.object.itemText);
 			ui.notifications.info(`Successfully Created: ${newItem.name} [${newItem._id}]`);
 			ui.sidebar.activateTab("items");
 
@@ -35,12 +40,6 @@ export default class ItemImporterSD extends foundry.appv1.api.FormApplication {
 		catch(error) {
 			ui.notifications.error(`Failed to fully parse the item stat block. ${error}`);
 		}
-	}
-
-	/** @inheritdoc */
-	_onSubmit(event) {
-		event.preventDefault();
-		super._onSubmit(event);
 	}
 
 

--- a/system/src/apps/MonsterImporterSD.mjs
+++ b/system/src/apps/MonsterImporterSD.mjs
@@ -1,34 +1,38 @@
-export default class MonsterImporterSD extends foundry.appv1.api.FormApplication {
+export default class MonsterImporterSD extends foundry.applications.api.HandlebarsApplicationMixin(
+	foundry.applications.api.ApplicationV2
+) {
 	/**
 	 * Contains an importer function to import monster stat blocks
 	 */
 
-	/** @inheritdoc */
-	static get defaultOptions() {
-		return foundry.utils.mergeObject(super.defaultOptions, {
-			classes: ["monster-importer"],
+	static DEFAULT_OPTIONS = {
+		id: "sd-monster-importer",
+		tag: "form",
+		window: {
+			resizable: true,
+			title: "SHADOWDARK.apps.monster-importer.title",
+			contentClasses: ["standard-form"],
+		},
+		position: {
 			width: 600,
 			height: 600,
-			resizable: true,
-		});
-	}
+		},
+		form: {
+			handler: MonsterImporterSD._onSubmitForm,
+			closeOnSubmit: false,
+		},
+	};
 
-	/** @inheritdoc */
-	get template() {
-		return "systems/shadowdark/templates/apps/monster-importer.hbs";
-	}
+	static PARTS = {
+		form: {
+			template: "systems/shadowdark/templates/apps/monster-importer.hbs",
+		},
+	};
 
-	/** @inheritdoc */
-	get title() {
-		const title = game.i18n.localize("SHADOWDARK.apps.monster-importer.title");
-		return `${title}`;
-	}
-
-	/** @inheritdoc */
-	async _updateObject(event, formData) {
-		event.preventDefault();
+	/** @override */
+	static async _onSubmitForm(event, form, formData) {
 		try {
-			let newNPC = await this._importMonster(formData.monsterText);
+			let newNPC = await this._importMonster(formData.object.monsterText);
 			ui.notifications.info(`Successfully Created: ${newNPC.name} [${newNPC._id}]`);
 			ui.sidebar.activateTab("actors");
 
@@ -36,12 +40,6 @@ export default class MonsterImporterSD extends foundry.appv1.api.FormApplication
 		catch(error) {
 			ui.notifications.error(`Failed to fully parse the monster stat block. ${error}`);
 		}
-	}
-
-	/** @inheritdoc */
-	_onSubmit(event) {
-		event.preventDefault();
-		super._onSubmit(event);
 	}
 
 	_toCamelCase(str) {

--- a/system/src/apps/SpellImporterSD.mjs
+++ b/system/src/apps/SpellImporterSD.mjs
@@ -1,33 +1,38 @@
-export default class SpellImporter extends foundry.appv1.api.FormApplication {
+export default class SpellImporter extends foundry.applications.api.HandlebarsApplicationMixin(
+	foundry.applications.api.ApplicationV2
+) {
 	/**
 	 * Contains an importer function to import spell stat blocks
 	 */
 
-	/** @inheritdoc */
-	static get defaultOptions() {
-		return foundry.utils.mergeObject(super.defaultOptions, {
-			classes: ["spell-importer"],
-			width: 300,
-			resizable: false,
-		});
-	}
+	static DEFAULT_OPTIONS = {
+		id: "sd-spell-importer",
+		tag: "form",
+		window: {
+			resizable: true,
+			title: "SHADOWDARK.apps.spell-importer.title",
+			contentClasses: ["standard-form"],
+		},
+		position: {
+			width: 600,
+			height: 600,
+		},
+		form: {
+			handler: SpellImporter._onSubmitForm,
+			closeOnSubmit: false,
+		},
+	};
 
-	/** @inheritdoc */
-	get template() {
-		return "systems/shadowdark/templates/apps/spell-importer.hbs";
-	}
+	static PARTS = {
+		form: {
+			template: "systems/shadowdark/templates/apps/spell-importer.hbs",
+		},
+	};
 
-	/** @inheritdoc */
-	get title() {
-		const title = game.i18n.localize("SHADOWDARK.apps.spell-importer.title");
-		return `${title}`;
-	}
-
-	/** @inheritdoc */
-	async _updateObject(event, formData) {
-		event.preventDefault();
+	/** @override */
+	static async _onSubmitForm(event, form, formData) {
 		try {
-			let newSpell = await this._importSpell(formData.spellText);
+			let newSpell = await this._importSpell(formData.object.spellText);
 			ui.notifications.info(`Successfully Created: ${newSpell.name} [${newSpell._id}]`);
 			ui.sidebar.activateTab("items");
 
@@ -35,12 +40,6 @@ export default class SpellImporter extends foundry.appv1.api.FormApplication {
 		catch(error) {
 			ui.notifications.error(`Failed to fully parse the spell stat block. ${error}`);
 		}
-	}
-
-	/** @inheritdoc */
-	_onSubmit(event) {
-		event.preventDefault();
-		super._onSubmit(event);
 	}
 
 	_toCamelCase(str) {

--- a/system/templates/apps/item-importer.hbs
+++ b/system/templates/apps/item-importer.hbs
@@ -15,6 +15,6 @@
 		<button type="submit">{{localize "SHADOWDARK.apps.item-importer.import_button"}}</button>
 	</div>
 	<div class="flex1" style="display: flex; flex-direction: column;">
-		<textarea name="itemText" style="flex: 1; width: 100%; resize: none;"></textarea>
+		<textarea name="itemText" placeholder="{{localize "SHADOWDARK.apps.item-importer.placeholder"}}" style="flex: 1; width: 100%; resize: none;"></textarea>
 	</div>
 </div>

--- a/system/templates/apps/item-importer.hbs
+++ b/system/templates/apps/item-importer.hbs
@@ -1,25 +1,18 @@
-<form class="item-importer" autocomplete="off">
-	<section>
-		<div>
-			<p>{{localize "SHADOWDARK.apps.item-importer.instruction1"}}</p>
-			<hr />
-			<p>
-
-				{{localize "SHADOWDARK.apps.item-importer.instruction2a"}}<br>
-				<div style="border:1px solid black;background-color: lightgrey; font-size:0.65em;margin-left:50px;margin-right:50px;">
-					{{localize "SHADOWDARK.apps.item-importer.instruction2b"}}<br>
-					<i>{{localize "SHADOWDARK.apps.item-importer.instruction2c"}}</i><br>
-					{{localize "SHADOWDARK.apps.item-importer.instruction2d"}}
-				</div>
-			</p>
-			<textarea name="itemText" style="height:300px;"></textarea>
-			<hr />
-			<p>{{localize "SHADOWDARK.apps.item-importer.instruction3"}}</p>
-		</div>
-	</section>
-	<footer class="sheet-footer flexrow">
-		<button class="import">
-			{{localize "SHADOWDARK.apps.item-importer.import_button"}}
-		</button>
-	</footer>
-</form>
+<div class="flexrow" style="flex: 1; align-items: stretch; gap: 10px;">
+	<div style="width: 250px; flex: none; padding: 4px 0;">
+		<p>{{localize "SHADOWDARK.apps.item-importer.instruction1"}}</p>
+		<hr />
+		<p>{{localize "SHADOWDARK.apps.item-importer.instruction2a"}}</p>
+		<blockquote style="font-size: 0.85em; opacity: 0.8;">
+			{{localize "SHADOWDARK.apps.item-importer.instruction2b"}}<br>
+			<i>{{localize "SHADOWDARK.apps.item-importer.instruction2c"}}</i><br>
+			{{localize "SHADOWDARK.apps.item-importer.instruction2d"}}
+		</blockquote>
+		<hr />
+		<p>{{localize "SHADOWDARK.apps.item-importer.instruction3"}}</p>
+		<button type="submit">{{localize "SHADOWDARK.apps.item-importer.import_button"}}</button>
+	</div>
+	<div class="flex1" style="display: flex; flex-direction: column;">
+		<textarea name="itemText" style="flex: 1; width: 100%; resize: none;"></textarea>
+	</div>
+</div>

--- a/system/templates/apps/item-importer.hbs
+++ b/system/templates/apps/item-importer.hbs
@@ -1,5 +1,7 @@
 <div class="flexrow" style="flex: 1; align-items: stretch; gap: 10px;">
 	<div style="width: 250px; flex: none; padding: 4px 0;">
+		<h1 style="font-family: var(--font-header); font-size: 2.5em; text-align: center;">{{localize "SHADOWDARK.apps.item-importer.header"}}</h1>
+		<hr />
 		<p>{{localize "SHADOWDARK.apps.item-importer.instruction1"}}</p>
 		<hr />
 		<p>{{localize "SHADOWDARK.apps.item-importer.instruction2a"}}</p>

--- a/system/templates/apps/monster-importer.hbs
+++ b/system/templates/apps/monster-importer.hbs
@@ -1,29 +1,23 @@
-<form class="monster-importer" autocomplete="off">
-	<div class="flexrow" style="height:100%;">
-		<div style="width:250px;margin:5px;margin-right:10px;flex:none;">
-			<h1 style="font-family: 'Old Newspaper Font';font-size: 2.5em;text-align:center;">Monster Importer</h1>
-			<hr>
-			<p>{{localize "SHADOWDARK.apps.monster-importer.instruction1"}}</p>
-			<hr />
-			<p>{{localize "SHADOWDARK.apps.monster-importer.instruction2a"}}</p>
-
-				<div style="border:1px solid black;background-color: lightgrey; font-size:0.65em;margin-left:70px;margin-right:70px;">
-					{{localize "SHADOWDARK.apps.monster-importer.instruction2b"}}<br>
-					<i>{{localize "SHADOWDARK.apps.monster-importer.instruction2c"}}</i><br>
-					{{localize "SHADOWDARK.apps.monster-importer.instruction2d"}}<br>
-					{{localize "SHADOWDARK.apps.monster-importer.instruction2e"}} 1 <br>
-					<br>
-					{{localize "SHADOWDARK.apps.monster-importer.instruction2e"}} 2	<br>
-					<br>
-					{{localize "SHADOWDARK.apps.monster-importer.instruction2e"}} N
-				</div>
-
-			<hr />
-			3.
-			<button class="import">{{localize "SHADOWDARK.apps.monster-importer.import_button"}}</button>
-		</div>
-		<div class="flex1">
-			<textarea name="monsterText" style="height:100%;"></textarea>
-		</div>
+<div class="flexrow" style="flex: 1; align-items: stretch; gap: 10px;">
+	<div style="width: 250px; flex: none; padding: 4px 0;">
+		<p>{{localize "SHADOWDARK.apps.monster-importer.instruction1"}}</p>
+		<hr />
+		<p>{{localize "SHADOWDARK.apps.monster-importer.instruction2a"}}</p>
+		<blockquote style="font-size: 0.85em; opacity: 0.8;">
+			{{localize "SHADOWDARK.apps.monster-importer.instruction2b"}}<br>
+			<i>{{localize "SHADOWDARK.apps.monster-importer.instruction2c"}}</i><br>
+			{{localize "SHADOWDARK.apps.monster-importer.instruction2d"}}<br>
+			{{localize "SHADOWDARK.apps.monster-importer.instruction2e"}} 1<br>
+			<br>
+			{{localize "SHADOWDARK.apps.monster-importer.instruction2e"}} 2<br>
+			<br>
+			{{localize "SHADOWDARK.apps.monster-importer.instruction2e"}} N
+		</blockquote>
+		<hr />
+		<p>{{localize "SHADOWDARK.apps.monster-importer.instruction3"}}</p>
+		<button type="submit">{{localize "SHADOWDARK.apps.monster-importer.import_button"}}</button>
 	</div>
-</form>
+	<div class="flex1" style="display: flex; flex-direction: column;">
+		<textarea name="monsterText" style="flex: 1; width: 100%; resize: none;"></textarea>
+	</div>
+</div>

--- a/system/templates/apps/monster-importer.hbs
+++ b/system/templates/apps/monster-importer.hbs
@@ -1,5 +1,7 @@
 <div class="flexrow" style="flex: 1; align-items: stretch; gap: 10px;">
 	<div style="width: 250px; flex: none; padding: 4px 0;">
+		<h1 style="font-family: var(--font-header); font-size: 2.5em; text-align: center;">{{localize "SHADOWDARK.apps.monster-importer.header"}}</h1>
+		<hr />
 		<p>{{localize "SHADOWDARK.apps.monster-importer.instruction1"}}</p>
 		<hr />
 		<p>{{localize "SHADOWDARK.apps.monster-importer.instruction2a"}}</p>

--- a/system/templates/apps/monster-importer.hbs
+++ b/system/templates/apps/monster-importer.hbs
@@ -20,6 +20,6 @@
 		<button type="submit">{{localize "SHADOWDARK.apps.monster-importer.import_button"}}</button>
 	</div>
 	<div class="flex1" style="display: flex; flex-direction: column;">
-		<textarea name="monsterText" style="flex: 1; width: 100%; resize: none;"></textarea>
+		<textarea name="monsterText" placeholder="{{localize "SHADOWDARK.apps.monster-importer.placeholder"}}" style="flex: 1; width: 100%; resize: none;"></textarea>
 	</div>
 </div>

--- a/system/templates/apps/spell-importer.hbs
+++ b/system/templates/apps/spell-importer.hbs
@@ -1,27 +1,20 @@
-<form class="spell-importer" autocomplete="off">
-	<section>
-		<div>
-			<p>{{localize "SHADOWDARK.apps.spell-importer.instruction1"}}</p>
-			<hr />
-			<p>
-				
-				{{localize "SHADOWDARK.apps.spell-importer.instruction2a"}}<br>
-				<div style="border:1px solid black;background-color: lightgrey; font-size:0.65em;margin-left:50px;margin-right:50px;">
-					{{localize "SHADOWDARK.apps.spell-importer.instruction2b"}}<br>
-					<i>{{localize "SHADOWDARK.apps.spell-importer.instruction2c"}}</i><br>
-					<strong>{{localize "SHADOWDARK.apps.spell-importer.instruction2d"}}</strong><br>
-					<strong>{{localize "SHADOWDARK.apps.spell-importer.instruction2e"}}</strong><br>
-					{{localize "SHADOWDARK.apps.spell-importer.instruction2f"}}
-				</div>
-			</p>
-			<textarea name="spellText" style="height:300px;"></textarea>
-			<hr />
-			<p>{{localize "SHADOWDARK.apps.spell-importer.instruction3"}}</p>
-		</div>
-	</section>
-	<footer class="sheet-footer flexrow">
-		<button class="import">
-			{{localize "SHADOWDARK.apps.spell-importer.import_button"}}
-		</button>
-	</footer>
-</form>
+<div class="flexrow" style="flex: 1; align-items: stretch; gap: 10px;">
+	<div style="width: 250px; flex: none; padding: 4px 0;">
+		<p>{{localize "SHADOWDARK.apps.spell-importer.instruction1"}}</p>
+		<hr />
+		<p>{{localize "SHADOWDARK.apps.spell-importer.instruction2a"}}</p>
+		<blockquote style="font-size: 0.85em; opacity: 0.8;">
+			{{localize "SHADOWDARK.apps.spell-importer.instruction2b"}}<br>
+			<i>{{localize "SHADOWDARK.apps.spell-importer.instruction2c"}}</i><br>
+			<strong>{{localize "SHADOWDARK.apps.spell-importer.instruction2d"}}</strong><br>
+			<strong>{{localize "SHADOWDARK.apps.spell-importer.instruction2e"}}</strong><br>
+			{{localize "SHADOWDARK.apps.spell-importer.instruction2f"}}
+		</blockquote>
+		<hr />
+		<p>{{localize "SHADOWDARK.apps.spell-importer.instruction3"}}</p>
+		<button type="submit">{{localize "SHADOWDARK.apps.spell-importer.import_button"}}</button>
+	</div>
+	<div class="flex1" style="display: flex; flex-direction: column;">
+		<textarea name="spellText" style="flex: 1; width: 100%; resize: none;"></textarea>
+	</div>
+</div>

--- a/system/templates/apps/spell-importer.hbs
+++ b/system/templates/apps/spell-importer.hbs
@@ -1,5 +1,7 @@
 <div class="flexrow" style="flex: 1; align-items: stretch; gap: 10px;">
 	<div style="width: 250px; flex: none; padding: 4px 0;">
+		<h1 style="font-family: var(--font-header); font-size: 2.5em; text-align: center;">{{localize "SHADOWDARK.apps.spell-importer.header"}}</h1>
+		<hr />
 		<p>{{localize "SHADOWDARK.apps.spell-importer.instruction1"}}</p>
 		<hr />
 		<p>{{localize "SHADOWDARK.apps.spell-importer.instruction2a"}}</p>

--- a/system/templates/apps/spell-importer.hbs
+++ b/system/templates/apps/spell-importer.hbs
@@ -17,6 +17,6 @@
 		<button type="submit">{{localize "SHADOWDARK.apps.spell-importer.import_button"}}</button>
 	</div>
 	<div class="flex1" style="display: flex; flex-direction: column;">
-		<textarea name="spellText" style="flex: 1; width: 100%; resize: none;"></textarea>
+		<textarea name="spellText" placeholder="{{localize "SHADOWDARK.apps.spell-importer.placeholder"}}" style="flex: 1; width: 100%; resize: none;"></textarea>
 	</div>
 </div>


### PR DESCRIPTION
While looking at the CSS structure for ApplicationV2 (#1210), I noticed that the importers do not have specific CSS defined. So these applications can just be ported over to V2.

  - These are the first three V2 migrations, more to come
  - Business logic is unchanged — only the V1→V2 plumbing and template layout
  - The three importers now share a unified layout (they didn't before)
  - We could generalize the three importers into a base class and inherit from them for each. That would save a lot of code