### PR TITLE
Add all magic items from core rulebook

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,7 @@
 - [#1202] Ammo type should be overridable as part of the attack roll dialog
 - [#1216] Allow Versatile weapons to be switched between 1H and 2H in the inventory so correct damage is displayed/rolled
 - [#1252] Restore unidentified item name and description when identified toggled off
+- [#1268] Added magic items from core rules and Cursed Scrolls 1-3 *(Ashley Towner)*
 
 
 ## Bugfixes

--- a/data/packs/magic-items.db/ac_bonus__J71TDxKnOnztuE6t.json
+++ b/data/packs/magic-items.db/ac_bonus__J71TDxKnOnztuE6t.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "AC Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/ac_bonus__SRuuhmxcNFfK8yUo.json
+++ b/data/packs/magic-items.db/ac_bonus__SRuuhmxcNFfK8yUo.json
@@ -1,0 +1,29 @@
+{
+	"_id": "SRuuhmxcNFfK8yUo",
+	"_key": "!items.effects!fntDmrpNulld7y2r.SRuuhmxcNFfK8yUo",
+	"changes": [
+		{
+			"key": "system.attributes.ac.value",
+			"mode": 2,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/skills/melee/shield-block-gray-orange.webp",
+	"name": "AC Bonus",
+	"origin": "Item.a9GWLEEGCKGrtN6D",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/ac_bonus__SRuuhmxcNFfK8yUo.json
+++ b/data/packs/magic-items.db/ac_bonus__SRuuhmxcNFfK8yUo.json
@@ -8,7 +8,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "AC Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/ac_bonus__UmHdci1cvynol7xU.json
+++ b/data/packs/magic-items.db/ac_bonus__UmHdci1cvynol7xU.json
@@ -1,0 +1,31 @@
+{
+	"_id": "UmHdci1cvynol7xU",
+	"_key": "!items.effects!LhREsz1KVI5yuEwM.UmHdci1cvynol7xU",
+	"changes": [
+		{
+			"key": "system.attributes.ac.value",
+			"mode": 2,
+			"value": "2"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/skills/melee/shield-block-gray-orange.webp",
+	"name": "AC Bonus",
+	"origin": "Item.hIWLvLNP6JWumyrw",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/ac_bonus__UmHdci1cvynol7xU.json
+++ b/data/packs/magic-items.db/ac_bonus__UmHdci1cvynol7xU.json
@@ -8,7 +8,7 @@
 			"value": "2"
 		}
 	],
-	"description": "",
+	"description": "AC Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/ac_bonus__naxiMCPRWIxWceVj.json
+++ b/data/packs/magic-items.db/ac_bonus__naxiMCPRWIxWceVj.json
@@ -1,0 +1,29 @@
+{
+	"_id": "naxiMCPRWIxWceVj",
+	"_key": "!items.effects!8RyBRclanxBD4pMx.naxiMCPRWIxWceVj",
+	"changes": [
+		{
+			"key": "system.attributes.ac.value",
+			"mode": 2,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/skills/melee/shield-block-gray-orange.webp",
+	"name": "AC Bonus",
+	"origin": "Item.lIQyD40OcRKVneot",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/ac_bonus__naxiMCPRWIxWceVj.json
+++ b/data/packs/magic-items.db/ac_bonus__naxiMCPRWIxWceVj.json
@@ -8,7 +8,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "AC Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/additional_gear_slots__MquW5uUJ7QQO7eFk.json
+++ b/data/packs/magic-items.db/additional_gear_slots__MquW5uUJ7QQO7eFk.json
@@ -9,7 +9,7 @@
 			"value": "10"
 		}
 	],
-	"description": "",
+	"description": "Additional Gear Slots",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/advantage_on_attacks_vs_undead__CcqfuguaihVg3TY3.json
+++ b/data/packs/magic-items.db/advantage_on_attacks_vs_undead__CcqfuguaihVg3TY3.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Advantage on attacks vs Undead",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/advantage_on_attacks_vs_undead__CcqfuguaihVg3TY3.json
+++ b/data/packs/magic-items.db/advantage_on_attacks_vs_undead__CcqfuguaihVg3TY3.json
@@ -1,0 +1,38 @@
+{
+	"_id": "CcqfuguaihVg3TY3",
+	"_key": "!items.effects!SuPwL1LQKe8DdaRq.CcqfuguaihVg3TY3",
+	"changes": [
+		{
+			"key": "system.roll.melee.advantage.this",
+			"mode": 2,
+			"priority": null,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"flags": {
+		"shadowdark": {
+			"situational": true
+		}
+	},
+	"img": "icons/commodities/tech/cog-steel-grey.webp",
+	"name": "Advantage on attacks vs Undead",
+	"origin": "Compendium.shadowdark.magic-items.Item.SuPwL1LQKe8DdaRq",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/advantage_vs_poison__Jezaa6jJyGQpprzu.json
+++ b/data/packs/magic-items.db/advantage_vs_poison__Jezaa6jJyGQpprzu.json
@@ -3,7 +3,7 @@
 	"_key": "!items.effects!MyHXrPewu36OmWB6.Jezaa6jJyGQpprzu",
 	"changes": [
 		{
-			"key": "system.roll.stat.advantage.all",
+			"key": "system.roll.stat.advantage.con",
 			"mode": 2,
 			"priority": null,
 			"value": "1"

--- a/data/packs/magic-items.db/advantage_vs_poison__Jezaa6jJyGQpprzu.json
+++ b/data/packs/magic-items.db/advantage_vs_poison__Jezaa6jJyGQpprzu.json
@@ -1,0 +1,38 @@
+{
+	"_id": "Jezaa6jJyGQpprzu",
+	"_key": "!items.effects!MyHXrPewu36OmWB6.Jezaa6jJyGQpprzu",
+	"changes": [
+		{
+			"key": "system.roll.stat.advantage.all",
+			"mode": 2,
+			"priority": null,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"flags": {
+		"shadowdark": {
+			"situational": true
+		}
+	},
+	"img": "icons/commodities/tech/cog-steel-grey.webp",
+	"name": "Advantage vs Poison",
+	"origin": "Compendium.shadowdark.magic-items.Item.MyHXrPewu36OmWB6",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/advantage_vs_poison__Jezaa6jJyGQpprzu.json
+++ b/data/packs/magic-items.db/advantage_vs_poison__Jezaa6jJyGQpprzu.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Advantage vs Poison",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/advantage_vs_unnatural_creatures___outsiders__6mClhm9ShmrgbUEL.json
+++ b/data/packs/magic-items.db/advantage_vs_unnatural_creatures___outsiders__6mClhm9ShmrgbUEL.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Advantage vs Unnatural Creatures & Outsiders",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/advantage_vs_unnatural_creatures___outsiders__6mClhm9ShmrgbUEL.json
+++ b/data/packs/magic-items.db/advantage_vs_unnatural_creatures___outsiders__6mClhm9ShmrgbUEL.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "Advantage vs Unnatural Creatures & Outsiders",
+	"description": "Advantage on attacks vs unnatural creatures and outsiders",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/advantage_vs_unnatural_creatures___outsiders__6mClhm9ShmrgbUEL.json
+++ b/data/packs/magic-items.db/advantage_vs_unnatural_creatures___outsiders__6mClhm9ShmrgbUEL.json
@@ -1,0 +1,38 @@
+{
+	"_id": "6mClhm9ShmrgbUEL",
+	"_key": "!items.effects!DtswEluGPMrFpzW1.6mClhm9ShmrgbUEL",
+	"changes": [
+		{
+			"key": "system.roll.ranged.advantage.this",
+			"mode": 2,
+			"priority": null,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"flags": {
+		"shadowdark": {
+			"situational": true
+		}
+	},
+	"img": "icons/commodities/tech/cog-steel-grey.webp",
+	"name": "Advantage vs Unnatural Creatures & Outsiders",
+	"origin": "Compendium.shadowdark.magic-items.Item.DtswEluGPMrFpzW1",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/alabaster_destrier__T7VGBPF272LjO0jB.json
+++ b/data/packs/magic-items.db/alabaster_destrier__T7VGBPF272LjO0jB.json
@@ -3,6 +3,8 @@
 	"_key": "!items!T7VGBPF272LjO0jB",
 	"effects": [
 	],
+	"flags": {
+	},
 	"folder": null,
 	"img": "icons/environment/creatures/horse-white.webp",
 	"name": "Alabaster Destrier",

--- a/data/packs/magic-items.db/alabaster_destrier__T7VGBPF272LjO0jB.json
+++ b/data/packs/magic-items.db/alabaster_destrier__T7VGBPF272LjO0jB.json
@@ -1,0 +1,44 @@
+{
+	"_id": "T7VGBPF272LjO0jB",
+	"_key": "!items!T7VGBPF272LjO0jB",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/environment/creatures/horse-white.webp",
+	"name": "Alabaster Destrier",
+	"system": {
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A smooth, pearly statuette of a running horse.</em></p><p></p><p><strong>Benefit.</strong> Once per day, the wielder can speak the command word to turn the statuette into a @UUID[Compendium.shadowdark.monsters.Actor.5Tp7B3qOMEAdMkJ8]{pegasus} that accepts neutral or lawful riders. The statuette remains in this form for 1 hour.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/alabaster_destrier__T7VGBPF272LjO0jB.json
+++ b/data/packs/magic-items.db/alabaster_destrier__T7VGBPF272LjO0jB.json
@@ -6,7 +6,7 @@
 	"flags": {
 	},
 	"folder": null,
-	"img": "icons/environment/creatures/horse-white.webp",
+	"img": "icons/sundries/gaming/chess-knight-white.webp",
 	"name": "Alabaster Destrier",
 	"system": {
 		"broken": false,

--- a/data/packs/magic-items.db/amulet_of_secrecy__RQ4nLtB4DgQiTt2d.json
+++ b/data/packs/magic-items.db/amulet_of_secrecy__RQ4nLtB4DgQiTt2d.json
@@ -3,6 +3,8 @@
 	"_key": "!items!RQ4nLtB4DgQiTt2d",
 	"effects": [
 	],
+	"flags": {
+	},
 	"folder": null,
 	"img": "icons/equipment/neck/amulet-carved-stone-eye.webp",
 	"name": "Amulet of Secrecy",

--- a/data/packs/magic-items.db/amulet_of_secrecy__RQ4nLtB4DgQiTt2d.json
+++ b/data/packs/magic-items.db/amulet_of_secrecy__RQ4nLtB4DgQiTt2d.json
@@ -1,0 +1,44 @@
+{
+	"_id": "RQ4nLtB4DgQiTt2d",
+	"_key": "!items!RQ4nLtB4DgQiTt2d",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/equipment/neck/amulet-carved-stone-eye.webp",
+	"name": "Amulet of Secrecy",
+	"system": {
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A heavy, flat pendant carved with a lidded eye.</em></p><p><strong>Benefit.</strong> You can't be detected by divination magic such as the scrying spell or a Crystal Ball while wearing this amulet.</p><p><strong>Curse.</strong> You constantly have the sensation of being watched.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/amulet_of_vitality__qHyL2dlqQaxwMzKX.json
+++ b/data/packs/magic-items.db/amulet_of_vitality__qHyL2dlqQaxwMzKX.json
@@ -1,0 +1,44 @@
+{
+	"_id": "qHyL2dlqQaxwMzKX",
+	"_key": "!items!qHyL2dlqQaxwMzKX",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/equipment/neck/amulet-geometric-gold-red.webp",
+	"name": "Amulet of Vitality",
+	"system": {
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A gold amulet with a red ruby teardrop at its center.</em></p><p><strong>Benefit.</strong> Your Constitution stat becomes 18 (+4) while wearing this amulet.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/amulet_of_vitality__qHyL2dlqQaxwMzKX.json
+++ b/data/packs/magic-items.db/amulet_of_vitality__qHyL2dlqQaxwMzKX.json
@@ -2,7 +2,10 @@
 	"_id": "qHyL2dlqQaxwMzKX",
 	"_key": "!items!qHyL2dlqQaxwMzKX",
 	"effects": [
+		"s6ifDUJHIkwx5wvx"
 	],
+	"flags": {
+	},
 	"folder": null,
 	"img": "icons/equipment/neck/amulet-geometric-gold-red.webp",
 	"name": "Amulet of Vitality",

--- a/data/packs/magic-items.db/armor_of_saint_terragnis__fKKSAFFX6vVGEzSi.json
+++ b/data/packs/magic-items.db/armor_of_saint_terragnis__fKKSAFFX6vVGEzSi.json
@@ -25,7 +25,7 @@
 			"gp": null,
 			"sp": 0
 		},
-		"description": "<p><em>Golden plate mail carved from head to toe with warrior angels.</em></p><p><strong>Bonus.</strong> +3 plate mail. Only a lawful worshipper of Saint Terragnis can wear this armor.</p><p><strong>Benefit.</strong> Hostile spells that target you are DC 18 to cast. Once per month, you can summon an Avatar of Saint Terragnis (treat as an archangel) to fight by your side for 10 rounds.</p>",
+		"description": "<p><em>Golden plate mail carved from head to toe with warrior angels.</em></p><p><strong>Bonus.</strong> +3 plate mail. Only a lawful worshipper of Saint Terragnis can wear this armor.</p><p><strong>Benefit.</strong> Hostile spells that target you are DC 18 to cast. Once per month, you can summon an Avatar of Saint Terragnis (treat as an @UUID[Compendium.shadowdark.monsters.Actor.GzjB5DsORxRuX2MV]{archangel}) to fight by your side for 10 rounds.</p>",
 		"equipped": false,
 		"isAmmunition": false,
 		"isPhysical": true,

--- a/data/packs/magic-items.db/armor_of_saint_terragnis__fKKSAFFX6vVGEzSi.json
+++ b/data/packs/magic-items.db/armor_of_saint_terragnis__fKKSAFFX6vVGEzSi.json
@@ -1,0 +1,48 @@
+{
+	"_id": "fKKSAFFX6vVGEzSi",
+	"_key": "!items!fKKSAFFX6vVGEzSi",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/equipment/chest/breastplate-layered-steel.webp",
+	"name": "Armor of Saint Terragnis",
+	"system": {
+		"ac": {
+			"attribute": "",
+			"base": 18,
+			"modifier": 0
+		},
+		"baseArmor": "plate-mail",
+		"bonuses": {
+			"acBonus": "3"
+		},
+		"broken": false,
+		"canBeEquipped": true,
+		"cost": {
+			"cp": 0,
+			"gp": null,
+			"sp": 0
+		},
+		"description": "<p><em>Golden plate mail carved from head to toe with warrior angels.</em></p><p><strong>Bonus.</strong> +3 plate mail. Only a lawful worshipper of Saint Terragnis can wear this armor.</p><p><strong>Benefit.</strong> Hostile spells that target you are DC 18 to cast. Once per month, you can summon an Avatar of Saint Terragnis (treat as an archangel) to fight by your side for 10 rounds.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"magicItem": true,
+		"predefinedEffects": "",
+		"properties": [
+			"Compendium.shadowdark.properties.Item.WhfSBiji8VG1mMzV",
+			"Compendium.shadowdark.properties.Item.kBLs47xhX1snaDGA"
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 3
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}

--- a/data/packs/magic-items.db/armor_of_saint_terragnis__fKKSAFFX6vVGEzSi.json
+++ b/data/packs/magic-items.db/armor_of_saint_terragnis__fKKSAFFX6vVGEzSi.json
@@ -3,14 +3,16 @@
 	"_key": "!items!fKKSAFFX6vVGEzSi",
 	"effects": [
 	],
+	"flags": {
+	},
 	"folder": null,
 	"img": "icons/equipment/chest/breastplate-layered-steel.webp",
 	"name": "Armor of Saint Terragnis",
 	"system": {
 		"ac": {
 			"attribute": "",
-			"base": 18,
-			"modifier": 0
+			"base": 15,
+			"modifier": 3
 		},
 		"baseArmor": "plate-mail",
 		"bonuses": {

--- a/data/packs/magic-items.db/armor_of_the_oni__hcC1kuGgQ2VdnHmj.json
+++ b/data/packs/magic-items.db/armor_of_the_oni__hcC1kuGgQ2VdnHmj.json
@@ -3,7 +3,8 @@
 	"_key": "!items!hcC1kuGgQ2VdnHmj",
 	"effects": [
 		"n3Z0tBxloczqrb2w",
-		"SzyJeSkWrWDD64zP"
+		"SzyJeSkWrWDD64zP",
+		"phVQo5ikKtoR4emZ"
 	],
 	"flags": {
 	},

--- a/data/packs/magic-items.db/armor_of_the_oni__hcC1kuGgQ2VdnHmj.json
+++ b/data/packs/magic-items.db/armor_of_the_oni__hcC1kuGgQ2VdnHmj.json
@@ -3,16 +3,18 @@
 	"_key": "!items!hcC1kuGgQ2VdnHmj",
 	"effects": [
 		"n3Z0tBxloczqrb2w",
-		"neOYG1GjgRxHKIMr"
+		"SzyJeSkWrWDD64zP"
 	],
+	"flags": {
+	},
 	"folder": null,
 	"img": "icons/equipment/chest/breastplate-banded-steel-gold.webp",
 	"name": "Armor of the Oni",
 	"system": {
 		"ac": {
 			"attribute": "",
-			"base": 16,
-			"modifier": 0
+			"base": 15,
+			"modifier": 1
 		},
 		"baseArmor": "plate-mail",
 		"bonuses": {
@@ -32,6 +34,8 @@
 		"languages": "Compendium.shadowdark.languages.Item.b5yBrLaRIl7ZEWKu",
 		"magicItem": true,
 		"properties": [
+			"Compendium.shadowdark.properties.Item.kBLs47xhX1snaDGA",
+			"Compendium.shadowdark.properties.Item.WhfSBiji8VG1mMzV"
 		],
 		"quantity": 1,
 		"slots": {

--- a/data/packs/magic-items.db/armor_of_the_oni__hcC1kuGgQ2VdnHmj.json
+++ b/data/packs/magic-items.db/armor_of_the_oni__hcC1kuGgQ2VdnHmj.json
@@ -42,7 +42,7 @@
 		"slots": {
 			"free_carry": 0,
 			"per_slot": 1,
-			"slots_used": 1
+			"slots_used": 3
 		},
 		"source": {
 			"title": "core-rules"

--- a/data/packs/magic-items.db/armor_of_the_oni__hcC1kuGgQ2VdnHmj.json
+++ b/data/packs/magic-items.db/armor_of_the_oni__hcC1kuGgQ2VdnHmj.json
@@ -1,0 +1,48 @@
+{
+	"_id": "hcC1kuGgQ2VdnHmj",
+	"_key": "!items!hcC1kuGgQ2VdnHmj",
+	"effects": [
+		"n3Z0tBxloczqrb2w",
+		"neOYG1GjgRxHKIMr"
+	],
+	"folder": null,
+	"img": "icons/equipment/chest/breastplate-banded-steel-gold.webp",
+	"name": "Armor of the Oni",
+	"system": {
+		"ac": {
+			"attribute": "",
+			"base": 16,
+			"modifier": 0
+		},
+		"baseArmor": "plate-mail",
+		"bonuses": {
+			"meleeAttackBonus": "1"
+		},
+		"broken": false,
+		"canBeEquipped": true,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>Black plate mail of lacquered, ironwood panels. The helm's visor is the face of a snarling oni.</em></p><p><strong>Bonus.</strong> +1 plate mail.</p><p><strong>Benefit.</strong> You can speak and understand Diabolic. Your melee weapon attacks deal +1 damage.</p><p><strong>Curse.</strong> You have disadvantage on attacks and spellcasting checks against demons.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"languages": "Compendium.shadowdark.languages.Item.b5yBrLaRIl7ZEWKu",
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}

--- a/data/packs/magic-items.db/asterion__X5FwZjvgzeSXvNDQ.json
+++ b/data/packs/magic-items.db/asterion__X5FwZjvgzeSXvNDQ.json
@@ -38,7 +38,7 @@
 			"slots_used": 2
 		},
 		"source": {
-			"title": "core-rules"
+			"title": "quickstart"
 		},
 		"stashed": false,
 		"type": "melee"

--- a/data/packs/magic-items.db/attack_damage_bonus__78SoFRRmEjEMdPIT.json
+++ b/data/packs/magic-items.db/attack_damage_bonus__78SoFRRmEjEMdPIT.json
@@ -9,7 +9,7 @@
 			"value": "2"
 		}
 	],
-	"description": "",
+	"description": "Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/attack_damage_bonus__E7DKiIaxjDrxq64c.json
+++ b/data/packs/magic-items.db/attack_damage_bonus__E7DKiIaxjDrxq64c.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/attack_damage_bonus__FqtIDxjhOFDvkQFn.json
+++ b/data/packs/magic-items.db/attack_damage_bonus__FqtIDxjhOFDvkQFn.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/attack_damage_bonus__JAfTcoh8jcncSGJM.json
+++ b/data/packs/magic-items.db/attack_damage_bonus__JAfTcoh8jcncSGJM.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/attack_damage_bonus__Qj2rqAj7XeIsjzzs.json
+++ b/data/packs/magic-items.db/attack_damage_bonus__Qj2rqAj7XeIsjzzs.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/attack_damage_bonus__pwG7d70XZD8JJL5p.json
+++ b/data/packs/magic-items.db/attack_damage_bonus__pwG7d70XZD8JJL5p.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/attack_roll_bonus__4QneUXW9pG2CMpKS.json
+++ b/data/packs/magic-items.db/attack_roll_bonus__4QneUXW9pG2CMpKS.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/attack_roll_bonus__9qMTrleWtCMKO3Xl.json
+++ b/data/packs/magic-items.db/attack_roll_bonus__9qMTrleWtCMKO3Xl.json
@@ -9,7 +9,7 @@
 			"value": "2"
 		}
 	],
-	"description": "",
+	"description": "Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/attack_roll_bonus__A3cEweAbyqxNxdzl.json
+++ b/data/packs/magic-items.db/attack_roll_bonus__A3cEweAbyqxNxdzl.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/attack_roll_bonus__HhILvM8lD0Nby5gq.json
+++ b/data/packs/magic-items.db/attack_roll_bonus__HhILvM8lD0Nby5gq.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/attack_roll_bonus__Rzbo47LZEvpyHfqg.json
+++ b/data/packs/magic-items.db/attack_roll_bonus__Rzbo47LZEvpyHfqg.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/attack_roll_bonus__qrgFpY2mTci173wM.json
+++ b/data/packs/magic-items.db/attack_roll_bonus__qrgFpY2mTci173wM.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/bag_of_badgers__DyzDQtoj6Y7Qv1AE.json
+++ b/data/packs/magic-items.db/bag_of_badgers__DyzDQtoj6Y7Qv1AE.json
@@ -1,0 +1,44 @@
+{
+	"_id": "DyzDQtoj6Y7Qv1AE",
+	"_key": "!items!DyzDQtoj6Y7Qv1AE",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/containers/bags/coinpouch-simple-leather-brown.webp",
+	"name": "Bag of Badgers",
+	"system": {
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A gray, fraying sack matted with white, bristly hair.</em></p><p><strong>Benefit.</strong> Once per day, you can reach inside the bag and pull out an angry @UUID[Compendium.shadowdark.monsters.Actor.VM65vWCNjlx5tKTP]{badger}. You can throw the badger up to a near distance. The badger attacks the nearest creature for 3 rounds before waddling away.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/bag_of_badgers__DyzDQtoj6Y7Qv1AE.json
+++ b/data/packs/magic-items.db/bag_of_badgers__DyzDQtoj6Y7Qv1AE.json
@@ -3,6 +3,8 @@
 	"_key": "!items!DyzDQtoj6Y7Qv1AE",
 	"effects": [
 	],
+	"flags": {
+	},
 	"folder": null,
 	"img": "icons/containers/bags/coinpouch-simple-leather-brown.webp",
 	"name": "Bag of Badgers",

--- a/data/packs/magic-items.db/bag_of_devouring__qcVQraEjj6CK0bpf.json
+++ b/data/packs/magic-items.db/bag_of_devouring__qcVQraEjj6CK0bpf.json
@@ -3,6 +3,8 @@
 	"_key": "!items!qcVQraEjj6CK0bpf",
 	"effects": [
 	],
+	"flags": {
+	},
 	"folder": null,
 	"img": "icons/containers/bags/sack-cloth-purple.webp",
 	"name": "Bag of Devouring",

--- a/data/packs/magic-items.db/bag_of_devouring__qcVQraEjj6CK0bpf.json
+++ b/data/packs/magic-items.db/bag_of_devouring__qcVQraEjj6CK0bpf.json
@@ -1,0 +1,44 @@
+{
+	"_id": "qcVQraEjj6CK0bpf",
+	"_key": "!items!qcVQraEjj6CK0bpf",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/containers/bags/sack-cloth-purple.webp",
+	"name": "Bag of Devouring",
+	"system": {
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A worn, leather pouch with tight drawstrings.</em></p><p><strong>Curse.</strong> This bag devours and destroys anything placed inside it in 1d6 rounds.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/bead_of_force__FTaL3OmCavdb0AIs.json
+++ b/data/packs/magic-items.db/bead_of_force__FTaL3OmCavdb0AIs.json
@@ -1,0 +1,44 @@
+{
+	"_id": "FTaL3OmCavdb0AIs",
+	"_key": "!items!FTaL3OmCavdb0AIs",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/commodities/gems/pearl-swirl-blue.webp",
+	"name": "Bead of Force",
+	"system": {
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A marble with a blue ring of light glowing softly inside it.</em></p><p><strong>Benefit.</strong> You can throw this bead at one target up to a near distance. If you hit, the target becomes caught in a @UUID[Compendium.shadowdark.spells.Item.B091clRxdPW3SQ4G]{resilient sphere} spell (pg. 69).</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/bead_of_force__FTaL3OmCavdb0AIs.json
+++ b/data/packs/magic-items.db/bead_of_force__FTaL3OmCavdb0AIs.json
@@ -3,6 +3,8 @@
 	"_key": "!items!FTaL3OmCavdb0AIs",
 	"effects": [
 	],
+	"flags": {
+	},
 	"folder": null,
 	"img": "icons/commodities/gems/pearl-swirl-blue.webp",
 	"name": "Bead of Force",

--- a/data/packs/magic-items.db/blade_of_vengeance__SuPwL1LQKe8DdaRq.json
+++ b/data/packs/magic-items.db/blade_of_vengeance__SuPwL1LQKe8DdaRq.json
@@ -3,7 +3,8 @@
 	"_key": "!items!SuPwL1LQKe8DdaRq",
 	"effects": [
 		"WhT5yrk9W2vCWs6X",
-		"9ScRP2bW6K4ljUpQ"
+		"9ScRP2bW6K4ljUpQ",
+		"CcqfuguaihVg3TY3"
 	],
 	"flags": {
 	},

--- a/data/packs/magic-items.db/blade_of_vengeance__SuPwL1LQKe8DdaRq.json
+++ b/data/packs/magic-items.db/blade_of_vengeance__SuPwL1LQKe8DdaRq.json
@@ -1,0 +1,58 @@
+{
+	"_id": "SuPwL1LQKe8DdaRq",
+	"_key": "!items!SuPwL1LQKe8DdaRq",
+	"effects": [
+		"MosrS1dHHXThJ96N"
+	],
+	"folder": null,
+	"img": "icons/weapons/swords/greatsword-crossguard-embossed-gold.webp",
+	"name": "Blade of Vengeance",
+	"system": {
+		"ammoClass": "",
+		"baseWeapon": "bastard-sword",
+		"bonuses": {
+			"attackBonus": "1",
+			"critical": {
+				"failureThreshold": 1,
+				"multiplier": 2,
+				"successThreshold": 20
+			},
+			"damageBonus": 0,
+			"damageMultiplier": 1
+		},
+		"broken": false,
+		"canBeEquipped": true,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"damage": {
+			"numDice": 1,
+			"oneHanded": "d8",
+			"twoHanded": "d10"
+		},
+		"description": "<p><em>A gray blade with a diamond- cut ruby in the pommel. It whistles sharply with each slice.</em></p><p><strong>Bonus.</strong> +2 bastard sword. Cannot be wielded by undead.</p><p><strong>Benefit.</strong> You have advantage on attacks against undead creatures with this sword. You can use the sword to cast @UUID[Compendium.shadowdark.spells.Item.mByUvcHIVEPWscfH]{turn undead }once per day (+4 bonus).</p><p><strong>Personality.</strong> Lawful. Grim, suspicious. Forged as a failsafe against the Witch-Kings if they should fall to darkness, which they did. Demands they be slain.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.qEIYaQ9j2EUmSrx6"
+		],
+		"quantity": 1,
+		"range": "close",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 2
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"type": "melee",
+		"weaponMastery": false
+	},
+	"type": "Weapon"
+}

--- a/data/packs/magic-items.db/blade_of_vengeance__SuPwL1LQKe8DdaRq.json
+++ b/data/packs/magic-items.db/blade_of_vengeance__SuPwL1LQKe8DdaRq.json
@@ -2,8 +2,11 @@
 	"_id": "SuPwL1LQKe8DdaRq",
 	"_key": "!items!SuPwL1LQKe8DdaRq",
 	"effects": [
-		"MosrS1dHHXThJ96N"
+		"WhT5yrk9W2vCWs6X",
+		"9ScRP2bW6K4ljUpQ"
 	],
+	"flags": {
+	},
 	"folder": null,
 	"img": "icons/weapons/swords/greatsword-crossguard-embossed-gold.webp",
 	"name": "Blade of Vengeance",

--- a/data/packs/magic-items.db/bloodlust__Mb7OBENXa5XnClS9.json
+++ b/data/packs/magic-items.db/bloodlust__Mb7OBENXa5XnClS9.json
@@ -39,7 +39,7 @@
 			"slots_used": 2
 		},
 		"source": {
-			"title": "core-rules"
+			"title": "quickstart"
 		},
 		"stashed": false,
 		"type": "melee"

--- a/data/packs/magic-items.db/bonus_to_control_water__0SIRUg3EWmVGZkBZ.json
+++ b/data/packs/magic-items.db/bonus_to_control_water__0SIRUg3EWmVGZkBZ.json
@@ -9,7 +9,7 @@
 			"value": "4"
 		}
 	],
-	"description": "",
+	"description": "Bonus to Control Water",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/bonus_to_control_water__0SIRUg3EWmVGZkBZ.json
+++ b/data/packs/magic-items.db/bonus_to_control_water__0SIRUg3EWmVGZkBZ.json
@@ -1,0 +1,38 @@
+{
+	"_id": "0SIRUg3EWmVGZkBZ",
+	"_key": "!items.effects!REKbDm3ShTNQouM2.0SIRUg3EWmVGZkBZ",
+	"changes": [
+		{
+			"key": "system.roll.spell.bonus.control-water",
+			"mode": 2,
+			"priority": null,
+			"value": "4"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"flags": {
+		"shadowdark": {
+			"situational": true
+		}
+	},
+	"img": "icons/commodities/tech/cog-steel-grey.webp",
+	"name": "Bonus to Control Water",
+	"origin": "Compendium.shadowdark.magic-items.Item.REKbDm3ShTNQouM2",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/bonus_to_control_water__0SIRUg3EWmVGZkBZ.json
+++ b/data/packs/magic-items.db/bonus_to_control_water__0SIRUg3EWmVGZkBZ.json
@@ -9,7 +9,7 @@
 			"value": "4"
 		}
 	],
-	"description": "Bonus to Control Water",
+	"description": "+4 to control water spellcasting checks (1/day)",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/bonus_to_spellcasting_or_ranged_attack__Kf2eneYOrzvxxnWU.json
+++ b/data/packs/magic-items.db/bonus_to_spellcasting_or_ranged_attack__Kf2eneYOrzvxxnWU.json
@@ -1,0 +1,44 @@
+{
+	"_id": "Kf2eneYOrzvxxnWU",
+	"_key": "!items.effects!v2khQSVLOXjdYA4j.Kf2eneYOrzvxxnWU",
+	"changes": [
+		{
+			"key": "system.roll.spell.bonus.all",
+			"mode": 2,
+			"priority": null,
+			"value": "1"
+		},
+		{
+			"key": "system.roll.ranged.bonus.all",
+			"mode": 2,
+			"priority": null,
+			"value": "1"
+		}
+	],
+	"description": "<p>+1 to your next spellcasting check or ranged attack (1/day)</p>",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"flags": {
+		"shadowdark": {
+			"situational": true
+		}
+	},
+	"img": "icons/magic/air/air-smoke-casting.webp",
+	"name": "Bonus to Spellcasting or Ranged Attack",
+	"origin": "Compendium.shadowdark.magic-items.Item.v2khQSVLOXjdYA4j",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/boots_of_dancing__rGOliwa8ZiiwiAxJ.json
+++ b/data/packs/magic-items.db/boots_of_dancing__rGOliwa8ZiiwiAxJ.json
@@ -3,6 +3,8 @@
 	"_key": "!items!rGOliwa8ZiiwiAxJ",
 	"effects": [
 	],
+	"flags": {
+	},
 	"folder": null,
 	"img": "icons/equipment/feet/boots-collared-leather.webp",
 	"name": "Boots of Dancing",

--- a/data/packs/magic-items.db/boots_of_dancing__rGOliwa8ZiiwiAxJ.json
+++ b/data/packs/magic-items.db/boots_of_dancing__rGOliwa8ZiiwiAxJ.json
@@ -1,0 +1,44 @@
+{
+	"_id": "rGOliwa8ZiiwiAxJ",
+	"_key": "!items!rGOliwa8ZiiwiAxJ",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/equipment/feet/boots-collared-leather.webp",
+	"name": "Boots of Dancing",
+	"system": {
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>Fine, supple boots of sheepskin.</em></p><p><strong>Curse.</strong> As soon as you don these boots, you begin cavorting and dancing uncontrollably. You move randomly each turn and must pass a [[request 15 dex]] check to remove the boots.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/boots_of_hovering__r1cwY7jUars9bs24.json
+++ b/data/packs/magic-items.db/boots_of_hovering__r1cwY7jUars9bs24.json
@@ -3,6 +3,8 @@
 	"_key": "!items!r1cwY7jUars9bs24",
 	"effects": [
 	],
+	"flags": {
+	},
 	"folder": null,
 	"img": "icons/skills/movement/feet-winged-boots-brown.webp",
 	"name": "Boots of Hovering",

--- a/data/packs/magic-items.db/boots_of_hovering__r1cwY7jUars9bs24.json
+++ b/data/packs/magic-items.db/boots_of_hovering__r1cwY7jUars9bs24.json
@@ -1,0 +1,44 @@
+{
+	"_id": "r1cwY7jUars9bs24",
+	"_key": "!items!r1cwY7jUars9bs24",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/skills/movement/feet-winged-boots-brown.webp",
+	"name": "Boots of Hovering",
+	"system": {
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>Brown, sturdy boots polished to a sheen. Small, silver wings adorn the heels.</em></p><p><strong>Benefit.</strong> You can walk on an insubstantial surface for 1 turn at a time. You fall through the surface if you end your turn on it.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/bracers_of_archery__j0WXRAkFtjg9LYKS.json
+++ b/data/packs/magic-items.db/bracers_of_archery__j0WXRAkFtjg9LYKS.json
@@ -1,0 +1,46 @@
+{
+	"_id": "j0WXRAkFtjg9LYKS",
+	"_key": "!items!j0WXRAkFtjg9LYKS",
+	"effects": [
+		"yrS7j3rhCRynCLL6"
+	],
+	"folder": null,
+	"img": "icons/equipment/wrist/bracer-quilted-leather.webp",
+	"name": "Bracers of Archery",
+	"system": {
+		"ac": {
+			"attribute": "",
+			"base": 0,
+			"modifier": 0
+		},
+		"baseArmor": "",
+		"bonuses": {
+			"rangedDamageBonus": "1"
+		},
+		"broken": false,
+		"canBeEquipped": true,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>Leather bracers embossed with soaring hawks.</em></p><p><strong>Benefit.</strong> You deal +1 damage with ranged weapons.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}

--- a/data/packs/magic-items.db/bracers_of_archery__j0WXRAkFtjg9LYKS.json
+++ b/data/packs/magic-items.db/bracers_of_archery__j0WXRAkFtjg9LYKS.json
@@ -2,8 +2,10 @@
 	"_id": "j0WXRAkFtjg9LYKS",
 	"_key": "!items!j0WXRAkFtjg9LYKS",
 	"effects": [
-		"yrS7j3rhCRynCLL6"
+		"yQZ0cvsfdvrSTM4o"
 	],
+	"flags": {
+	},
 	"folder": null,
 	"img": "icons/equipment/wrist/bracer-quilted-leather.webp",
 	"name": "Bracers of Archery",

--- a/data/packs/magic-items.db/brak_s_book_of_misspells__hVxGqq2Ala8hC0xJ.json
+++ b/data/packs/magic-items.db/brak_s_book_of_misspells__hVxGqq2Ala8hC0xJ.json
@@ -1,0 +1,44 @@
+{
+	"_id": "hVxGqq2Ala8hC0xJ",
+	"_key": "!items!hVxGqq2Ala8hC0xJ",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/sundries/books/book-backed-wood-tan.webp",
+	"name": "Brak's Book of Misspells",
+	"system": {
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A tome bound in ratskin that bears a jagged, glowing rune.</em></p><p><strong>Curse.</strong> This spellbook contains one scroll each of @UUID[Compendium.shadowdark.spells.Item.16XuBF2xjUnoepyp]{acid arrow} (pg. 54), @UUID[Compendium.shadowdark.spells.Item.j2gvzfnMGQwxqgGg]{fireball} (pg. 60), and @UUID[Actor.2xHFafRF1iQUJUHj.Item.vTvKrv5VC2UQnrHM]{sleep} (pg. 71). When a wizard tries to cast or learn a spell from these scrolls, the spell targets the caster on a success.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/brak_s_book_of_misspells__hVxGqq2Ala8hC0xJ.json
+++ b/data/packs/magic-items.db/brak_s_book_of_misspells__hVxGqq2Ala8hC0xJ.json
@@ -16,7 +16,7 @@
 			"gp": 0,
 			"sp": 0
 		},
-		"description": "<p><em>A tome bound in ratskin that bears a jagged, glowing rune.</em></p><p><strong>Curse.</strong> This spellbook contains one scroll each of @UUID[Compendium.shadowdark.spells.Item.16XuBF2xjUnoepyp]{acid arrow} (pg. 54), @UUID[Compendium.shadowdark.spells.Item.j2gvzfnMGQwxqgGg]{fireball} (pg. 60), and @UUID[Actor.2xHFafRF1iQUJUHj.Item.vTvKrv5VC2UQnrHM]{sleep} (pg. 71). When a wizard tries to cast or learn a spell from these scrolls, the spell targets the caster on a success.</p>",
+		"description": "<p><em>A tome bound in ratskin that bears a jagged, glowing rune.</em></p><p><strong>Curse.</strong> This spellbook contains one scroll each of @UUID[Compendium.shadowdark.spells.Item.16XuBF2xjUnoepyp]{acid arrow} (pg. 54), @UUID[Compendium.shadowdark.spells.Item.j2gvzfnMGQwxqgGg]{fireball} (pg. 60), and @UUID[Compendium.shadowdark.spells.Item.n1I5OLR6M2e0jLbi]{sleep} (pg. 71). When a wizard tries to cast or learn a spell from these scrolls, the spell targets the caster on a success.</p>",
 		"equipped": false,
 		"isAmmunition": false,
 		"isPhysical": true,

--- a/data/packs/magic-items.db/brak_s_book_of_misspells__hVxGqq2Ala8hC0xJ.json
+++ b/data/packs/magic-items.db/brak_s_book_of_misspells__hVxGqq2Ala8hC0xJ.json
@@ -3,6 +3,8 @@
 	"_key": "!items!hVxGqq2Ala8hC0xJ",
 	"effects": [
 	],
+	"flags": {
+	},
 	"folder": null,
 	"img": "icons/sundries/books/book-backed-wood-tan.webp",
 	"name": "Brak's Book of Misspells",

--- a/data/packs/magic-items.db/circlet_of_wisdom__yE6fl9FlZldHBupD.json
+++ b/data/packs/magic-items.db/circlet_of_wisdom__yE6fl9FlZldHBupD.json
@@ -2,8 +2,10 @@
 	"_id": "yE6fl9FlZldHBupD",
 	"_key": "!items!yE6fl9FlZldHBupD",
 	"effects": [
-		"JGN2W0klkumjFNoV"
+		"FKzhrPnFt0njaDh8"
 	],
+	"flags": {
+	},
 	"folder": null,
 	"img": "icons/commodities/treasure/crown-gold-laurel-wreath.webp",
 	"name": "Circlet of Wisdom",
@@ -20,7 +22,7 @@
 			"gp": 0,
 			"sp": 0
 		},
-		"description": "",
+		"description": "<p><em>A thin, silver circlet set with a shimmering, blue pearl.</em></p><p><strong>Benefit.</strong> Your Wisdom stat becomes 18 (+4) while wearing this circlet.</p>",
 		"equipped": false,
 		"isAmmunition": false,
 		"isPhysical": true,

--- a/data/packs/magic-items.db/circlet_of_wisdom__yE6fl9FlZldHBupD.json
+++ b/data/packs/magic-items.db/circlet_of_wisdom__yE6fl9FlZldHBupD.json
@@ -1,0 +1,50 @@
+{
+	"_id": "yE6fl9FlZldHBupD",
+	"_key": "!items!yE6fl9FlZldHBupD",
+	"effects": [
+		"JGN2W0klkumjFNoV"
+	],
+	"folder": null,
+	"img": "icons/commodities/treasure/crown-gold-laurel-wreath.webp",
+	"name": "Circlet of Wisdom",
+	"system": {
+		"abilities": {
+			"wis": {
+				"base": "18"
+			}
+		},
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/cloak_of_the_bat__2zk5qjIWmN5OqNf5.json
+++ b/data/packs/magic-items.db/cloak_of_the_bat__2zk5qjIWmN5OqNf5.json
@@ -3,6 +3,8 @@
 	"_key": "!items!2zk5qjIWmN5OqNf5",
 	"effects": [
 	],
+	"flags": {
+	},
 	"folder": null,
 	"img": "icons/equipment/back/cloak-heavy-black-red.webp",
 	"name": "Cloak of the bat",

--- a/data/packs/magic-items.db/cloak_of_the_bat__2zk5qjIWmN5OqNf5.json
+++ b/data/packs/magic-items.db/cloak_of_the_bat__2zk5qjIWmN5OqNf5.json
@@ -1,0 +1,44 @@
+{
+	"_id": "2zk5qjIWmN5OqNf5",
+	"_key": "!items!2zk5qjIWmN5OqNf5",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/equipment/back/cloak-heavy-black-red.webp",
+	"name": "Cloak of the bat",
+	"system": {
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A leathery, black cloak that has a ragged hem and a hood with pointed ears.</em></p><p><strong>Benefit.</strong> You can fly a near distance as your movement while in a shadowy area.</p><p><strong>Curse.</strong> Each time you use the cloak to fly, roll a d20. On a result of 1, you and your gear turn into a small bat for 3 rounds.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/critical_failure_threshold__UojiuFQ7ufucHAMl.json
+++ b/data/packs/magic-items.db/critical_failure_threshold__UojiuFQ7ufucHAMl.json
@@ -9,7 +9,7 @@
 			"value": "3"
 		}
 	],
-	"description": "",
+	"description": "Critical Failure Threshold",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/critical_multiplier__2NdFJHTHy28UaTCh.json
+++ b/data/packs/magic-items.db/critical_multiplier__2NdFJHTHy28UaTCh.json
@@ -9,7 +9,7 @@
 			"value": "4"
 		}
 	],
-	"description": "",
+	"description": "Critical Multiplier",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/critical_success_threshold__b7lXcLAavPlpMhqp.json
+++ b/data/packs/magic-items.db/critical_success_threshold__b7lXcLAavPlpMhqp.json
@@ -9,7 +9,7 @@
 			"value": "18"
 		}
 	],
-	"description": "",
+	"description": "Critical Success Threshold",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/crystal_ball__lYl5E9urwAHXoqIr.json
+++ b/data/packs/magic-items.db/crystal_ball__lYl5E9urwAHXoqIr.json
@@ -1,0 +1,44 @@
+{
+	"_id": "lYl5E9urwAHXoqIr",
+	"_key": "!items!lYl5E9urwAHXoqIr",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/magic/perception/orb-crystal-ball-scrying.webp",
+	"name": "Crystal Ball",
+	"system": {
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A flawless glass orb with roiling images swirling inside it.</em></p><p><strong>Benefit.</strong> Only wizards can use a Crystal Ball. You can use it to cast the @UUID[Compendium.shadowdark.spells.Item.FrdLzy8cWPcVS2Mz]{scrying} spell (pg. 70). If you fail the spellcasting check to cast scrying, the Crystal Ball ceases to function for a day.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/crystal_ball__lYl5E9urwAHXoqIr.json
+++ b/data/packs/magic-items.db/crystal_ball__lYl5E9urwAHXoqIr.json
@@ -3,6 +3,8 @@
 	"_key": "!items!lYl5E9urwAHXoqIr",
 	"effects": [
 	],
+	"flags": {
+	},
 	"folder": null,
 	"img": "icons/magic/perception/orb-crystal-ball-scrying.webp",
 	"name": "Crystal Ball",

--- a/data/packs/magic-items.db/dagger_of_the_goblin_hero__YITrYmzXxk6Yjxfc.json
+++ b/data/packs/magic-items.db/dagger_of_the_goblin_hero__YITrYmzXxk6Yjxfc.json
@@ -2,8 +2,12 @@
 	"_id": "YITrYmzXxk6Yjxfc",
 	"_key": "!items!YITrYmzXxk6Yjxfc",
 	"effects": [
-		"kUrrVadALCQYuXNm"
+		"kUrrVadALCQYuXNm",
+		"eXpmyWBLi6CfFuTt",
+		"tOLeg6MI1ii7c98V"
 	],
+	"flags": {
+	},
 	"folder": null,
 	"img": "icons/weapons/daggers/dagger-curved-purple.webp",
 	"name": "Dagger of the Goblin Hero",

--- a/data/packs/magic-items.db/dagger_of_the_goblin_hero__YITrYmzXxk6Yjxfc.json
+++ b/data/packs/magic-items.db/dagger_of_the_goblin_hero__YITrYmzXxk6Yjxfc.json
@@ -1,0 +1,60 @@
+{
+	"_id": "YITrYmzXxk6Yjxfc",
+	"_key": "!items!YITrYmzXxk6Yjxfc",
+	"effects": [
+		"kUrrVadALCQYuXNm"
+	],
+	"folder": null,
+	"img": "icons/weapons/daggers/dagger-curved-purple.webp",
+	"name": "Dagger of the Goblin Hero",
+	"system": {
+		"ammoClass": "",
+		"baseWeapon": "dagger",
+		"bonuses": {
+			"attackBonus": 0,
+			"critical": {
+				"failureThreshold": 1,
+				"multiplier": 2,
+				"successThreshold": 20
+			},
+			"damageBonus": 0,
+			"damageMultiplier": 1
+		},
+		"broken": false,
+		"canBeEquipped": true,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"damage": {
+			"numDice": 1,
+			"oneHanded": "d4",
+			"twoHanded": ""
+		},
+		"description": "<p><em>A curved dagger with a half- moon notch at the blade's base.</em></p><p><strong>Bonus.</strong> +1 dagger.</p><p><strong>Benefit.</strong> You can speak Goblin. All goblinoid creatures react to you with a friendly attitude.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"languages": "Compendium.shadowdark.languages.Item.NN9wFGgwk49oOQeN",
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.rqQwpoeWEqi0ZcYK",
+			"Compendium.shadowdark.properties.Item.c35ROL1nXwC840kC"
+		],
+		"quantity": 1,
+		"range": "near",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"type": "melee",
+		"weaponMastery": false
+	},
+	"type": "Weapon"
+}

--- a/data/packs/magic-items.db/disadvantage_on_attacks___spellcasting_vs_demons__phVQo5ikKtoR4emZ.json
+++ b/data/packs/magic-items.db/disadvantage_on_attacks___spellcasting_vs_demons__phVQo5ikKtoR4emZ.json
@@ -1,0 +1,47 @@
+{
+	"_id": "phVQo5ikKtoR4emZ",
+	"_key": "!items.effects!hcC1kuGgQ2VdnHmj.phVQo5ikKtoR4emZ",
+	"changes": [
+		{
+			"key": "system.roll.melee.advantage.all",
+			"mode": 2,
+			"priority": null,
+			"value": "-1"
+		},
+		{
+			"key": "system.roll.ranged.advantage.all",
+			"mode": 2,
+			"priority": null,
+			"value": "-1"
+		},
+		{
+			"key": "system.roll.spell.advantage.all",
+			"mode": 2,
+			"priority": null,
+			"value": ""
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"flags": {
+	},
+	"img": "icons/commodities/tech/cog-steel-grey.webp",
+	"name": "Disadvantage on Attacks & Spellcasting vs Demons",
+	"origin": "Compendium.shadowdark.magic-items.Item.hcC1kuGgQ2VdnHmj",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/disadvantage_on_attacks___spellcasting_vs_demons__phVQo5ikKtoR4emZ.json
+++ b/data/packs/magic-items.db/disadvantage_on_attacks___spellcasting_vs_demons__phVQo5ikKtoR4emZ.json
@@ -18,10 +18,10 @@
 			"key": "system.roll.spell.advantage.all",
 			"mode": 2,
 			"priority": null,
-			"value": ""
+			"value": "-1"
 		}
 	],
-	"description": "",
+	"description": "Disadvantage on Attacks & Spellcasting vs Demons",
 	"disabled": false,
 	"duration": {
 		"combat": null,
@@ -33,6 +33,9 @@
 		"turns": null
 	},
 	"flags": {
+		"shadowdark": {
+			"situational": true
+		}
 	},
 	"img": "icons/commodities/tech/cog-steel-grey.webp",
 	"name": "Disadvantage on Attacks & Spellcasting vs Demons",

--- a/data/packs/magic-items.db/disadvantage_on_attacks___spellcasting_vs_demons__phVQo5ikKtoR4emZ.json
+++ b/data/packs/magic-items.db/disadvantage_on_attacks___spellcasting_vs_demons__phVQo5ikKtoR4emZ.json
@@ -21,7 +21,7 @@
 			"value": "-1"
 		}
 	],
-	"description": "Disadvantage on Attacks & Spellcasting vs Demons",
+	"description": "Disadvantage on Attacks &amp; Spellcasting vs Demons",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/disadvantage_on_attacks___spells_vs_snakes__gKzyPrgEBI8O9NXr.json
+++ b/data/packs/magic-items.db/disadvantage_on_attacks___spells_vs_snakes__gKzyPrgEBI8O9NXr.json
@@ -21,7 +21,7 @@
 			"value": "-1"
 		}
 	],
-	"description": "Disadvantage on Attacks & Spells vs Snakes",
+	"description": "Disadvantage on attacks and hostile spells targeting snakes",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/disadvantage_on_attacks___spells_vs_snakes__gKzyPrgEBI8O9NXr.json
+++ b/data/packs/magic-items.db/disadvantage_on_attacks___spells_vs_snakes__gKzyPrgEBI8O9NXr.json
@@ -1,0 +1,50 @@
+{
+	"_id": "gKzyPrgEBI8O9NXr",
+	"_key": "!items.effects!EiyxS6MOvGlZgG65.gKzyPrgEBI8O9NXr",
+	"changes": [
+		{
+			"key": "system.roll.melee.advantage.all",
+			"mode": 2,
+			"priority": null,
+			"value": "-1"
+		},
+		{
+			"key": "system.roll.ranged.advantage.all",
+			"mode": 2,
+			"priority": null,
+			"value": "-1"
+		},
+		{
+			"key": "system.roll.spell.advantage.all",
+			"mode": 2,
+			"priority": null,
+			"value": "-1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"flags": {
+		"shadowdark": {
+			"situational": true
+		}
+	},
+	"img": "icons/commodities/tech/cog-steel-grey.webp",
+	"name": "Disadvantage on Attacks & Spells vs Snakes",
+	"origin": "Compendium.shadowdark.magic-items.Item.EiyxS6MOvGlZgG65",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/disadvantage_on_attacks___spells_vs_snakes__gKzyPrgEBI8O9NXr.json
+++ b/data/packs/magic-items.db/disadvantage_on_attacks___spells_vs_snakes__gKzyPrgEBI8O9NXr.json
@@ -21,7 +21,7 @@
 			"value": "-1"
 		}
 	],
-	"description": "",
+	"description": "Disadvantage on Attacks & Spells vs Snakes",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/double_damage_vs_demons__devils____undead__us7NkXHO8GnlNAiE.json
+++ b/data/packs/magic-items.db/double_damage_vs_demons__devils____undead__us7NkXHO8GnlNAiE.json
@@ -9,7 +9,7 @@
 			"value": "2"
 		}
 	],
-	"description": "Double Damage vs Demons, Devils &  Undead",
+	"description": "Double Damage vs Demons, Devils &amp;  Undead",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/double_damage_vs_demons__devils____undead__us7NkXHO8GnlNAiE.json
+++ b/data/packs/magic-items.db/double_damage_vs_demons__devils____undead__us7NkXHO8GnlNAiE.json
@@ -1,0 +1,38 @@
+{
+	"_id": "us7NkXHO8GnlNAiE",
+	"_key": "!items.effects!MgWPwzNTzC7cPi7H.us7NkXHO8GnlNAiE",
+	"changes": [
+		{
+			"key": "system.roll.spell.advantage.all",
+			"mode": 2,
+			"priority": null,
+			"value": "2"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"flags": {
+		"shadowdark": {
+			"situational": true
+		}
+	},
+	"img": "icons/commodities/tech/cog-steel-grey.webp",
+	"name": "Double Damage vs Demons, Devils &  Undead",
+	"origin": "Compendium.shadowdark.magic-items.Item.MgWPwzNTzC7cPi7H",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/double_damage_vs_demons__devils____undead__us7NkXHO8GnlNAiE.json
+++ b/data/packs/magic-items.db/double_damage_vs_demons__devils____undead__us7NkXHO8GnlNAiE.json
@@ -9,7 +9,7 @@
 			"value": "2"
 		}
 	],
-	"description": "",
+	"description": "Double Damage vs Demons, Devils &  Undead",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/double_damage_vs_giants__12wqYPS5nYdD0srs.json
+++ b/data/packs/magic-items.db/double_damage_vs_giants__12wqYPS5nYdD0srs.json
@@ -1,0 +1,38 @@
+{
+	"_id": "12wqYPS5nYdD0srs",
+	"_key": "!items.effects!EBfBPArPRSyLXFPM.12wqYPS5nYdD0srs",
+	"changes": [
+		{
+			"key": "system.roll.attack.damage.this",
+			"mode": 1,
+			"priority": null,
+			"value": "2"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"flags": {
+		"shadowdark": {
+			"situational": true
+		}
+	},
+	"img": "icons/commodities/tech/cog-steel-grey.webp",
+	"name": "Double Damage vs Giants",
+	"origin": "Compendium.shadowdark.magic-items.Item.EBfBPArPRSyLXFPM",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/double_damage_vs_giants__12wqYPS5nYdD0srs.json
+++ b/data/packs/magic-items.db/double_damage_vs_giants__12wqYPS5nYdD0srs.json
@@ -9,7 +9,7 @@
 			"value": "2"
 		}
 	],
-	"description": "",
+	"description": "Double Damage vs Giants",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/double_damage_vs_giants__GH1P7tijaj5st9hm.json
+++ b/data/packs/magic-items.db/double_damage_vs_giants__GH1P7tijaj5st9hm.json
@@ -9,7 +9,7 @@
 			"value": "2"
 		}
 	],
-	"description": "",
+	"description": "Double Damage vs Giants",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/double_damage_vs_giants__GH1P7tijaj5st9hm.json
+++ b/data/packs/magic-items.db/double_damage_vs_giants__GH1P7tijaj5st9hm.json
@@ -1,0 +1,35 @@
+{
+	"_id": "GH1P7tijaj5st9hm",
+	"_key": "!items.effects!FqhEJHkaKd0emTzn.GH1P7tijaj5st9hm",
+	"changes": [
+		{
+			"key": "system.roll.attack.damage.this",
+			"mode": 1,
+			"priority": null,
+			"value": "2"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"flags": {
+	},
+	"img": "icons/commodities/tech/cog-steel-grey.webp",
+	"name": "Double Damage vs Giants",
+	"origin": "Compendium.shadowdark.magic-items.Item.FqhEJHkaKd0emTzn",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/double_damage_vs_lycanthropes__G7VI8iNu9to3a2iz.json
+++ b/data/packs/magic-items.db/double_damage_vs_lycanthropes__G7VI8iNu9to3a2iz.json
@@ -1,0 +1,38 @@
+{
+	"_id": "G7VI8iNu9to3a2iz",
+	"_key": "!items.effects!bpJlJ3vnZVmvOEJV.G7VI8iNu9to3a2iz",
+	"changes": [
+		{
+			"key": "system.roll.attack.damage.this",
+			"mode": 1,
+			"priority": null,
+			"value": "2"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"flags": {
+		"shadowdark": {
+			"situational": true
+		}
+	},
+	"img": "icons/commodities/tech/cog-steel-grey.webp",
+	"name": "Double Damage vs Lycanthropes",
+	"origin": "Compendium.shadowdark.magic-items.Item.bpJlJ3vnZVmvOEJV",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/double_damage_vs_lycanthropes__G7VI8iNu9to3a2iz.json
+++ b/data/packs/magic-items.db/double_damage_vs_lycanthropes__G7VI8iNu9to3a2iz.json
@@ -9,7 +9,7 @@
 			"value": "2"
 		}
 	],
-	"description": "",
+	"description": "Double Damage vs Lycanthropes",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/egg_of_the_cockatrice__LflQgWEekkaKPm8Z.json
+++ b/data/packs/magic-items.db/egg_of_the_cockatrice__LflQgWEekkaKPm8Z.json
@@ -1,0 +1,44 @@
+{
+	"_id": "LflQgWEekkaKPm8Z",
+	"_key": "!items!LflQgWEekkaKPm8Z",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/consumables/eggs/egg-spotted-cyan.webp",
+	"name": "Egg of the Cockatrice",
+	"system": {
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A blue, hard egg as big as a coconut and heavy as a stone.</em></p><p><strong>Benefit.</strong> Once per week, you can speak a command word that causes a @UUID[Compendium.shadowdark.monsters.Actor.xUxKG0CR6Elw1l7h]{cockatrice} to hatch and follow your commands for 5 rounds before flying away. The egg repairs itself over one week.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/egg_of_the_cockatrice__LflQgWEekkaKPm8Z.json
+++ b/data/packs/magic-items.db/egg_of_the_cockatrice__LflQgWEekkaKPm8Z.json
@@ -3,6 +3,8 @@
 	"_key": "!items!LflQgWEekkaKPm8Z",
 	"effects": [
 	],
+	"flags": {
+	},
 	"folder": null,
 	"img": "icons/consumables/eggs/egg-spotted-cyan.webp",
 	"name": "Egg of the Cockatrice",

--- a/data/packs/magic-items.db/flying_carpet__GIRNb0BTURa4wyLH.json
+++ b/data/packs/magic-items.db/flying_carpet__GIRNb0BTURa4wyLH.json
@@ -3,6 +3,8 @@
 	"_key": "!items!GIRNb0BTURa4wyLH",
 	"effects": [
 	],
+	"flags": {
+	},
 	"folder": null,
 	"img": "icons/commodities/cloth/cloth-bolt-gold-red.webp",
 	"name": "Flying Carpet",

--- a/data/packs/magic-items.db/flying_carpet__GIRNb0BTURa4wyLH.json
+++ b/data/packs/magic-items.db/flying_carpet__GIRNb0BTURa4wyLH.json
@@ -1,0 +1,44 @@
+{
+	"_id": "GIRNb0BTURa4wyLH",
+	"_key": "!items!GIRNb0BTURa4wyLH",
+	"effects": [
+	],
+	"folder": null,
+	"img": "icons/commodities/cloth/cloth-bolt-gold-red.webp",
+	"name": "Flying Carpet",
+	"system": {
+		"broken": false,
+		"canBeEquipped": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A richly woven, red carpet with gold tassels.</em></p><p><strong>Benefit.</strong> The carpet fits two riders (one is the driver). It can fly double near on the driver's turn.</p><p><strong>Personality.</strong> Neutral. Playful, mischievous. Enjoys visiting new places and gets restless without a frequent change in location.</p>",
+		"equipped": false,
+		"isAmmunition": false,
+		"isPhysical": true,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/genie_lamp__vJHD7gb6RzIPAxef.json
+++ b/data/packs/magic-items.db/genie_lamp__vJHD7gb6RzIPAxef.json
@@ -1,0 +1,51 @@
+{
+	"_id": "vJHD7gb6RzIPAxef",
+	"_key": "!items!vJHD7gb6RzIPAxef",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/commodities/treasure/brass-lamp-yellow.webp",
+	"name": "Genie Lamp",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A tarnished, brass oil lamp.</em></p><p><strong>Benefit.</strong> Rubbing the lamp causes its resident @UUID[Compendium.shadowdark.monsters.Actor.ytftI0motwEnF29v]{djinni} (50% chance) or efreeti (50% chance) to emerge. A djinni grants its summoner one @UUID[Compendium.shadowdark.spells.Item.hMGQuETjBxuMwjsR]{wish} spell (pg. 73) before disappearing. An @UUID[Compendium.shadowdark.monsters.Actor.o1aBfxHFxYVHLTRn]{efreeti} does the same, but only after being defeated in combat.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/gloves_of_agility__Ka1NPr6edk9cwrzo.json
+++ b/data/packs/magic-items.db/gloves_of_agility__Ka1NPr6edk9cwrzo.json
@@ -1,0 +1,48 @@
+{
+	"_id": "Ka1NPr6edk9cwrzo",
+	"_key": "!items!Ka1NPr6edk9cwrzo",
+	"effects": [
+		"I9RcaNvoUpSqiWUz"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/equipment/hand/gloves-leather-tan.webp",
+	"name": "Gloves of Agility",
+	"system": {
+		"ac": {
+			"attribute": "dex",
+			"base": 0,
+			"modifier": 0
+		},
+		"baseArmor": "",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>Thin, leather gloves that seem to meld with the wearer's hands.</em></p><p><strong>Benefit.</strong> Your Dexterity stat becomes 18 (+4) while wearing these gloves.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}

--- a/data/packs/magic-items.db/goblin_bomb__OHQxOIarBQvydTiV.json
+++ b/data/packs/magic-items.db/goblin_bomb__OHQxOIarBQvydTiV.json
@@ -1,0 +1,51 @@
+{
+	"_id": "OHQxOIarBQvydTiV",
+	"_key": "!items!OHQxOIarBQvydTiV",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/thrown/bomb-fuse-black.webp",
+	"name": "Goblin Bomb",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A preserved rat stuffed with an explosive charge and a fuse.</em></p><p><strong>Benefit.</strong> You can light the bomb's fuse and throw it a near distance. It explodes in [[/r 1d4]] rounds, dealing [[/r 2d8]] damage to everything in near range.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/greataxe_of_the_horde__RbAtv4hRODYmOoit.json
+++ b/data/packs/magic-items.db/greataxe_of_the_horde__RbAtv4hRODYmOoit.json
@@ -1,0 +1,53 @@
+{
+	"_id": "RbAtv4hRODYmOoit",
+	"_key": "!items!RbAtv4hRODYmOoit",
+	"effects": [
+		"ENAyqljvyYqIr8rK",
+		"ZDqSlow0fxMp6JOf"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/axes/axe-battle-broad-stone.webp",
+	"name": "Greataxe of the Horde",
+	"system": {
+		"ammoClass": "",
+		"baseWeapon": "greataxe",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"damage": {
+			"oneHanded": "d8",
+			"twoHanded": "d10"
+		},
+		"description": "<p><em>A jagged greataxe carved from a weighty dragon bone.</em></p><p><strong>Bonus.</strong> +2 greataxe.</p><p><strong>Benefit.</strong> Once per day, you can turn a regular hit with this weapon into a critical hit.</p><p><strong>Curse.</strong> Each time you go below half your hit points, make a DC 12 Charisma check. On a failure, you enter a battle rage for 1d4 rounds and must attack the nearest creature.</p>",
+		"equipped": false,
+		"handedness": "",
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.qEIYaQ9j2EUmSrx6"
+		],
+		"quantity": 1,
+		"range": "close",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"type": "melee"
+	},
+	"type": "Weapon"
+}

--- a/data/packs/magic-items.db/greataxe_of_the_horde__RbAtv4hRODYmOoit.json
+++ b/data/packs/magic-items.db/greataxe_of_the_horde__RbAtv4hRODYmOoit.json
@@ -23,7 +23,7 @@
 			"oneHanded": "d8",
 			"twoHanded": "d10"
 		},
-		"description": "<p><em>A jagged greataxe carved from a weighty dragon bone.</em></p><p><strong>Bonus.</strong> +2 greataxe.</p><p><strong>Benefit.</strong> Once per day, you can turn a regular hit with this weapon into a critical hit.</p><p><strong>Curse.</strong> Each time you go below half your hit points, make a DC 12 Charisma check. On a failure, you enter a battle rage for 1d4 rounds and must attack the nearest creature.</p>",
+		"description": "<p><em>A jagged greataxe carved from a weighty dragon bone.</em></p><p><strong>Bonus.</strong> +2 greataxe.</p><p><strong>Benefit.</strong> Once per day, you can turn a regular hit with this weapon into a critical hit.</p><p><strong>Curse.</strong> Each time you go below half your hit points, make a [[check 12 cha]] check. On a failure, you enter a battle rage for [[/r 1d4]] rounds and must attack the nearest creature.</p>",
 		"equipped": false,
 		"handedness": "",
 		"identification": {

--- a/data/packs/magic-items.db/hat_of_intellect__BJ59d0lCvvMKSbu7.json
+++ b/data/packs/magic-items.db/hat_of_intellect__BJ59d0lCvvMKSbu7.json
@@ -1,0 +1,48 @@
+{
+	"_id": "BJ59d0lCvvMKSbu7",
+	"_key": "!items!BJ59d0lCvvMKSbu7",
+	"effects": [
+		"fEHEHVFcLflsUsCv"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/equipment/head/hat-pointed-leather-pink.webp",
+	"name": "Hat of Intellect",
+	"system": {
+		"ac": {
+			"attribute": "dex",
+			"base": 0,
+			"modifier": 0
+		},
+		"baseArmor": "",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A floppy, pointed hat with a wide brim.</em></p><p><strong>Benefit.</strong> Your Intelligence stat becomes 18 (+4) while wearing this hat.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}

--- a/data/packs/magic-items.db/hat_of_the_hound__T66dAbuDLi41JgOZ.json
+++ b/data/packs/magic-items.db/hat_of_the_hound__T66dAbuDLi41JgOZ.json
@@ -1,0 +1,47 @@
+{
+	"_id": "T66dAbuDLi41JgOZ",
+	"_key": "!items!T66dAbuDLi41JgOZ",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/equipment/head/hat-belted-simple-brown.webp",
+	"name": "Hat of the Hound",
+	"system": {
+		"ac": {
+			"attribute": "dex",
+			"base": 0,
+			"modifier": 0
+		},
+		"baseArmor": "",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A rounded, jaunty bowler hat.</em></p><p><strong>Benefit.</strong> You can transform into a @UUID[Compendium.shadowdark.monsters.Actor.lJyH2RWm3t5MB5iG]{mastiff} each day for up to 10 rounds total. Your clothing and possessions transform with you.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}

--- a/data/packs/magic-items.db/helm_of_mind_reading__HxnAZ36Mm2jSDF6p.json
+++ b/data/packs/magic-items.db/helm_of_mind_reading__HxnAZ36Mm2jSDF6p.json
@@ -2,6 +2,7 @@
 	"_id": "HxnAZ36Mm2jSDF6p",
 	"_key": "!items!HxnAZ36Mm2jSDF6p",
 	"effects": [
+		"lx4pzHIfjRY8COai"
 	],
 	"flags": {
 	},

--- a/data/packs/magic-items.db/helm_of_mind_reading__HxnAZ36Mm2jSDF6p.json
+++ b/data/packs/magic-items.db/helm_of_mind_reading__HxnAZ36Mm2jSDF6p.json
@@ -1,0 +1,47 @@
+{
+	"_id": "HxnAZ36Mm2jSDF6p",
+	"_key": "!items!HxnAZ36Mm2jSDF6p",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/commodities/biological/organ-brain-pink.webp",
+	"name": "Helm of Mind Reading",
+	"system": {
+		"ac": {
+			"attribute": "dex",
+			"base": 0,
+			"modifier": 0
+		},
+		"baseArmor": "",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A helm carved with brain ridges, a spinal neck-guard, and octopus-like tentacles.</em></p><p><strong>Benefit.</strong> You can cast the @UUID[Compendium.shadowdark.spells.Item.XBt4wA37ypUiXkp6]{detect thoughts} spell (pg. 58) three times per day (+4 bonus).</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}

--- a/data/packs/magic-items.db/holy_prayer_ac_bonus__G5THNKdzVuAqhJ5Q.json
+++ b/data/packs/magic-items.db/holy_prayer_ac_bonus__G5THNKdzVuAqhJ5Q.json
@@ -1,0 +1,38 @@
+{
+	"_id": "G5THNKdzVuAqhJ5Q",
+	"_key": "!items.effects!8RyBRclanxBD4pMx.G5THNKdzVuAqhJ5Q",
+	"changes": [
+		{
+			"key": "system.attributes.ac.value",
+			"mode": 2,
+			"priority": null,
+			"value": "2"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"flags": {
+		"shadowdark": {
+			"situational": true
+		}
+	},
+	"img": "icons/commodities/tech/cog-steel-grey.webp",
+	"name": "Holy Prayer AC Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.8RyBRclanxBD4pMx",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/holy_prayer_ac_bonus__G5THNKdzVuAqhJ5Q.json
+++ b/data/packs/magic-items.db/holy_prayer_ac_bonus__G5THNKdzVuAqhJ5Q.json
@@ -9,7 +9,7 @@
 			"value": "2"
 		}
 	],
-	"description": "",
+	"description": "Holy Prayer AC Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/holy_prayer_ac_bonus__G5THNKdzVuAqhJ5Q.json
+++ b/data/packs/magic-items.db/holy_prayer_ac_bonus__G5THNKdzVuAqhJ5Q.json
@@ -9,7 +9,7 @@
 			"value": "2"
 		}
 	],
-	"description": "Holy Prayer AC Bonus",
+	"description": "+2 AC for 3 rounds after speaking a holy prayer (1/day)",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/horned_helm_of_ramlaat__qOpf91Qn5FFNABid.json
+++ b/data/packs/magic-items.db/horned_helm_of_ramlaat__qOpf91Qn5FFNABid.json
@@ -1,0 +1,47 @@
+{
+	"_id": "qOpf91Qn5FFNABid",
+	"_key": "!items!qOpf91Qn5FFNABid",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/equipment/head/mask-horned-skull.webp",
+	"name": "Horned Helm of Ramlaat",
+	"system": {
+		"ac": {
+			"attribute": "dex",
+			"base": 0,
+			"modifier": 1
+		},
+		"baseArmor": "",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A bloodstained helm made of a ram's skull.</em></p><p><strong>Benefit.</strong> This helm grants you a +1 bonus to your armor class. You have advantage on any check you make to knock down creatures or objects.</p><p><strong>Curse.</strong> You feel compelled to headbutt delicate objects.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}

--- a/data/packs/magic-items.db/hourglass_of_the_black_sands__bN40eJ3tMTx1R4zT.json
+++ b/data/packs/magic-items.db/hourglass_of_the_black_sands__bN40eJ3tMTx1R4zT.json
@@ -1,0 +1,51 @@
+{
+	"_id": "bN40eJ3tMTx1R4zT",
+	"_key": "!items!bN40eJ3tMTx1R4zT",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/sundries/misc/hourglass-wood.webp",
+	"name": "Hourglass of the Black Sands",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>An ancient hourglass running with obsidian sand.</em></p><p><strong>Benefit.</strong> Once per day, you can turn the hourglass when you cast a spell. The spell's effects last 1d4 rounds longer.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/longbow_of_the_elven_kings__DtswEluGPMrFpzW1.json
+++ b/data/packs/magic-items.db/longbow_of_the_elven_kings__DtswEluGPMrFpzW1.json
@@ -3,7 +3,8 @@
 	"_key": "!items!DtswEluGPMrFpzW1",
 	"effects": [
 		"HOkTvzEf4v5RBLfx",
-		"UTm25I1vjFzNqZKZ"
+		"UTm25I1vjFzNqZKZ",
+		"6mClhm9ShmrgbUEL"
 	],
 	"flags": {
 	},

--- a/data/packs/magic-items.db/longbow_of_the_elven_kings__DtswEluGPMrFpzW1.json
+++ b/data/packs/magic-items.db/longbow_of_the_elven_kings__DtswEluGPMrFpzW1.json
@@ -1,0 +1,53 @@
+{
+	"_id": "DtswEluGPMrFpzW1",
+	"_key": "!items!DtswEluGPMrFpzW1",
+	"effects": [
+		"HOkTvzEf4v5RBLfx",
+		"UTm25I1vjFzNqZKZ"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/bows/shortbow-leather.webp",
+	"name": "Longbow of the Elven Kings",
+	"system": {
+		"ammoClass": "arrows",
+		"baseWeapon": "longbow",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"damage": {
+			"oneHanded": "",
+			"twoHanded": "d8"
+		},
+		"description": "<p><em>A deeply curved longbow with deer antler reinforcements.</em></p><p><strong>Bonus.</strong> +1 longbow.</p><p><strong>Benefit.</strong> You have advantage on attacks with this bow against unnatural creatures and outsiders.</p><p><strong>Personality.</strong> Neutral. Proud, timeless. Believes protecting the natural order is the highest calling. Demands all unnatural creatures be found and slain.</p>",
+		"equipped": false,
+		"handedness": "",
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.b6Gm2ULKj2qyy2xJ"
+		],
+		"quantity": 1,
+		"range": "far",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"type": "ranged"
+	},
+	"type": "Weapon"
+}

--- a/data/packs/magic-items.db/magic_ink__hwarEJirfMd5BAKX.json
+++ b/data/packs/magic-items.db/magic_ink__hwarEJirfMd5BAKX.json
@@ -1,0 +1,51 @@
+{
+	"_id": "hwarEJirfMd5BAKX",
+	"_key": "!items!hwarEJirfMd5BAKX",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/tools/scribal/ink-quill-red.webp",
+	"name": "Magic Ink",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A pot of glossy, black ink that disappears as it dries.</em></p><p><strong>Benefit.</strong> The ink's writing is invisible when cool and can only be seen when warmed up by a nearby source of strong heat. There's enough for [[/r 1d4]] uses.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/melee_attack_roll_bonus__neOYG1GjgRxHKIMr.json
+++ b/data/packs/magic-items.db/melee_attack_roll_bonus__neOYG1GjgRxHKIMr.json
@@ -8,7 +8,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Melee Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/melee_attack_roll_bonus__neOYG1GjgRxHKIMr.json
+++ b/data/packs/magic-items.db/melee_attack_roll_bonus__neOYG1GjgRxHKIMr.json
@@ -1,0 +1,27 @@
+{
+	"_id": "neOYG1GjgRxHKIMr",
+	"_key": "!items.effects!hcC1kuGgQ2VdnHmj.neOYG1GjgRxHKIMr",
+	"changes": [
+		{
+			"key": "system.bonuses.meleeAttackBonus",
+			"mode": 2,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Melee Attack Roll Bonus",
+	"origin": "Item.WQAnfvteIZallISc",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/melee_damage_bonus__SzyJeSkWrWDD64zP.json
+++ b/data/packs/magic-items.db/melee_damage_bonus__SzyJeSkWrWDD64zP.json
@@ -1,0 +1,29 @@
+{
+	"_id": "SzyJeSkWrWDD64zP",
+	"_key": "!items.effects!hcC1kuGgQ2VdnHmj.SzyJeSkWrWDD64zP",
+	"changes": [
+		{
+			"key": "system.roll.melee.damage.all",
+			"mode": 2,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/skills/melee/strike-axe-blood-red.webp",
+	"name": "Melee Damage Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.hcC1kuGgQ2VdnHmj",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/melee_damage_bonus__SzyJeSkWrWDD64zP.json
+++ b/data/packs/magic-items.db/melee_damage_bonus__SzyJeSkWrWDD64zP.json
@@ -8,7 +8,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Melee Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/memnon_s_blazing_javelin__Nz0Wzbzgwa74gEgQ.json
+++ b/data/packs/magic-items.db/memnon_s_blazing_javelin__Nz0Wzbzgwa74gEgQ.json
@@ -1,0 +1,53 @@
+{
+	"_id": "Nz0Wzbzgwa74gEgQ",
+	"_key": "!items!Nz0Wzbzgwa74gEgQ",
+	"effects": [
+		"POfmKSqbE5nitw2s",
+		"HIFDdRlLUKbLS5zK"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/polearms/javelin.webp",
+	"name": "Memnon's Blazing Javelin",
+	"system": {
+		"ammoClass": "",
+		"baseWeapon": "javelin",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"damage": {
+			"oneHanded": "d4",
+			"twoHanded": ""
+		},
+		"description": "<p><em>This golden javelin occasionally blinks and wavers, briefly turning into a bolt of lightning.</em></p><p><strong>Bonus.</strong> +1 javelin. Can only be wielded by a chaotic being. If you also wield Memnon's Discordant Blade and Memnon's Entropic Armor, it becomes a +3 javelin.</p><p><strong>Benefit.</strong> The javelin always returns to your hand after being thrown. Once per day, when you throw this javelin, you can turn it into lightning as per the @UUID[Compendium.shadowdark.spells.Item.7uTblEDfklCO1et7]{lightning bolt} spell (no spellcasting check).</p>",
+		"equipped": false,
+		"handedness": "",
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.c35ROL1nXwC840kC"
+		],
+		"quantity": 1,
+		"range": "far",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": ""
+		},
+		"stashed": false,
+		"type": "melee"
+	},
+	"type": "Weapon"
+}

--- a/data/packs/magic-items.db/memnon_s_blazing_javelin__Nz0Wzbzgwa74gEgQ.json
+++ b/data/packs/magic-items.db/memnon_s_blazing_javelin__Nz0Wzbzgwa74gEgQ.json
@@ -44,7 +44,7 @@
 			"slots_used": 1
 		},
 		"source": {
-			"title": ""
+			"title": "core-rules"
 		},
 		"stashed": false,
 		"type": "melee"

--- a/data/packs/magic-items.db/memnon_s_blazing_javelin__completed_set___5gdNWsFJjgmtZroK.json
+++ b/data/packs/magic-items.db/memnon_s_blazing_javelin__completed_set___5gdNWsFJjgmtZroK.json
@@ -1,0 +1,53 @@
+{
+	"_id": "5gdNWsFJjgmtZroK",
+	"_key": "!items!5gdNWsFJjgmtZroK",
+	"effects": [
+		"POfmKSqbE5nitw2s",
+		"HIFDdRlLUKbLS5zK"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/polearms/javelin.webp",
+	"name": "Memnon's Blazing Javelin (Completed Set)",
+	"system": {
+		"ammoClass": "",
+		"baseWeapon": "javelin",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"damage": {
+			"oneHanded": "d4",
+			"twoHanded": ""
+		},
+		"description": "<p><em>This golden javelin occasionally blinks and wavers, briefly turning into a bolt of lightning.</em></p><p><strong>Bonus.</strong> +1 javelin. Can only be wielded by a chaotic being. If you also wield Memnon's Discordant Blade and Memnon's Entropic Armor, it becomes a +3 javelin.</p><p><strong>Benefit.</strong> The javelin always returns to your hand after being thrown. Once per day, when you throw this javelin, you can turn it into lightning as per the @UUID[Compendium.shadowdark.spells.Item.7uTblEDfklCO1et7]{lightning bolt} spell (no spellcasting check).</p>",
+		"equipped": false,
+		"handedness": "",
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.c35ROL1nXwC840kC"
+		],
+		"quantity": 1,
+		"range": "far",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": ""
+		},
+		"stashed": false,
+		"type": "melee"
+	},
+	"type": "Weapon"
+}

--- a/data/packs/magic-items.db/memnon_s_blazing_javelin__completed_set___5gdNWsFJjgmtZroK.json
+++ b/data/packs/magic-items.db/memnon_s_blazing_javelin__completed_set___5gdNWsFJjgmtZroK.json
@@ -44,7 +44,7 @@
 			"slots_used": 1
 		},
 		"source": {
-			"title": ""
+			"title": "core-rules"
 		},
 		"stashed": false,
 		"type": "melee"

--- a/data/packs/magic-items.db/memnon_s_blazing_javelin__completed_set___5gdNWsFJjgmtZroK.json
+++ b/data/packs/magic-items.db/memnon_s_blazing_javelin__completed_set___5gdNWsFJjgmtZroK.json
@@ -2,8 +2,8 @@
 	"_id": "5gdNWsFJjgmtZroK",
 	"_key": "!items!5gdNWsFJjgmtZroK",
 	"effects": [
-		"POfmKSqbE5nitw2s",
-		"HIFDdRlLUKbLS5zK"
+		"8DPxbb4aUGGtrGlG",
+		"doAgFd0Q4WixkRrC"
 	],
 	"flags": {
 	},

--- a/data/packs/magic-items.db/memnon_s_discordant_blade__5vaHRsgVMO4v6ePR.json
+++ b/data/packs/magic-items.db/memnon_s_discordant_blade__5vaHRsgVMO4v6ePR.json
@@ -1,0 +1,53 @@
+{
+	"_id": "5vaHRsgVMO4v6ePR",
+	"_key": "!items!5vaHRsgVMO4v6ePR",
+	"effects": [
+		"MYoK22maOIV6Z0VE",
+		"qx4j9GoWPYmbbu9g"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/swords/greatsword-crossguard-flanged-red.webp",
+	"name": "Memnon's Discordant Blade",
+	"system": {
+		"ammoClass": "",
+		"baseWeapon": "greatsword",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"damage": {
+			"oneHanded": "",
+			"twoHanded": "d12"
+		},
+		"description": "<p><em>This barbed greatsword's red blade trails a shower of sparks when swung to strike.</em></p><p><strong>Bonus.</strong> +1 greatsword. Can only be wielded by a chaotic being. If you also wield Memnon's Entropic Armor and Memnon's Blazing Javelin, it becomes a +3 greatsword.</p><p><strong>Benefit.</strong> Once per day, you can utterly annihilate one creature of level 9 or less that you damage with this blade. The creature can pass a [[request 18 con]] check to take [[/r 3d8]] damage instead.</p><p><strong>Curse.</strong> You cannot relinquish ownership of this blade unless it is taken from you by a creature that defeats you in combat. For each day you do not slay a LV 2 or greater creature with this sword, you lose [[/r 1d6]] hit points. These are restored only when you kill a LV 2 or greater creature with the sword.</p>",
+		"equipped": false,
+		"handedness": "",
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.b6Gm2ULKj2qyy2xJ"
+		],
+		"quantity": 1,
+		"range": "close",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 2
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"type": "melee"
+	},
+	"type": "Weapon"
+}

--- a/data/packs/magic-items.db/memnon_s_discordant_blade__completed_set___4BkbHe0cL8Zvsd7a.json
+++ b/data/packs/magic-items.db/memnon_s_discordant_blade__completed_set___4BkbHe0cL8Zvsd7a.json
@@ -1,0 +1,53 @@
+{
+	"_id": "4BkbHe0cL8Zvsd7a",
+	"_key": "!items!4BkbHe0cL8Zvsd7a",
+	"effects": [
+		"MYoK22maOIV6Z0VE",
+		"qx4j9GoWPYmbbu9g"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/swords/greatsword-crossguard-flanged-red.webp",
+	"name": "Memnon's Discordant Blade (Completed Set)",
+	"system": {
+		"ammoClass": "",
+		"baseWeapon": "greatsword",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"damage": {
+			"oneHanded": "",
+			"twoHanded": "d12"
+		},
+		"description": "<p><em>This barbed greatsword's red blade trails a shower of sparks when swung to strike.</em></p><p><strong>Bonus.</strong> +1 greatsword. Can only be wielded by a chaotic being. If you also wield Memnon's Entropic Armor and Memnon's Blazing Javelin, it becomes a +3 greatsword.</p><p><strong>Benefit.</strong> Once per day, you can utterly annihilate one creature of level 9 or less that you damage with this blade. The creature can pass a [[request 18 con]] check to take [[/r 3d8]] damage instead.</p><p><strong>Curse.</strong> You cannot relinquish ownership of this blade unless it is taken from you by a creature that defeats you in combat. For each day you do not slay a LV 2 or greater creature with this sword, you lose [[/r 1d6]] hit points. These are restored only when you kill a LV 2 or greater creature with the sword.</p>",
+		"equipped": false,
+		"handedness": "",
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.b6Gm2ULKj2qyy2xJ"
+		],
+		"quantity": 1,
+		"range": "close",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 2
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"type": "melee"
+	},
+	"type": "Weapon"
+}

--- a/data/packs/magic-items.db/memnon_s_discordant_blade__completed_set___4BkbHe0cL8Zvsd7a.json
+++ b/data/packs/magic-items.db/memnon_s_discordant_blade__completed_set___4BkbHe0cL8Zvsd7a.json
@@ -2,8 +2,8 @@
 	"_id": "4BkbHe0cL8Zvsd7a",
 	"_key": "!items!4BkbHe0cL8Zvsd7a",
 	"effects": [
-		"MYoK22maOIV6Z0VE",
-		"qx4j9GoWPYmbbu9g"
+		"Z4UACwRTky38K63x",
+		"dbXv9ddp6TR15AFk"
 	],
 	"flags": {
 	},

--- a/data/packs/magic-items.db/memnon_s_entropic_armor__completed_set___SaFi5epjplNcIBhL.json
+++ b/data/packs/magic-items.db/memnon_s_entropic_armor__completed_set___SaFi5epjplNcIBhL.json
@@ -1,0 +1,49 @@
+{
+	"_id": "SaFi5epjplNcIBhL",
+	"_key": "!items!SaFi5epjplNcIBhL",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/equipment/chest/breastplate-cuirass-steel-blue.webp",
+	"name": "Memnon's Entropic Armor (Completed Set)",
+	"system": {
+		"ac": {
+			"attribute": "",
+			"base": 15,
+			"modifier": 3
+		},
+		"baseArmor": "plate-mail",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 130,
+			"sp": 0
+		},
+		"description": "<p><em>Deep blue plate mail traced with gold lightning motifs and red gems arrayed into the shape of flames.</em></p><p><strong>Bonus.</strong> +1 plate mail. Can only be worn by a chaotic being. If you also wield Memnon's Discordant Blade and Memnon's Blazing Javelin, it becomes +3 plate mail.</p><p><strong>Benefit.</strong> Once per day, you can speak the armor's command word. Until your next turn, all non-magical weapons that strike you are instantly unmade, shattering into dust. You take no damage from them.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.WhfSBiji8VG1mMzV",
+			"Compendium.shadowdark.properties.Item.kBLs47xhX1snaDGA"
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 3
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}

--- a/data/packs/magic-items.db/memnon_s_entropic_armor__u9WwthDIOfRjI0Px.json
+++ b/data/packs/magic-items.db/memnon_s_entropic_armor__u9WwthDIOfRjI0Px.json
@@ -1,0 +1,49 @@
+{
+	"_id": "u9WwthDIOfRjI0Px",
+	"_key": "!items!u9WwthDIOfRjI0Px",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/equipment/chest/breastplate-cuirass-steel-blue.webp",
+	"name": "Memnon's Entropic Armor",
+	"system": {
+		"ac": {
+			"attribute": "",
+			"base": 15,
+			"modifier": 1
+		},
+		"baseArmor": "plate-mail",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 130,
+			"sp": 0
+		},
+		"description": "<p><em>Deep blue plate mail traced with gold lightning motifs and red gems arrayed into the shape of flames.</em></p><p><strong>Bonus.</strong> +1 plate mail. Can only be worn by a chaotic being. If you also wield Memnon's Discordant Blade and Memnon's Blazing Javelin, it becomes +3 plate mail.</p><p><strong>Benefit.</strong> Once per day, you can speak the armor's command word. Until your next turn, all non-magical weapons that strike you are instantly unmade, shattering into dust. You take no damage from them.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.WhfSBiji8VG1mMzV",
+			"Compendium.shadowdark.properties.Item.kBLs47xhX1snaDGA"
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 3
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}

--- a/data/packs/magic-items.db/mirror_of_mischief__LCfKStEtJi9WIRoL.json
+++ b/data/packs/magic-items.db/mirror_of_mischief__LCfKStEtJi9WIRoL.json
@@ -1,0 +1,51 @@
+{
+	"_id": "LCfKStEtJi9WIRoL",
+	"_key": "!items!LCfKStEtJi9WIRoL",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/sundries/survival/mirror-plain.webp",
+	"name": "Mirror of Mischief",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A full-length mirror polished to a gleaming shine. Grinning, silver demons grasp the mirror, their claws forming its frame.</em></p><p><strong>Curse.</strong> The first time a humanoid creature looks into this mirror, the mirror creates an evil and malicious duplicate of them. The duplicate can step from the mirror and is an exact copy of the subject (except for magical gear, which looks identical but is mundane in nature). The evil duplicate can live indefinitely outside the mirror. It attempts to sow chaos in the life of the creature it duplicated.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/moonwrought_chainmail__v2khQSVLOXjdYA4j.json
+++ b/data/packs/magic-items.db/moonwrought_chainmail__v2khQSVLOXjdYA4j.json
@@ -1,0 +1,47 @@
+{
+	"_id": "v2khQSVLOXjdYA4j",
+	"_key": "!items!v2khQSVLOXjdYA4j",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/equipment/chest/breastplate-layered-leather-green.webp",
+	"name": "Moonwrought Chainmail",
+	"system": {
+		"ac": {
+			"attribute": "dex",
+			"base": 13,
+			"modifier": 1
+		},
+		"baseArmor": "chainmail",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 240,
+			"sp": 0
+		},
+		"description": "<p><em>A luminous jacket of chainmail as lightweight as a silk shirt.</em></p><p><strong>Bonus.</strong> +1 mithral chainmail.</p><p><strong>Benefit.</strong> Once per day, you can speak the armor's command word. You gain a +1 bonus to your next spellcasting check or ranged attack.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}

--- a/data/packs/magic-items.db/moonwrought_chainmail__v2khQSVLOXjdYA4j.json
+++ b/data/packs/magic-items.db/moonwrought_chainmail__v2khQSVLOXjdYA4j.json
@@ -2,6 +2,7 @@
 	"_id": "v2khQSVLOXjdYA4j",
 	"_key": "!items!v2khQSVLOXjdYA4j",
 	"effects": [
+		"Kf2eneYOrzvxxnWU"
 	],
 	"flags": {
 	},

--- a/data/packs/magic-items.db/necklace_of_charm__Bm8NbNaVH1pUerSh.json
+++ b/data/packs/magic-items.db/necklace_of_charm__Bm8NbNaVH1pUerSh.json
@@ -1,0 +1,48 @@
+{
+	"_id": "Bm8NbNaVH1pUerSh",
+	"_key": "!items!Bm8NbNaVH1pUerSh",
+	"effects": [
+		"MN2vxYiGWgfQSbpi"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/equipment/neck/choker-chain-thin-gold.webp",
+	"name": "Necklace of Charm",
+	"system": {
+		"ac": {
+			"attribute": "dex",
+			"base": 0,
+			"modifier": 0
+		},
+		"baseArmor": "",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A gold, fishbone chain that shimmers with subtle beauty.</em></p><p><strong>Benefit.</strong> Your Charisma stat becomes 18 (+4) while wearing this necklace.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}

--- a/data/packs/magic-items.db/necrotic_mace_of_withering__r4V3eAGkZ1klmFe7.json
+++ b/data/packs/magic-items.db/necrotic_mace_of_withering__r4V3eAGkZ1klmFe7.json
@@ -1,0 +1,52 @@
+{
+	"_id": "r4V3eAGkZ1klmFe7",
+	"_key": "!items!r4V3eAGkZ1klmFe7",
+	"effects": [
+		"Qt03jfl943CxPGeL",
+		"CaRqa4l3vE2ZALbE"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/maces/mace-round-ornate-purple.webp",
+	"name": "Necrotic Mace of Withering",
+	"system": {
+		"ammoClass": "",
+		"baseWeapon": "mace",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"damage": {
+			"oneHanded": "d6",
+			"twoHanded": ""
+		},
+		"description": "<p><em>A wrought iron mace tipped with a heavy, screaming skull. Black ichor runs from the skull's eyes when the mace is used to channel necrotic energy.</em></p><p><strong>Bonus.</strong> +1 mace. Can only be wielded by a chaotic priest.</p><p><strong>Benefit.</strong> While holding the mace, you can turn @UUID[Compendium.shadowdark.spells.Item.N9NvonT0RL6PyiiV]{cure wounds} spells you cast into harmful magic that instead inflicts the same amount of damage it would heal.</p><p><strong>Curse.</strong> If you use the mace to cast an inverted cure wounds spell, you are haunted by nightmares that night. You must pass a [[check 12 wis]] check during your next rest or gain no benefit from resting.</p>",
+		"equipped": false,
+		"handedness": "",
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"range": "close",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"type": "melee"
+	},
+	"type": "Weapon"
+}

--- a/data/packs/magic-items.db/nightcloak_armor__VBGCekyAG0Z5wsqq.json
+++ b/data/packs/magic-items.db/nightcloak_armor__VBGCekyAG0Z5wsqq.json
@@ -1,0 +1,47 @@
+{
+	"_id": "VBGCekyAG0Z5wsqq",
+	"_key": "!items!VBGCekyAG0Z5wsqq",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/equipment/chest/breastplate-layered-leather-studded-black.webp",
+	"name": "Nightcloak Armor",
+	"system": {
+		"ac": {
+			"attribute": "dex",
+			"base": 11,
+			"modifier": 1
+		},
+		"baseArmor": "",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 10,
+			"sp": 0
+		},
+		"description": "<p><em>Matte black leathers enchanted to deepen and darken shadows.</em></p><p><strong>Bonus.</strong> +1 leather armor.</p><p><strong>Benefit.</strong> Once per day, you may choose to automatically pass a Dexterity check to hide.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}

--- a/data/packs/magic-items.db/obsidian_witchknife__3Wgj18VMKb0KmRHI.json
+++ b/data/packs/magic-items.db/obsidian_witchknife__3Wgj18VMKb0KmRHI.json
@@ -1,0 +1,54 @@
+{
+	"_id": "3Wgj18VMKb0KmRHI",
+	"_key": "!items!3Wgj18VMKb0KmRHI",
+	"effects": [
+		"U8i8NfAsHGKpezHN",
+		"1WtVBmSCkzVeEdL7"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/daggers/dagger-simple-violet.webp",
+	"name": "Obsidian Witchknife",
+	"system": {
+		"ammoClass": "",
+		"baseWeapon": "dagger",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 1,
+			"sp": 0
+		},
+		"damage": {
+			"oneHanded": "d4",
+			"twoHanded": ""
+		},
+		"description": "<p><em>A glinting, obsidian blade that trails black smoke in thin curls.</em></p><p><strong>Bonus.</strong> +2 dagger. Cannot be wielded by a lawful being.</p><p><strong>Benefit.</strong> When you cast a spell while holding this dagger, you may wound yourself with it. Add the amount of damage you take to your spellcasting check.</p>",
+		"equipped": false,
+		"handedness": "",
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.rqQwpoeWEqi0ZcYK",
+			"Compendium.shadowdark.properties.Item.c35ROL1nXwC840kC"
+		],
+		"quantity": 1,
+		"range": "near",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"type": "melee"
+	},
+	"type": "Weapon"
+}

--- a/data/packs/magic-items.db/onyx_destrier__WUX1XxV0f7mknPSq.json
+++ b/data/packs/magic-items.db/onyx_destrier__WUX1XxV0f7mknPSq.json
@@ -1,0 +1,51 @@
+{
+	"_id": "WUX1XxV0f7mknPSq",
+	"_key": "!items!WUX1XxV0f7mknPSq",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/sundries/gaming/chess-knite-gray.webp",
+	"name": "Onyx Destrier",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A polished, ebony statuette of a running horse.</em></p><p><strong>Benefit.</strong> Once per day, the wielder can speak the command word to turn the statuette into a @UUID[Compendium.shadowdark.monsters.Actor.bxcbuzesUqGpEBxw]{nightmare} that accepts neutral or chaotic riders. The statuette remains in this form for 1 hour.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/ophidian_armor__MyHXrPewu36OmWB6.json
+++ b/data/packs/magic-items.db/ophidian_armor__MyHXrPewu36OmWB6.json
@@ -2,6 +2,7 @@
 	"_id": "MyHXrPewu36OmWB6",
 	"_key": "!items!MyHXrPewu36OmWB6",
 	"effects": [
+		"Jezaa6jJyGQpprzu"
 	],
 	"flags": {
 	},

--- a/data/packs/magic-items.db/permanent_ability__cha___07RIJ800mgt95fNl.json
+++ b/data/packs/magic-items.db/permanent_ability__cha___07RIJ800mgt95fNl.json
@@ -9,7 +9,7 @@
 			"value": "18"
 		}
 	],
-	"description": "",
+	"description": "Permanent Ability (Cha)",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/permanent_ability__cha___MN2vxYiGWgfQSbpi.json
+++ b/data/packs/magic-items.db/permanent_ability__cha___MN2vxYiGWgfQSbpi.json
@@ -8,7 +8,7 @@
 			"value": "18"
 		}
 	],
-	"description": "",
+	"description": "Permanent Ability (Cha)",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/permanent_ability__cha___MN2vxYiGWgfQSbpi.json
+++ b/data/packs/magic-items.db/permanent_ability__cha___MN2vxYiGWgfQSbpi.json
@@ -1,0 +1,29 @@
+{
+	"_id": "MN2vxYiGWgfQSbpi",
+	"_key": "!items.effects!Bm8NbNaVH1pUerSh.MN2vxYiGWgfQSbpi",
+	"changes": [
+		{
+			"key": "system.abilities.cha.value",
+			"mode": 5,
+			"value": "18"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/skills/melee/strike-axe-blood-red.webp",
+	"name": "Permanent Ability (Cha)",
+	"origin": "Compendium.shadowdark.magic-items.Item.Bm8NbNaVH1pUerSh",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/permanent_ability__con___s6ifDUJHIkwx5wvx.json
+++ b/data/packs/magic-items.db/permanent_ability__con___s6ifDUJHIkwx5wvx.json
@@ -8,7 +8,7 @@
 			"value": "18"
 		}
 	],
-	"description": "",
+	"description": "Permanent Ability (Con)",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/permanent_ability__con___s6ifDUJHIkwx5wvx.json
+++ b/data/packs/magic-items.db/permanent_ability__con___s6ifDUJHIkwx5wvx.json
@@ -1,0 +1,29 @@
+{
+	"_id": "s6ifDUJHIkwx5wvx",
+	"_key": "!items.effects!qHyL2dlqQaxwMzKX.s6ifDUJHIkwx5wvx",
+	"changes": [
+		{
+			"key": "system.abilities.con.value",
+			"mode": 5,
+			"value": "18"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/skills/melee/strike-axe-blood-red.webp",
+	"name": "Permanent Ability (Con)",
+	"origin": "Compendium.shadowdark.magic-items.Item.qHyL2dlqQaxwMzKX",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/permanent_ability__con___zrPgEyvt0Qpp6rca.json
+++ b/data/packs/magic-items.db/permanent_ability__con___zrPgEyvt0Qpp6rca.json
@@ -9,7 +9,7 @@
 			"value": "18"
 		}
 	],
-	"description": "",
+	"description": "Permanent Ability (Con)",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/permanent_ability__dex___2iAdf3ZD4FdzPonT.json
+++ b/data/packs/magic-items.db/permanent_ability__dex___2iAdf3ZD4FdzPonT.json
@@ -9,7 +9,7 @@
 			"value": "18"
 		}
 	],
-	"description": "",
+	"description": "Permanent Ability (Dex)",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/permanent_ability__dex___I9RcaNvoUpSqiWUz.json
+++ b/data/packs/magic-items.db/permanent_ability__dex___I9RcaNvoUpSqiWUz.json
@@ -1,0 +1,29 @@
+{
+	"_id": "I9RcaNvoUpSqiWUz",
+	"_key": "!items.effects!Ka1NPr6edk9cwrzo.I9RcaNvoUpSqiWUz",
+	"changes": [
+		{
+			"key": "system.abilities.dex.value",
+			"mode": 5,
+			"value": "18"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/skills/melee/strike-axe-blood-red.webp",
+	"name": "Permanent Ability (Dex)",
+	"origin": "Compendium.shadowdark.magic-items.Item.Ka1NPr6edk9cwrzo",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/permanent_ability__dex___I9RcaNvoUpSqiWUz.json
+++ b/data/packs/magic-items.db/permanent_ability__dex___I9RcaNvoUpSqiWUz.json
@@ -8,7 +8,7 @@
 			"value": "18"
 		}
 	],
-	"description": "",
+	"description": "Permanent Ability (Dex)",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/permanent_ability__int___94JaF8oYeiAAWASd.json
+++ b/data/packs/magic-items.db/permanent_ability__int___94JaF8oYeiAAWASd.json
@@ -9,7 +9,7 @@
 			"value": "18"
 		}
 	],
-	"description": "",
+	"description": "Permanent Ability (Int)",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/permanent_ability__int___fEHEHVFcLflsUsCv.json
+++ b/data/packs/magic-items.db/permanent_ability__int___fEHEHVFcLflsUsCv.json
@@ -1,0 +1,29 @@
+{
+	"_id": "fEHEHVFcLflsUsCv",
+	"_key": "!items.effects!BJ59d0lCvvMKSbu7.fEHEHVFcLflsUsCv",
+	"changes": [
+		{
+			"key": "system.abilities.int.value",
+			"mode": 5,
+			"value": "18"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/skills/melee/strike-axe-blood-red.webp",
+	"name": "Permanent Ability (Int)",
+	"origin": "Compendium.shadowdark.magic-items.Item.BJ59d0lCvvMKSbu7",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/permanent_ability__int___fEHEHVFcLflsUsCv.json
+++ b/data/packs/magic-items.db/permanent_ability__int___fEHEHVFcLflsUsCv.json
@@ -8,7 +8,7 @@
 			"value": "18"
 		}
 	],
-	"description": "",
+	"description": "Permanent Ability (Int)",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/permanent_ability__str___N3a7CEwOlseizR4z.json
+++ b/data/packs/magic-items.db/permanent_ability__str___N3a7CEwOlseizR4z.json
@@ -9,7 +9,7 @@
 			"value": "18"
 		}
 	],
-	"description": "",
+	"description": "Permanent Ability (Str)",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/permanent_ability__str___mEwSq29I1Sr8gG2t.json
+++ b/data/packs/magic-items.db/permanent_ability__str___mEwSq29I1Sr8gG2t.json
@@ -9,7 +9,7 @@
 			"value": "18"
 		}
 	],
-	"description": "",
+	"description": "Permanent Ability (Str)",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/permanent_ability__wis___FKzhrPnFt0njaDh8.json
+++ b/data/packs/magic-items.db/permanent_ability__wis___FKzhrPnFt0njaDh8.json
@@ -8,7 +8,7 @@
 			"value": "18"
 		}
 	],
-	"description": "",
+	"description": "Permanent Ability (Wis)",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/permanent_ability__wis___FKzhrPnFt0njaDh8.json
+++ b/data/packs/magic-items.db/permanent_ability__wis___FKzhrPnFt0njaDh8.json
@@ -1,0 +1,29 @@
+{
+	"_id": "FKzhrPnFt0njaDh8",
+	"_key": "!items.effects!yE6fl9FlZldHBupD.FKzhrPnFt0njaDh8",
+	"changes": [
+		{
+			"key": "system.abilities.wis.value",
+			"mode": 5,
+			"value": "18"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/skills/melee/strike-axe-blood-red.webp",
+	"name": "Permanent Ability (Wis)",
+	"origin": "Compendium.shadowdark.magic-items.Item.yE6fl9FlZldHBupD",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/permanent_ability__wis___JGN2W0klkumjFNoV.json
+++ b/data/packs/magic-items.db/permanent_ability__wis___JGN2W0klkumjFNoV.json
@@ -8,7 +8,7 @@
 			"value": "18"
 		}
 	],
-	"description": "",
+	"description": "Permanent Ability (Wis)",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/permanent_ability__wis___JGN2W0klkumjFNoV.json
+++ b/data/packs/magic-items.db/permanent_ability__wis___JGN2W0klkumjFNoV.json
@@ -1,0 +1,27 @@
+{
+	"_id": "JGN2W0klkumjFNoV",
+	"_key": "!items.effects!yE6fl9FlZldHBupD.JGN2W0klkumjFNoV",
+	"changes": [
+		{
+			"key": "system.abilities.wis.base",
+			"mode": 5,
+			"value": "18"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"img": "icons/skills/melee/strike-axe-blood-red.webp",
+	"name": "Permanent Ability (Wis)",
+	"origin": "Compendium.shadowdark.magic-items.Item.yE6fl9FlZldHBupD",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/permanent_ability__wis___cUIGFlc2YR57pzXl.json
+++ b/data/packs/magic-items.db/permanent_ability__wis___cUIGFlc2YR57pzXl.json
@@ -9,7 +9,7 @@
 			"value": "18"
 		}
 	],
-	"description": "",
+	"description": "Permanent Ability (Wis)",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/permanentability__1sKZFEAOhR1t3W5D.json
+++ b/data/packs/magic-items.db/permanentability__1sKZFEAOhR1t3W5D.json
@@ -9,7 +9,7 @@
 			"value": "18"
 		}
 	],
-	"description": "",
+	"description": "permanentAbility",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/pipe_of_the_rolling_hills__0NAHhZTnQxABY5KR.json
+++ b/data/packs/magic-items.db/pipe_of_the_rolling_hills__0NAHhZTnQxABY5KR.json
@@ -1,0 +1,51 @@
+{
+	"_id": "0NAHhZTnQxABY5KR",
+	"_key": "!items!0NAHhZTnQxABY5KR",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/sundries/misc/pipe-wooden-curved-oak.webp",
+	"name": "Pipe of the Rolling Hills",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A long, curved pipe that smells of cloves and resin.</em></p><p><strong>Benefit.</strong> Up to three times per day, regain [[/r 1d4]] hit points when you smoke this pipe.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/pipes_of_the_sewers__H7bYrQvVPrcT2WNA.json
+++ b/data/packs/magic-items.db/pipes_of_the_sewers__H7bYrQvVPrcT2WNA.json
@@ -1,0 +1,51 @@
+{
+	"_id": "H7bYrQvVPrcT2WNA",
+	"_key": "!items!H7bYrQvVPrcT2WNA",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/tools/instruments/pipe-flue-tan.webp",
+	"name": "Pipes of the Sewers",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A set of tarnished, brass pan pipes with seven cylinders.</em></p><p><strong>Benefit.</strong> Once per day, you can play these pipes to summon [[/r 2d6]] @UUID[Compendium.shadowdark.monsters.Actor.OYtg4Ta4PIpvIZxq]{giant rats}. The rats obey you for [[/r 1d6]] rounds, and then they scatter and flee.</p><p><strong>Curse.</strong> If you stop playing while the rats are present, they turn on you and attack.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/portable_hole__XqUtkdpMMHiMhDF8.json
+++ b/data/packs/magic-items.db/portable_hole__XqUtkdpMMHiMhDF8.json
@@ -1,0 +1,51 @@
+{
+	"_id": "XqUtkdpMMHiMhDF8",
+	"_key": "!items!XqUtkdpMMHiMhDF8",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/creatures/eyes/void-single-black-purple.webp",
+	"name": "Portable Hole",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A black, velvet square of cloth that unfolds into a wide circle.</em></p><p><strong>Benefit.</strong> The Portable Hole folds open on a flat surface into a 6-foot wide, 6-foot deep hole. It has 20 gear slots of storage. The hole closes when you fold the cloth into a small square.</p><p><strong>Curse.</strong> Placing this item inside a Bag of Holding or another Portable Hole destroys both items and all held inside them.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/potion_of_flying__yyJOvnqhX1euicdL.json
+++ b/data/packs/magic-items.db/potion_of_flying__yyJOvnqhX1euicdL.json
@@ -1,0 +1,48 @@
+{
+	"_id": "yyJOvnqhX1euicdL",
+	"_key": "!items!yyJOvnqhX1euicdL",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/consumables/potions/bottle-round-label-cork-yellow.webp",
+	"name": "Potion of Flying",
+	"system": {
+		"broken": false,
+		"class": [
+		],
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A sunny liquid with bubbles that flash and pop like tiny stars.</em></p><p><strong>Benefit.</strong> You can fly a near distance for 10 rounds when you drink this potion.</p>",
+		"duration": {
+			"type": "rounds"
+		},
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"lost": false,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"range": "near",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Potion"
+}

--- a/data/packs/magic-items.db/potion_of_forgetfulness__aw7hHQoAE6rlpR3R.json
+++ b/data/packs/magic-items.db/potion_of_forgetfulness__aw7hHQoAE6rlpR3R.json
@@ -1,0 +1,48 @@
+{
+	"_id": "aw7hHQoAE6rlpR3R",
+	"_key": "!items!aw7hHQoAE6rlpR3R",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/consumables/potions/potion-flask-corled-pink-red.webp",
+	"name": "Potion of Forgetfulness",
+	"system": {
+		"broken": false,
+		"class": [
+		],
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A pink draught that swirls with a counter-clockwise current.</em></p><p><strong>Benefit.</strong> If you serve this potion to an intelligent being and that being drinks it, the imbiber permanently forgets one memory of your choosing.</p>",
+		"duration": {
+			"type": "rounds"
+		},
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"lost": false,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"range": "near",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Potion"
+}

--- a/data/packs/magic-items.db/potion_of_giant_strength__Ap6sRdj5Jd54oUrq.json
+++ b/data/packs/magic-items.db/potion_of_giant_strength__Ap6sRdj5Jd54oUrq.json
@@ -1,0 +1,48 @@
+{
+	"_id": "Ap6sRdj5Jd54oUrq",
+	"_key": "!items!Ap6sRdj5Jd54oUrq",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/consumables/potions/bottle-conical-corked-green.webp",
+	"name": "Potion of Giant Strength",
+	"system": {
+		"broken": false,
+		"class": [
+		],
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A clay jar holding a stew of green, leafy sludge.</em></p><p><strong>Benefit.</strong> Your Strength becomes 18 (+4) and you deal x2 damage on melee attacks for 10 rounds.</p>",
+		"duration": {
+			"type": "rounds"
+		},
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"lost": false,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"range": "near",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Potion"
+}

--- a/data/packs/magic-items.db/potion_of_legendary_deeds__9Nbvjkl5WEl108wI.json
+++ b/data/packs/magic-items.db/potion_of_legendary_deeds__9Nbvjkl5WEl108wI.json
@@ -1,0 +1,48 @@
+{
+	"_id": "9Nbvjkl5WEl108wI",
+	"_key": "!items!9Nbvjkl5WEl108wI",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/consumables/potions/potion-flask-corked-orange.webp",
+	"name": "Potion of Legendary Deeds",
+	"system": {
+		"broken": false,
+		"class": [
+		],
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A golden elixir that resonates with a faint, angelic chord.</em></p><p><strong>Benefit.</strong> When you drink this potion, you gain one level and your XP total resets to zero.</p>",
+		"duration": {
+			"type": "rounds"
+		},
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"lost": false,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"range": "near",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Potion"
+}

--- a/data/packs/magic-items.db/potion_of_polymorph__YF9uaDDWLwFCYanF.json
+++ b/data/packs/magic-items.db/potion_of_polymorph__YF9uaDDWLwFCYanF.json
@@ -1,0 +1,48 @@
+{
+	"_id": "YF9uaDDWLwFCYanF",
+	"_key": "!items!YF9uaDDWLwFCYanF",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/consumables/potions/potion-bottle-labeled-stopped-purple.webp",
+	"name": "Potion of Polymorph",
+	"system": {
+		"broken": false,
+		"class": [
+		],
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A pickled newt floats in this lavender flask of clear liquid.</em></p><p><strong>Benefit.</strong> When you drink this potion, it casts the @UUID[Compendium.shadowdark.spells.Item.1ZAZQsFvPBEZPkVP]{polymorph} spell (pg. 67) on you with a duration of 1 hour instead of 10 rounds.</p>",
+		"duration": {
+			"type": "rounds"
+		},
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"lost": false,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"range": "near",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Potion"
+}

--- a/data/packs/magic-items.db/potion_of_vitality__emEwhB9r2Q1k8hVj.json
+++ b/data/packs/magic-items.db/potion_of_vitality__emEwhB9r2Q1k8hVj.json
@@ -1,0 +1,48 @@
+{
+	"_id": "emEwhB9r2Q1k8hVj",
+	"_key": "!items!emEwhB9r2Q1k8hVj",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/consumables/potions/bottle-corked-red.webp",
+	"name": "Potion of Vitality",
+	"system": {
+		"broken": false,
+		"class": [
+		],
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A crimson elixir that gently thumps with a heartbeat.</em></p><p><strong>Benefit.</strong> When you drink this potion, roll your class's hit points die. You permanently gain that many HP.</p><p><strong>Curse.</strong> If you drink more than one Potion of Vitality in your lifetime, you must pass a [[check 18 con]] check each time or die instantly.</p>",
+		"duration": {
+			"type": "rounds"
+		},
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"lost": false,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"range": "near",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Potion"
+}

--- a/data/packs/magic-items.db/ranged_damage_bonus__yQZ0cvsfdvrSTM4o.json
+++ b/data/packs/magic-items.db/ranged_damage_bonus__yQZ0cvsfdvrSTM4o.json
@@ -8,7 +8,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Ranged Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/ranged_damage_bonus__yQZ0cvsfdvrSTM4o.json
+++ b/data/packs/magic-items.db/ranged_damage_bonus__yQZ0cvsfdvrSTM4o.json
@@ -1,0 +1,29 @@
+{
+	"_id": "yQZ0cvsfdvrSTM4o",
+	"_key": "!items.effects!j0WXRAkFtjg9LYKS.yQZ0cvsfdvrSTM4o",
+	"changes": [
+		{
+			"key": "system.roll.ranged.damage.all",
+			"mode": 2,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/skills/melee/strike-axe-blood-red.webp",
+	"name": "Ranged Damage Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.j0WXRAkFtjg9LYKS",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/ranged_damage_bonus__yrS7j3rhCRynCLL6.json
+++ b/data/packs/magic-items.db/ranged_damage_bonus__yrS7j3rhCRynCLL6.json
@@ -1,0 +1,27 @@
+{
+	"_id": "yrS7j3rhCRynCLL6",
+	"_key": "!items.effects!j0WXRAkFtjg9LYKS.yrS7j3rhCRynCLL6",
+	"changes": [
+		{
+			"key": "system.bonuses.rangedDamageBonus",
+			"mode": 2,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"img": "icons/skills/melee/strike-axe-blood-red.webp",
+	"name": "Ranged Damage Bonus",
+	"origin": "Item.lD298MxRkDjTggZd",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/ranged_damage_bonus__yrS7j3rhCRynCLL6.json
+++ b/data/packs/magic-items.db/ranged_damage_bonus__yrS7j3rhCRynCLL6.json
@@ -8,7 +8,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Ranged Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/ring_of_feather_falling__dGfhC5esJRavsNGW.json
+++ b/data/packs/magic-items.db/ring_of_feather_falling__dGfhC5esJRavsNGW.json
@@ -1,0 +1,47 @@
+{
+	"_id": "dGfhC5esJRavsNGW",
+	"_key": "!items!dGfhC5esJRavsNGW",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/equipment/finger/ring-shell-white-blue.webp",
+	"name": "Ring of Feather Falling",
+	"system": {
+		"ac": {
+			"attribute": "dex",
+			"base": 0,
+			"modifier": 0
+		},
+		"baseArmor": "",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A pearly ring carved in the likeness of an owl feather.</em></p><p><strong>Benefit.</strong> Once per day, the ring can cast @UUID[Compendium.shadowdark.spells.Item.0ejsM2UIZDHs5u2f]{feather fall }(pg. 60) on you when you fall.</p><p><strong>Personality.</strong> Neutral. Fearful of heights. Mentally hoots in an owl-like voice to stay away from the edge of cliffs and pits.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}

--- a/data/packs/magic-items.db/ring_of_fireballs__qMJ2GeLJ6DS7soRG.json
+++ b/data/packs/magic-items.db/ring_of_fireballs__qMJ2GeLJ6DS7soRG.json
@@ -1,0 +1,47 @@
+{
+	"_id": "qMJ2GeLJ6DS7soRG",
+	"_key": "!items!qMJ2GeLJ6DS7soRG",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/equipment/finger/ring-cabochon-thin-copper-red.webp",
+	"name": "Ring of Fireballs",
+	"system": {
+		"ac": {
+			"attribute": "dex",
+			"base": 0,
+			"modifier": 0
+		},
+		"baseArmor": "",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A bronze loop with claws holding a red marble. A fiery miasma swirls inside the glass.</em></p><p><strong>Benefit.</strong> You can pluck the glass marble from the ring and throw it up to a far distance, causing a @UUID[Compendium.shadowdark.spells.Item.j2gvzfnMGQwxqgGg]{fireball} spell (pg. 60) to bloom at the site of impact. The glass marble regrows after you successfully complete a rest.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}

--- a/data/packs/magic-items.db/ring_of_invisibility__9esQ9xXLB2gHf0Sf.json
+++ b/data/packs/magic-items.db/ring_of_invisibility__9esQ9xXLB2gHf0Sf.json
@@ -1,0 +1,47 @@
+{
+	"_id": "9esQ9xXLB2gHf0Sf",
+	"_key": "!items!9esQ9xXLB2gHf0Sf",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/equipment/finger/ring-band-thick-rounded-gold.webp",
+	"name": "Ring of Invisibility",
+	"system": {
+		"ac": {
+			"attribute": "dex",
+			"base": 0,
+			"modifier": 0
+		},
+		"baseArmor": "",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A simple, gold band polished to a warm shine.</em></p><p><strong>Benefit.</strong> Once per day, the ring can cast the @UUID[Compendium.shadowdark.spells.Item.PZ0qPp6lG9SVMoAr]{invisibility} spell (pg. 63) on you.</p><p><strong>Curse.</strong> There is a cumulative 1% chance each time you rest that your sleep is ruined by apocalyptic nightmares, and you gain no benefit from resting. This resets to a 1% chance each time it triggers.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}

--- a/data/packs/magic-items.db/ring_of_ramlaat__slnpt7AznlHzLJva.json
+++ b/data/packs/magic-items.db/ring_of_ramlaat__slnpt7AznlHzLJva.json
@@ -1,0 +1,47 @@
+{
+	"_id": "slnpt7AznlHzLJva",
+	"_key": "!items!slnpt7AznlHzLJva",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/equipment/finger/ring-bone-spiked-white.webp",
+	"name": "Ring of Ramlaat",
+	"system": {
+		"ac": {
+			"attribute": "dex",
+			"base": 0,
+			"modifier": 0
+		},
+		"baseArmor": "",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A bone-carved ring with a ram skull. Its horns twist forward and red lights glow in its eye sockets.</em></p><p><strong>Benefit.</strong> Once per day, you can enter a rage where you deal double damage for 5 rounds. During the rage, you can't cast spells and enemies have advantage on melee attacks against you.</p><p><strong>Personality.</strong> Chaotic. Aggressive, overconfident. Seeks to provoke you and your enemies into battle.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}

--- a/data/packs/magic-items.db/robe_of_the_archmage__h2i73FkXUZZybLc1.json
+++ b/data/packs/magic-items.db/robe_of_the_archmage__h2i73FkXUZZybLc1.json
@@ -1,0 +1,48 @@
+{
+	"_id": "h2i73FkXUZZybLc1",
+	"_key": "!items!h2i73FkXUZZybLc1",
+	"effects": [
+		"2O1rrQbpFSYKLiI8"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/equipment/back/cloak-collared-red-gold.webp",
+	"name": "Robe of the Archmage",
+	"system": {
+		"ac": {
+			"attribute": "dex",
+			"base": 15,
+			"modifier": 0
+		},
+		"baseArmor": "",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A red silk robe with a wide, gold-hemmed mantle. Golden eyes and moons dust its sleeves.</em></p><p><strong>Benefit.</strong> Only a wizard with the Archmage title can wear this robe. </p><p>Your unarmored AC becomes 15 plus your Dexterity modifier. </p><p>Choose three spells you know. Their spellcasting DC is always 11. </p><p>You have advantage on casting the disintegrate spell.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}

--- a/data/packs/magic-items.db/robe_of_the_druid__dupIuIdb8hVNC5gh.json
+++ b/data/packs/magic-items.db/robe_of_the_druid__dupIuIdb8hVNC5gh.json
@@ -1,0 +1,48 @@
+{
+	"_id": "dupIuIdb8hVNC5gh",
+	"_key": "!items!dupIuIdb8hVNC5gh",
+	"effects": [
+		"OJ3nY3HrPcGtdv4L"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/equipment/back/cloak-collared-leaves-green.webp",
+	"name": "Robe of the Druid",
+	"system": {
+		"ac": {
+			"attribute": "dex",
+			"base": 15,
+			"modifier": 0
+		},
+		"baseArmor": "",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A green velvet robe with a deep hood and hems embroidered with silver leaves and vines.</em></p><p><strong>Benefit.</strong> Only a wizard with the Druid title can wear this robe.</p><p>Your unarmored AC becomes 15 plus your Dexterity modifier.</p><p>Twice per day, you can regain the ability to cast one lost spell.</p><p>You have advantage on casting the @UUID[Compendium.shadowdark.spells.Item.qz6bKMyDaGyifklx]{shapechange} spell. When you cast it, its duration is 1 hour instead of focus.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}

--- a/data/packs/magic-items.db/robe_of_the_sorcerer__BMNSa23mVQ2UzDce.json
+++ b/data/packs/magic-items.db/robe_of_the_sorcerer__BMNSa23mVQ2UzDce.json
@@ -1,0 +1,48 @@
+{
+	"_id": "BMNSa23mVQ2UzDce",
+	"_key": "!items!BMNSa23mVQ2UzDce",
+	"effects": [
+		"OJ3nY3HrPcGtdv4L"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/equipment/back/cloak-hooded-blue.webp",
+	"name": "Robe of the Sorcerer",
+	"system": {
+		"ac": {
+			"attribute": "dex",
+			"base": 15,
+			"modifier": 0
+		},
+		"baseArmor": "",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A black leather robe with a shadowed cowl and clawed clasps on thin, mithral chains.</em></p><p><strong>Benefit.</strong> Only a wizard with the Sorcerer title can wear this robe.</p><p>Your unarmored AC becomes 15 plus your Dexterity modifier.</p><p>When you cast a spell that deals damage, add your Intelligence modifier to the total. You have advantage on casting the @UUID[Item.ECmGYgkY6fCSpazn]{power word kill} spell.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}

--- a/data/packs/magic-items.db/robe_of_the_sorcerer__BMNSa23mVQ2UzDce.json
+++ b/data/packs/magic-items.db/robe_of_the_sorcerer__BMNSa23mVQ2UzDce.json
@@ -2,7 +2,7 @@
 	"_id": "BMNSa23mVQ2UzDce",
 	"_key": "!items!BMNSa23mVQ2UzDce",
 	"effects": [
-		"OJ3nY3HrPcGtdv4L"
+		"BR7oklaQANiLMTwW"
 	],
 	"flags": {
 	},
@@ -22,7 +22,7 @@
 			"gp": 0,
 			"sp": 0
 		},
-		"description": "<p><em>A black leather robe with a shadowed cowl and clawed clasps on thin, mithral chains.</em></p><p><strong>Benefit.</strong> Only a wizard with the Sorcerer title can wear this robe.</p><p>Your unarmored AC becomes 15 plus your Dexterity modifier.</p><p>When you cast a spell that deals damage, add your Intelligence modifier to the total. You have advantage on casting the @UUID[Item.ECmGYgkY6fCSpazn]{power word kill} spell.</p>",
+		"description": "<p><em>A black leather robe with a shadowed cowl and clawed clasps on thin, mithral chains.</em></p><p><strong>Benefit.</strong> Only a wizard with the Sorcerer title can wear this robe.</p><p>Your unarmored AC becomes 15 plus your Dexterity modifier.</p><p>When you cast a spell that deals damage, add your Intelligence modifier to the total. You have advantage on casting the @UUID[Compendium.shadowdark.spells.Item.ttcu6Hcf7zUzxJmk]{power word kill} spell.</p>",
 		"equipped": false,
 		"identification": {
 			"description": "",

--- a/data/packs/magic-items.db/scimitar_of_the_ash_moon__Zci7qHVAp0lHEYID.json
+++ b/data/packs/magic-items.db/scimitar_of_the_ash_moon__Zci7qHVAp0lHEYID.json
@@ -1,0 +1,53 @@
+{
+	"_id": "Zci7qHVAp0lHEYID",
+	"_key": "!items!Zci7qHVAp0lHEYID",
+	"effects": [
+		"LryuYkHDYOAm4I0g",
+		"4JjKaawthhmI2NLb"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/swords/scimitar-guard-red.webp",
+	"name": "Scimitar of the Ash Moon",
+	"system": {
+		"ammoClass": "",
+		"baseWeapon": "greatsword",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 12,
+			"sp": 0
+		},
+		"damage": {
+			"oneHanded": "",
+			"twoHanded": "d12"
+		},
+		"description": "<p><em>This wide, curved blade has a snarling efreeti head on the bronze pommel.</em></p><p><strong>Bonus.</strong> +3 greatsword.</p><p><strong>Benefit.</strong> If you roll a critical hit with this weapon, the target is beheaded. It dies instantly if decapitation would kill it.</p>",
+		"equipped": false,
+		"handedness": "",
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.b6Gm2ULKj2qyy2xJ"
+		],
+		"quantity": 1,
+		"range": "close",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 2
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"type": "melee"
+	},
+	"type": "Weapon"
+}

--- a/data/packs/magic-items.db/shield_of_the_crusader__8RyBRclanxBD4pMx.json
+++ b/data/packs/magic-items.db/shield_of_the_crusader__8RyBRclanxBD4pMx.json
@@ -2,7 +2,8 @@
 	"_id": "8RyBRclanxBD4pMx",
 	"_key": "!items!8RyBRclanxBD4pMx",
 	"effects": [
-		"naxiMCPRWIxWceVj"
+		"naxiMCPRWIxWceVj",
+		"G5THNKdzVuAqhJ5Q"
 	],
 	"flags": {
 	},

--- a/data/packs/magic-items.db/shield_of_the_crusader__8RyBRclanxBD4pMx.json
+++ b/data/packs/magic-items.db/shield_of_the_crusader__8RyBRclanxBD4pMx.json
@@ -1,0 +1,50 @@
+{
+	"_id": "8RyBRclanxBD4pMx",
+	"_key": "!items!8RyBRclanxBD4pMx",
+	"effects": [
+		"naxiMCPRWIxWceVj"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/equipment/shield/kite-bronze-boss-brown.webp",
+	"name": "Shield of the Crusader",
+	"system": {
+		"ac": {
+			"attribute": "",
+			"base": 0,
+			"modifier": 2
+		},
+		"baseArmor": "",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 10,
+			"sp": 0
+		},
+		"description": "<p><em>A weighty kite shield painted with a faded, crimson cross.</em></p><p><strong>Bonus.</strong> +1 shield. Can only be wielded by a lawful being.</p><p><strong>Benefit.</strong> Once per day, you can speak a prayer to wreathe the shield in holy flames, granting +2 to your AC for 3 rounds.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.jq0m0lGb7QOCSJXL",
+			"Compendium.shadowdark.properties.Item.61gM0DuJQwLbIBwu"
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}

--- a/data/packs/magic-items.db/shield_of_the_lion__fntDmrpNulld7y2r.json
+++ b/data/packs/magic-items.db/shield_of_the_lion__fntDmrpNulld7y2r.json
@@ -1,0 +1,50 @@
+{
+	"_id": "fntDmrpNulld7y2r",
+	"_key": "!items!fntDmrpNulld7y2r",
+	"effects": [
+		"SRuuhmxcNFfK8yUo"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/equipment/shield/kite-steel-boss-gold.webp",
+	"name": "Shield of the Lion",
+	"system": {
+		"ac": {
+			"attribute": "",
+			"base": 0,
+			"modifier": 2
+		},
+		"baseArmor": "",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 10,
+			"sp": 0
+		},
+		"description": "<p><em>This shield is carved as a roaring lion's face with a flowing mane.</em></p><p><strong>Bonus.</strong> +1 shield.</p><p><strong>Benefit.</strong> Once per day, you can command the lion to animate and bellow a ferocious roar. All hostile creatures within near range must immediately make a morale check.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.jq0m0lGb7QOCSJXL",
+			"Compendium.shadowdark.properties.Item.61gM0DuJQwLbIBwu"
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}

--- a/data/packs/magic-items.db/shield_of_the_witch_king__LhREsz1KVI5yuEwM.json
+++ b/data/packs/magic-items.db/shield_of_the_witch_king__LhREsz1KVI5yuEwM.json
@@ -1,0 +1,50 @@
+{
+	"_id": "LhREsz1KVI5yuEwM",
+	"_key": "!items!LhREsz1KVI5yuEwM",
+	"effects": [
+		"UmHdci1cvynol7xU"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/equipment/shield/kite-decorative-steel-claws.webp",
+	"name": "Shield of the Witch-King",
+	"system": {
+		"ac": {
+			"attribute": "",
+			"base": 0,
+			"modifier": 2
+		},
+		"baseArmor": "",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 10,
+			"sp": 0
+		},
+		"description": "<p><em>A jagged triangle of black steel with spiny, armored plates.</em></p><p><strong>Bonus.</strong> +2 shield. Can only be wielded by a chaotic being.</p><p><strong>Benefit.</strong> You take half damage from undead creatures.</p><p><strong>Curse.</strong> If you go to 0 HP, the spirit of Ix-Natheer tries to steal your body. He blocks healing magic from affecting you. If you die, Ix-Natheer possesses you.</p><p><strong>Personality.</strong> Chaotic. The spirit of the witch-king Ix-Natheer animates this shield. He pounces on opportunities to betray his wielder so he can try to take over their body and return to unlife.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.jq0m0lGb7QOCSJXL",
+			"Compendium.shadowdark.properties.Item.61gM0DuJQwLbIBwu"
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}

--- a/data/packs/magic-items.db/silver_mace_of_wrath__bpJlJ3vnZVmvOEJV.json
+++ b/data/packs/magic-items.db/silver_mace_of_wrath__bpJlJ3vnZVmvOEJV.json
@@ -3,7 +3,8 @@
 	"_key": "!items!bpJlJ3vnZVmvOEJV",
 	"effects": [
 		"l9MlejatmWj0EesQ",
-		"Vn1UKd6iBKvZh0tc"
+		"Vn1UKd6iBKvZh0tc",
+		"G7VI8iNu9to3a2iz"
 	],
 	"flags": {
 	},

--- a/data/packs/magic-items.db/silver_mace_of_wrath__bpJlJ3vnZVmvOEJV.json
+++ b/data/packs/magic-items.db/silver_mace_of_wrath__bpJlJ3vnZVmvOEJV.json
@@ -1,0 +1,52 @@
+{
+	"_id": "bpJlJ3vnZVmvOEJV",
+	"_key": "!items!bpJlJ3vnZVmvOEJV",
+	"effects": [
+		"l9MlejatmWj0EesQ",
+		"Vn1UKd6iBKvZh0tc"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/maces/mace-spiked-cube-wood.webp",
+	"name": "Silver Mace of Wrath",
+	"system": {
+		"ammoClass": "",
+		"baseWeapon": "",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 5,
+			"sp": 0
+		},
+		"damage": {
+			"oneHanded": "d6",
+			"twoHanded": ""
+		},
+		"description": "<p><em>A tarnished, silver mace with seven flanges in the shape of crescent moons.</em></p><p><strong>Bonus.</strong> +1 mace.</p><p><strong>Benefit.</strong> This weapon deals double damage against creatures with lycanthropy.</p>",
+		"equipped": false,
+		"handedness": "",
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"range": "close",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"type": "melee"
+	},
+	"type": "Weapon"
+}

--- a/data/packs/magic-items.db/speak___understand_diabolic__n3Z0tBxloczqrb2w.json
+++ b/data/packs/magic-items.db/speak___understand_diabolic__n3Z0tBxloczqrb2w.json
@@ -9,7 +9,7 @@
 			"value": "Compendium.shadowdark.languages.Item.b5yBrLaRIl7ZEWKu"
 		}
 	],
-	"description": "Speak & Understand Diabolic",
+	"description": "Speak &amp; Understand Diabolic",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/speak___understand_diabolic__n3Z0tBxloczqrb2w.json
+++ b/data/packs/magic-items.db/speak___understand_diabolic__n3Z0tBxloczqrb2w.json
@@ -9,7 +9,7 @@
 			"value": "Compendium.shadowdark.languages.Item.b5yBrLaRIl7ZEWKu"
 		}
 	],
-	"description": "",
+	"description": "Speak & Understand Diabolic",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/speak___understand_diabolic__n3Z0tBxloczqrb2w.json
+++ b/data/packs/magic-items.db/speak___understand_diabolic__n3Z0tBxloczqrb2w.json
@@ -1,0 +1,33 @@
+{
+	"_id": "n3Z0tBxloczqrb2w",
+	"_key": "!items.effects!hcC1kuGgQ2VdnHmj.n3Z0tBxloczqrb2w",
+	"changes": [
+		{
+			"key": "system.languages",
+			"mode": 2,
+			"priority": null,
+			"value": "Compendium.shadowdark.languages.Item.b5yBrLaRIl7ZEWKu"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"img": "icons/commodities/tech/cog-steel-grey.webp",
+	"name": "Speak & Understand Diabolic",
+	"origin": "Item.WQAnfvteIZallISc",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/speak_goblin__kUrrVadALCQYuXNm.json
+++ b/data/packs/magic-items.db/speak_goblin__kUrrVadALCQYuXNm.json
@@ -1,0 +1,33 @@
+{
+	"_id": "kUrrVadALCQYuXNm",
+	"_key": "!items.effects!YITrYmzXxk6Yjxfc.kUrrVadALCQYuXNm",
+	"changes": [
+		{
+			"key": "system.languages",
+			"mode": 2,
+			"priority": null,
+			"value": "Compendium.shadowdark.languages.Item.NN9wFGgwk49oOQeN"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"img": "icons/commodities/tech/cog-steel-grey.webp",
+	"name": "Speak Goblin",
+	"origin": "Compendium.shadowdark.magic-items.Item.YITrYmzXxk6Yjxfc",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/speak_goblin__kUrrVadALCQYuXNm.json
+++ b/data/packs/magic-items.db/speak_goblin__kUrrVadALCQYuXNm.json
@@ -20,6 +20,8 @@
 		"startTurn": null,
 		"turns": null
 	},
+	"flags": {
+	},
 	"img": "icons/commodities/tech/cog-steel-grey.webp",
 	"name": "Speak Goblin",
 	"origin": "Compendium.shadowdark.magic-items.Item.YITrYmzXxk6Yjxfc",

--- a/data/packs/magic-items.db/speak_goblin__kUrrVadALCQYuXNm.json
+++ b/data/packs/magic-items.db/speak_goblin__kUrrVadALCQYuXNm.json
@@ -9,7 +9,7 @@
 			"value": "Compendium.shadowdark.languages.Item.NN9wFGgwk49oOQeN"
 		}
 	],
-	"description": "",
+	"description": "Speak Goblin",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/spellcasting_advantage_on_spell__2O1rrQbpFSYKLiI8.json
+++ b/data/packs/magic-items.db/spellcasting_advantage_on_spell__2O1rrQbpFSYKLiI8.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Spellcasting Advantage on Spell",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/spellcasting_advantage_on_spell__2O1rrQbpFSYKLiI8.json
+++ b/data/packs/magic-items.db/spellcasting_advantage_on_spell__2O1rrQbpFSYKLiI8.json
@@ -1,0 +1,35 @@
+{
+	"_id": "2O1rrQbpFSYKLiI8",
+	"_key": "!items.effects!h2i73FkXUZZybLc1.2O1rrQbpFSYKLiI8",
+	"changes": [
+		{
+			"key": "system.roll.spell.advantage.disintegrate",
+			"mode": 2,
+			"priority": null,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"flags": {
+	},
+	"img": "icons/magic/air/air-smoke-casting.webp",
+	"name": "Spellcasting Advantage on Spell",
+	"origin": "Compendium.shadowdark.magic-items.Item.h2i73FkXUZZybLc1",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/spellcasting_advantage_on_spell__BR7oklaQANiLMTwW.json
+++ b/data/packs/magic-items.db/spellcasting_advantage_on_spell__BR7oklaQANiLMTwW.json
@@ -1,0 +1,35 @@
+{
+	"_id": "BR7oklaQANiLMTwW",
+	"_key": "!items.effects!BMNSa23mVQ2UzDce.BR7oklaQANiLMTwW",
+	"changes": [
+		{
+			"key": "system.roll.spell.advantage.power-word-kill",
+			"mode": 2,
+			"priority": null,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"flags": {
+	},
+	"img": "icons/magic/air/air-smoke-casting.webp",
+	"name": "Spellcasting Advantage on Spell",
+	"origin": "Compendium.shadowdark.magic-items.Item.BMNSa23mVQ2UzDce",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/spellcasting_advantage_on_spell__BR7oklaQANiLMTwW.json
+++ b/data/packs/magic-items.db/spellcasting_advantage_on_spell__BR7oklaQANiLMTwW.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Spellcasting Advantage on Spell",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/spellcasting_advantage_on_spell__Kf2eneYOrzvxxnWU.json
+++ b/data/packs/magic-items.db/spellcasting_advantage_on_spell__Kf2eneYOrzvxxnWU.json
@@ -1,0 +1,38 @@
+{
+	"_id": "Kf2eneYOrzvxxnWU",
+	"_key": "!items.effects!v2khQSVLOXjdYA4j.Kf2eneYOrzvxxnWU",
+	"changes": [
+		{
+			"key": "system.roll.spell.advantage.all",
+			"mode": 2,
+			"priority": null,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"flags": {
+		"shadowdark": {
+			"situational": true
+		}
+	},
+	"img": "icons/magic/air/air-smoke-casting.webp",
+	"name": "Spellcasting Advantage on Spell",
+	"origin": "Compendium.shadowdark.magic-items.Item.v2khQSVLOXjdYA4j",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/spellcasting_advantage_on_spell__Kf2eneYOrzvxxnWU.json
+++ b/data/packs/magic-items.db/spellcasting_advantage_on_spell__Kf2eneYOrzvxxnWU.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Spellcasting Advantage on Spell",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/spellcasting_advantage_on_spell__Kf2eneYOrzvxxnWU.json
+++ b/data/packs/magic-items.db/spellcasting_advantage_on_spell__Kf2eneYOrzvxxnWU.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "Spellcasting Advantage on Spell",
+	"description": "+1 to your next spellcasting check or ranged attack (1/day)",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/spellcasting_advantage_on_spell__OJ3nY3HrPcGtdv4L.json
+++ b/data/packs/magic-items.db/spellcasting_advantage_on_spell__OJ3nY3HrPcGtdv4L.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Spellcasting Advantage on Spell",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/spellcasting_advantage_on_spell__OJ3nY3HrPcGtdv4L.json
+++ b/data/packs/magic-items.db/spellcasting_advantage_on_spell__OJ3nY3HrPcGtdv4L.json
@@ -1,0 +1,35 @@
+{
+	"_id": "OJ3nY3HrPcGtdv4L",
+	"_key": "!items.effects!dupIuIdb8hVNC5gh.OJ3nY3HrPcGtdv4L",
+	"changes": [
+		{
+			"key": "system.roll.spell.advantage.shapechanger",
+			"mode": 2,
+			"priority": null,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"flags": {
+	},
+	"img": "icons/magic/air/air-smoke-casting.webp",
+	"name": "Spellcasting Advantage on Spell",
+	"origin": "Compendium.shadowdark.magic-items.Item.dupIuIdb8hVNC5gh",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/spellcasting_check_bonus__lx4pzHIfjRY8COai.json
+++ b/data/packs/magic-items.db/spellcasting_check_bonus__lx4pzHIfjRY8COai.json
@@ -9,7 +9,7 @@
 			"value": "4"
 		}
 	],
-	"description": "",
+	"description": "Spellcasting Check Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/spellcasting_check_bonus__lx4pzHIfjRY8COai.json
+++ b/data/packs/magic-items.db/spellcasting_check_bonus__lx4pzHIfjRY8COai.json
@@ -9,7 +9,7 @@
 			"value": "4"
 		}
 	],
-	"description": "Spellcasting Check Bonus",
+	"description": "+4 to detect thoughts spellcasting checks (3/day)",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/spellcasting_check_bonus__lx4pzHIfjRY8COai.json
+++ b/data/packs/magic-items.db/spellcasting_check_bonus__lx4pzHIfjRY8COai.json
@@ -1,0 +1,38 @@
+{
+	"_id": "lx4pzHIfjRY8COai",
+	"_key": "!items.effects!HxnAZ36Mm2jSDF6p.lx4pzHIfjRY8COai",
+	"changes": [
+		{
+			"key": "system.roll.spell.bonus.detect-thoughts",
+			"mode": 2,
+			"priority": null,
+			"value": "4"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"flags": {
+		"shadowdark": {
+			"situational": true
+		}
+	},
+	"img": "icons/magic/fire/flame-burning-fist-strike.webp",
+	"name": "Spellcasting Check Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.HxnAZ36Mm2jSDF6p",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/sphere_of_annihilation__VIPaEqaV8GRmXtfk.json
+++ b/data/packs/magic-items.db/sphere_of_annihilation__VIPaEqaV8GRmXtfk.json
@@ -1,0 +1,51 @@
+{
+	"_id": "VIPaEqaV8GRmXtfk",
+	"_key": "!items!VIPaEqaV8GRmXtfk",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/magic/unholy/orb-glowing-purple.webp",
+	"name": "Sphere of Annihilation",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A three-foot, spherical void of pure darkness that hovers above the ground.</em></p><p><strong>Benefit.</strong> This sphere utterly destroys all matter it touches.</p><p>Intelligent beings can move the flying sphere a near distance by passing a [[check 18 int]] check. If multiple creatures vie for control of the sphere, it is a contested Intelligence check instead. Wizards have advantage on this check. The winner moves the sphere a near distance.</p><p>If the sphere moves into a space occupied by a creature, the being controlling the sphere makes an attack roll against that creature with a +7 bonus. On a hit, the creature is obliterated.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/spyglass_of_true_sight__UgFCjZ4xbq7MgOMV.json
+++ b/data/packs/magic-items.db/spyglass_of_true_sight__UgFCjZ4xbq7MgOMV.json
@@ -1,0 +1,51 @@
+{
+	"_id": "UgFCjZ4xbq7MgOMV",
+	"_key": "!items!UgFCjZ4xbq7MgOMV",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/tools/navigation/spyglass-telescope-brass.webp",
+	"name": "Spyglass of True Sight",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A brass, telescoping lens with magical runes carved on it.</em></p><p><strong>Benefit.</strong> When you look through the spyglass, you can see invisible creatures and objects.</p><p><strong>Curse.</strong> The wielder feels a compulsion to look at everything through the spyglass.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/staff_of_ord__ck4lutlGUcVmIE6y.json
+++ b/data/packs/magic-items.db/staff_of_ord__ck4lutlGUcVmIE6y.json
@@ -23,7 +23,7 @@
 			"oneHanded": "",
 			"twoHanded": "d4"
 		},
-		"description": "",
+		"description": "<p><em>A tapered, mithral staff that resonates with arcane power. The tip features an upward- looking eye in a circle of runes.</em></p><p><strong>Bonus.</strong> +3 staff. Can only be wielded by a wizard.</p><p><strong>Benefit.</strong> Functions as a wand of @UUID[Compendium.shadowdark.spells.Item.UWGzL8qsentdrvar]{dimension door} (pg. 59), @UUID[Compendium.shadowdark.spells.Item.j2gvzfnMGQwxqgGg]{fireball} (pg. 60), @UUID[Compendium.shadowdark.spells.Item.AnJVapep2NJoicUP]{sending} (pg. 70), and @UUID[Compendium.shadowdark.spells.Item.AZo6rYWOo0SHvpxZ]{telekinesis} (pg. 72). Unlike a wand, the staff remains intact if you roll a 1 on your spellcasting checks. Hostile spells targeting you are DC 18 to cast.</p>",
 		"equipped": false,
 		"handedness": "",
 		"identification": {

--- a/data/packs/magic-items.db/staff_of_ord__ck4lutlGUcVmIE6y.json
+++ b/data/packs/magic-items.db/staff_of_ord__ck4lutlGUcVmIE6y.json
@@ -1,0 +1,53 @@
+{
+	"_id": "ck4lutlGUcVmIE6y",
+	"_key": "!items!ck4lutlGUcVmIE6y",
+	"effects": [
+		"kjwVuIlPksnF2hR1",
+		"n94S9biW3s0ZHhoR"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/staves/staff-obsidian.webp",
+	"name": "Staff of Ord",
+	"system": {
+		"ammoClass": "",
+		"baseWeapon": "",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 5
+		},
+		"damage": {
+			"oneHanded": "",
+			"twoHanded": "d4"
+		},
+		"description": "",
+		"equipped": false,
+		"handedness": "",
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.b6Gm2ULKj2qyy2xJ"
+		],
+		"quantity": 1,
+		"range": "close",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"type": "melee"
+	},
+	"type": "Weapon"
+}

--- a/data/packs/magic-items.db/staff_of_the_cobra__EiyxS6MOvGlZgG65.json
+++ b/data/packs/magic-items.db/staff_of_the_cobra__EiyxS6MOvGlZgG65.json
@@ -1,0 +1,53 @@
+{
+	"_id": "EiyxS6MOvGlZgG65",
+	"_key": "!items!EiyxS6MOvGlZgG65",
+	"effects": [
+		"2QCEx24N0mtaaRR7",
+		"apF91F2anJCrmkSm"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/staves/staff-animal-skull-feathers.webp",
+	"name": "Staff of The Cobra",
+	"system": {
+		"ammoClass": "",
+		"baseWeapon": "",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 5
+		},
+		"damage": {
+			"oneHanded": "",
+			"twoHanded": "d4"
+		},
+		"description": "<p><em>A curved scepter tipped with a ruby-eyed, flaring cobra head.</em></p><p><strong>Bonus.</strong> +1 staff.</p><p><strong>Benefit.</strong> All snakes regard you with a friendly attitude unless you do something to upset them. Once per day, you can throw the staff to the ground. It becomes a giant snake for 5 rounds that obeys your mental commands. If the giant snake goes to 0 HP, it reverts into a staff.</p><p><strong>Curse.</strong> You have disadvantage on attacks and casting hostile spells targeting snakes.</p>",
+		"equipped": false,
+		"handedness": "",
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.b6Gm2ULKj2qyy2xJ"
+		],
+		"quantity": 1,
+		"range": "close",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"type": "melee"
+	},
+	"type": "Weapon"
+}

--- a/data/packs/magic-items.db/staff_of_the_cobra__EiyxS6MOvGlZgG65.json
+++ b/data/packs/magic-items.db/staff_of_the_cobra__EiyxS6MOvGlZgG65.json
@@ -3,7 +3,8 @@
 	"_key": "!items!EiyxS6MOvGlZgG65",
 	"effects": [
 		"2QCEx24N0mtaaRR7",
-		"apF91F2anJCrmkSm"
+		"apF91F2anJCrmkSm",
+		"gKzyPrgEBI8O9NXr"
 	],
 	"flags": {
 	},

--- a/data/packs/magic-items.db/the_kytherian_mechanism__agUvJNSQFTGdGoMi.json
+++ b/data/packs/magic-items.db/the_kytherian_mechanism__agUvJNSQFTGdGoMi.json
@@ -1,0 +1,51 @@
+{
+	"_id": "agUvJNSQFTGdGoMi",
+	"_key": "!items!agUvJNSQFTGdGoMi",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/commodities/tech/watch.webp",
+	"name": "The Kytherian Mechanism",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A towering, brass platform mounted with countless cogs and gears speckled in blue- green rust.</em></p><p><strong>Benefit.</strong> A handle turns The Kytherian Mechanism's mighty wheels, but it doesn't function until its seven missing @UUID[Compendium.shadowdark.magic-items.Item.0c0G5Dnzq9Il8zZY]{Kytherian Cogs} are replaced.</p><p>Once functional, activating the mechanism allows the operator to undo one event of their choosing from history. Then, the seven Kytherian Cogs magically scatter to far-flung locations.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/the_malediction_infernal__KC0iAiMQzgk2fJeX.json
+++ b/data/packs/magic-items.db/the_malediction_infernal__KC0iAiMQzgk2fJeX.json
@@ -1,0 +1,51 @@
+{
+	"_id": "KC0iAiMQzgk2fJeX",
+	"_key": "!items!KC0iAiMQzgk2fJeX",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/sundries/books/book-symbol-skull-grey.webp",
+	"name": "The Malediction Infernal",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A black, leatherbound tome with a grinning demon face embossed on the cover.</em></p><p><strong>Benefit.</strong> A chaotic being who reads this tome gains a level and learns the @UUID[Compendium.shadowdark.languages.Item.b5yBrLaRIl7ZEWKu]{Diabolic} language.</p><p>A non-chaotic being who reads this book must pass a [[check 18 wis]] check or lose one level.</p><p>After being read, the tome teleports to a far-flung location.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/thrice_blessed_sword__MgWPwzNTzC7cPi7H.json
+++ b/data/packs/magic-items.db/thrice_blessed_sword__MgWPwzNTzC7cPi7H.json
@@ -3,7 +3,8 @@
 	"_key": "!items!MgWPwzNTzC7cPi7H",
 	"effects": [
 		"un7hIgJAJuzdyLvo",
-		"uBVpxbCrrpyNJxZS"
+		"uBVpxbCrrpyNJxZS",
+		"us7NkXHO8GnlNAiE"
 	],
 	"flags": {
 	},

--- a/data/packs/magic-items.db/thrice_blessed_sword__MgWPwzNTzC7cPi7H.json
+++ b/data/packs/magic-items.db/thrice_blessed_sword__MgWPwzNTzC7cPi7H.json
@@ -1,0 +1,52 @@
+{
+	"_id": "MgWPwzNTzC7cPi7H",
+	"_key": "!items!MgWPwzNTzC7cPi7H",
+	"effects": [
+		"un7hIgJAJuzdyLvo",
+		"uBVpxbCrrpyNJxZS"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/swords/sword-guard.webp",
+	"name": "Thrice-Blessed Sword",
+	"system": {
+		"ammoClass": "",
+		"baseWeapon": "longsword",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 9,
+			"sp": 0
+		},
+		"damage": {
+			"oneHanded": "d8",
+			"twoHanded": ""
+		},
+		"description": "<p><em>A lustrous, golden-handled blade anointed with blessed tears, incense, and prayers.</em></p><p><strong>Bonus.</strong> +3 longsword. Only a lawful priest who has achieved the Templar title or higher can wield this sword.</p><p><strong>Benefit.</strong> You deal double damage against demons, devils, and undead.</p><p><strong>Personality.</strong> Lawful. Virtuous, naive. Refuses to be wielded against worshippers of lawful gods, especially self-proclaimed converts. Demands each foe be given the chance to convert before being slain.</p>",
+		"equipped": false,
+		"handedness": "",
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"range": "close",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"type": "melee"
+	},
+	"type": "Weapon"
+}

--- a/data/packs/magic-items.db/tome_mordanticus__M1yLoU6PO25K3MC9.json
+++ b/data/packs/magic-items.db/tome_mordanticus__M1yLoU6PO25K3MC9.json
@@ -1,0 +1,51 @@
+{
+	"_id": "M1yLoU6PO25K3MC9",
+	"_key": "!items!M1yLoU6PO25K3MC9",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/sundries/books/book-open-brown.webp",
+	"name": "Tome Mordanticus",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A hand-drawn bestiary of the multiverse's most notable creatures and people.</em></p><p><strong>Benefit.</strong> When you read the tome, you learn three @UUID[Compendium.shadowdark.magic-items.Item.gNah418e2ykhDWDE]{True Names} (pg. 319) of three beings you choose. Your True Name also appears in the book after reading it.</p><p><strong>Personality.</strong> Neutral. Pedantic, fussy. The book constantly tries to escape its owner and can telepathically reach out a near distance to any creature.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/tome_of_gehemna__8KfATAoAfi2MRGgT.json
+++ b/data/packs/magic-items.db/tome_of_gehemna__8KfATAoAfi2MRGgT.json
@@ -1,0 +1,51 @@
+{
+	"_id": "8KfATAoAfi2MRGgT",
+	"_key": "!items!8KfATAoAfi2MRGgT",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/sundries/books/book-reye-reptile-brown.webp",
+	"name": "Tome of Gehemna",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A sturdy, russet volume held by metal clasps. A golden eye in a circle adorns the cover.</em></p><p><strong>Benefit.</strong> Each day, a random wizard spell scroll appears inside the tome, replacing the spell scroll from the prior day.</p><p><strong>Personality.</strong> Neutral. Instructive, technical. Drones on about the obscure points of spellcasting and has an opinion on every wizard's technique.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/tome_of_hadebe__WdocdxLV3parywtm.json
+++ b/data/packs/magic-items.db/tome_of_hadebe__WdocdxLV3parywtm.json
@@ -1,0 +1,51 @@
+{
+	"_id": "WdocdxLV3parywtm",
+	"_key": "!items!WdocdxLV3parywtm",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/sundries/books/book-embossed-clasp-gold-brown.webp",
+	"name": "Tome of Hadebe",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A brass-plated book with pages of etched copper leaf.</em></p><p><strong>Benefit.</strong> The tome contains one each of the following scrolls: @UUID[Compendium.shadowdark.spells.Item.ItN82uLU3PhJFLNm]{burning hands} (pg. 56), @UUID[Compendium.shadowdark.spells.Item.j2gvzfnMGQwxqgGg]{fireball} (pg. 60), and @UUID[Compendium.shadowdark.spells.Item.71VbHnopcTmRXz47]{prismatic orb} (pg. 67).</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/trident_of_the_seas__REKbDm3ShTNQouM2.json
+++ b/data/packs/magic-items.db/trident_of_the_seas__REKbDm3ShTNQouM2.json
@@ -1,0 +1,53 @@
+{
+	"_id": "REKbDm3ShTNQouM2",
+	"_key": "!items!REKbDm3ShTNQouM2",
+	"effects": [
+		"nv1kzlTwOcLqpi7w",
+		"dZkdrikRTlcELylW"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/polearms/trident-silver-blue.webp",
+	"name": "Trident of the Seas",
+	"system": {
+		"ammoClass": "",
+		"baseWeapon": "",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 5
+		},
+		"damage": {
+			"oneHanded": "d6",
+			"twoHanded": ""
+		},
+		"description": "<p><em>A three-pronged, mithral harpoon studded with pearls.</em></p><p><strong>Bonus.</strong> +2 spear.</p><p><strong>Benefit.</strong> You can breathe underwater, as well as speak to and understand wild sea creatures. Once per day, you can cast @UUID[Compendium.shadowdark.spells.Item.TKDuwFu1hP2lX549]{control water} (pg. 57) with a +4 bonus.</p>",
+		"equipped": false,
+		"handedness": "",
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": true,
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.c35ROL1nXwC840kC"
+		],
+		"quantity": 1,
+		"range": "near",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"type": "melee"
+	},
+	"type": "Weapon"
+}

--- a/data/packs/magic-items.db/trident_of_the_seas__REKbDm3ShTNQouM2.json
+++ b/data/packs/magic-items.db/trident_of_the_seas__REKbDm3ShTNQouM2.json
@@ -3,7 +3,8 @@
 	"_key": "!items!REKbDm3ShTNQouM2",
 	"effects": [
 		"nv1kzlTwOcLqpi7w",
-		"dZkdrikRTlcELylW"
+		"dZkdrikRTlcELylW",
+		"0SIRUg3EWmVGZkBZ"
 	],
 	"flags": {
 	},

--- a/data/packs/magic-items.db/vigilant__iEbHLvRPWNXo32qm.json
+++ b/data/packs/magic-items.db/vigilant__iEbHLvRPWNXo32qm.json
@@ -38,7 +38,7 @@
 			"slots_used": 1
 		},
 		"source": {
-			"title": "core-rules"
+			"title": "quickstart"
 		},
 		"stashed": false,
 		"type": "melee"

--- a/data/packs/magic-items.db/wand_of_blind_deafen__yyUwr6H9imWcJ9YS.json
+++ b/data/packs/magic-items.db/wand_of_blind_deafen__yyUwr6H9imWcJ9YS.json
@@ -10,7 +10,7 @@
 	"name": "Wand of Blind/Deafen",
 	"system": {
 		"ammoClass": "",
-		"baseWeapon": "wand",
+		"baseWeapon": "",
 		"broken": false,
 		"cost": {
 			"cp": 0,

--- a/data/packs/magic-items.db/wand_of_unlife__gqSggLFDj78yoPW2.json
+++ b/data/packs/magic-items.db/wand_of_unlife__gqSggLFDj78yoPW2.json
@@ -1,0 +1,51 @@
+{
+	"_id": "gqSggLFDj78yoPW2",
+	"_key": "!items!gqSggLFDj78yoPW2",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/wands/wand-skull-horned.webp",
+	"name": "Wand of Unlife",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>The knobby finger-bone of a swamp troll steeped in acrid embalming fluid.</em></p><p><strong>Benefit.</strong> This wand contains the spells @UUID[Compendium.shadowdark.spells.Item.M702ErO4KOtMJzsK]{animate dead} (pg. 54) and @UUID[Compendium.shadowdark.spells.Item.uNxbpd7fENzDUxfd]{create undead} (pg. 58).</p><p><strong>Curse.</strong> Each time you use the wand to cast a spell, you take [[/r 1d4]] points of Constitution damage. If you reach 0 Constitution from this effect, you die and turn into a zombie.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/wand_of_warding__P921JRq5leqOWpwv.json
+++ b/data/packs/magic-items.db/wand_of_warding__P921JRq5leqOWpwv.json
@@ -1,0 +1,51 @@
+{
+	"_id": "P921JRq5leqOWpwv",
+	"_key": "!items!P921JRq5leqOWpwv",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/wands/wand-carved-stone-shard.webp",
+	"name": "Wand of Warding",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A thin, weighty rod of dark iron inscribed with spiraling runes.</em></p><p><strong>Benefit.</strong> This wand contains the spells @UUID[Compendium.shadowdark.spells.Item.6N33hyLWYZCRgkeX]{dispel magic} (pg. 59) and @UUID[Compendium.shadowdark.spells.Item.P9LFIH0PW4Zlx3RG]{protection from energy }(pg. 68).</p><p><strong>Curse.</strong> Each time you fail a spellcasting check with this wand, you also lose the ability to cast a random spell you know until you complete a rest.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/war_horn_of_the_angels__C1rI56xY6qTRDHyj.json
+++ b/data/packs/magic-items.db/war_horn_of_the_angels__C1rI56xY6qTRDHyj.json
@@ -1,0 +1,51 @@
+{
+	"_id": "C1rI56xY6qTRDHyj",
+	"_key": "!items!C1rI56xY6qTRDHyj",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/tools/instruments/horn-white-gray.webp",
+	"name": "War Horn of the Angels",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>An opalescent ox horn capped with a golden mouthpiece.</em></p><p><strong>Benefit.</strong> Only a lawful being can wield the horn. Once per day, you can blow the horn to cast @UUID[Compendium.shadowdark.spells.Item.hhCpwnqFy8ntO0jU]{rebuke unholy} (pg. 69) with a +4 bonus.</p><p>A demon or devil who hears the horn has disadvantage on its Charisma check vs. your rebuke unholy spellcasting check.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/warhammer_of_the_dwarf_lords__EBfBPArPRSyLXFPM.json
+++ b/data/packs/magic-items.db/warhammer_of_the_dwarf_lords__EBfBPArPRSyLXFPM.json
@@ -2,9 +2,9 @@
 	"_id": "EBfBPArPRSyLXFPM",
 	"_key": "!items!EBfBPArPRSyLXFPM",
 	"effects": [
-		"3uu1cZFg4jJ9uOBU",
-		"JeLSOetsunFunEnm",
-		"12wqYPS5nYdD0srs"
+		"12wqYPS5nYdD0srs",
+		"nYIEUngawHOWjKLV",
+		"5k96o8ZHd5spUP9K"
 	],
 	"flags": {
 	},

--- a/data/packs/magic-items.db/warhammer_of_the_dwarf_lords__EBfBPArPRSyLXFPM.json
+++ b/data/packs/magic-items.db/warhammer_of_the_dwarf_lords__EBfBPArPRSyLXFPM.json
@@ -1,0 +1,54 @@
+{
+	"_id": "EBfBPArPRSyLXFPM",
+	"_key": "!items!EBfBPArPRSyLXFPM",
+	"effects": [
+		"3uu1cZFg4jJ9uOBU",
+		"JeLSOetsunFunEnm"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/hammers/hammer-war-rounding.webp",
+	"name": "Warhammer of the Dwarf Lords",
+	"system": {
+		"ammoClass": "",
+		"baseWeapon": "",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 10,
+			"sp": 0
+		},
+		"damage": {
+			"oneHanded": "",
+			"twoHanded": "d10"
+		},
+		"description": "<p><em>A boxy hammer with a stout handle and leather throwing strap. It hums with a baritone resonance when spun.</em></p><p><strong>Bonus.</strong> +1 warhammer. +2 if wielded by a dwarf.</p><p><strong>Benefit.</strong> This weapon has the thrown property (pg. 37) to a near distance. It always returns to your hand after being thrown.<br>Your attacks with this weapon deal double damage against giants.</p>",
+		"equipped": false,
+		"handedness": "",
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.b6Gm2ULKj2qyy2xJ",
+			"Compendium.shadowdark.properties.Item.c35ROL1nXwC840kC"
+		],
+		"quantity": 1,
+		"range": "close",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"type": "melee"
+	},
+	"type": "Weapon"
+}

--- a/data/packs/magic-items.db/warhammer_of_the_dwarf_lords__EBfBPArPRSyLXFPM.json
+++ b/data/packs/magic-items.db/warhammer_of_the_dwarf_lords__EBfBPArPRSyLXFPM.json
@@ -3,7 +3,8 @@
 	"_key": "!items!EBfBPArPRSyLXFPM",
 	"effects": [
 		"3uu1cZFg4jJ9uOBU",
-		"JeLSOetsunFunEnm"
+		"JeLSOetsunFunEnm",
+		"12wqYPS5nYdD0srs"
 	],
 	"flags": {
 	},

--- a/data/packs/magic-items.db/warhammer_of_the_dwarf_lords__wielded_by_a_dwarf___FqhEJHkaKd0emTzn.json
+++ b/data/packs/magic-items.db/warhammer_of_the_dwarf_lords__wielded_by_a_dwarf___FqhEJHkaKd0emTzn.json
@@ -3,7 +3,8 @@
 	"_key": "!items!FqhEJHkaKd0emTzn",
 	"effects": [
 		"3uu1cZFg4jJ9uOBU",
-		"JeLSOetsunFunEnm"
+		"JeLSOetsunFunEnm",
+		"GH1P7tijaj5st9hm"
 	],
 	"flags": {
 	},

--- a/data/packs/magic-items.db/warhammer_of_the_dwarf_lords__wielded_by_a_dwarf___FqhEJHkaKd0emTzn.json
+++ b/data/packs/magic-items.db/warhammer_of_the_dwarf_lords__wielded_by_a_dwarf___FqhEJHkaKd0emTzn.json
@@ -1,0 +1,54 @@
+{
+	"_id": "FqhEJHkaKd0emTzn",
+	"_key": "!items!FqhEJHkaKd0emTzn",
+	"effects": [
+		"3uu1cZFg4jJ9uOBU",
+		"JeLSOetsunFunEnm"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/hammers/hammer-war-rounding.webp",
+	"name": "Warhammer of the Dwarf Lords (Wielded by a Dwarf)",
+	"system": {
+		"ammoClass": "",
+		"baseWeapon": "",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 10,
+			"sp": 0
+		},
+		"damage": {
+			"oneHanded": "",
+			"twoHanded": "d10"
+		},
+		"description": "<p><em>A boxy hammer with a stout handle and leather throwing strap. It hums with a baritone resonance when spun.</em></p><p><strong>Bonus.</strong> +1 warhammer. +2 if wielded by a dwarf.</p><p><strong>Benefit.</strong> This weapon has the thrown property (pg. 37) to a near distance. It always returns to your hand after being thrown.<br>Your attacks with this weapon deal double damage against giants.</p>",
+		"equipped": false,
+		"handedness": "",
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.b6Gm2ULKj2qyy2xJ",
+			"Compendium.shadowdark.properties.Item.c35ROL1nXwC840kC"
+		],
+		"quantity": 1,
+		"range": "close",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"type": "melee"
+	},
+	"type": "Weapon"
+}

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__1WtVBmSCkzVeEdL7.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__1WtVBmSCkzVeEdL7.json
@@ -8,7 +8,7 @@
 			"value": "2"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__1WtVBmSCkzVeEdL7.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__1WtVBmSCkzVeEdL7.json
@@ -26,6 +26,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__1WtVBmSCkzVeEdL7.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__1WtVBmSCkzVeEdL7.json
@@ -1,0 +1,31 @@
+{
+	"_id": "1WtVBmSCkzVeEdL7",
+	"_key": "!items.effects!3Wgj18VMKb0KmRHI.1WtVBmSCkzVeEdL7",
+	"changes": [
+		{
+			"key": "system.roll.attack.damage.this",
+			"mode": 2,
+			"value": "2"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
+	"name": "Weapon Attack Damage Bonus",
+	"origin": "Item.Jsn81bt8tPxZCdmD",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": false,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__2QCEx24N0mtaaRR7.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__2QCEx24N0mtaaRR7.json
@@ -1,0 +1,29 @@
+{
+	"_id": "2QCEx24N0mtaaRR7",
+	"_key": "!items.effects!EiyxS6MOvGlZgG65.2QCEx24N0mtaaRR7",
+	"changes": [
+		{
+			"key": "system.roll.attack.damage.this",
+			"mode": 2,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
+	"name": "Weapon Attack Damage Bonus",
+	"origin": "Item.u8JqsRuUaGOch5Se",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": false,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__2QCEx24N0mtaaRR7.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__2QCEx24N0mtaaRR7.json
@@ -24,6 +24,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__2QCEx24N0mtaaRR7.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__2QCEx24N0mtaaRR7.json
@@ -8,7 +8,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__5k96o8ZHd5spUP9K.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__5k96o8ZHd5spUP9K.json
@@ -1,0 +1,29 @@
+{
+	"_id": "5k96o8ZHd5spUP9K",
+	"_key": "!items.effects!EBfBPArPRSyLXFPM.5k96o8ZHd5spUP9K",
+	"changes": [
+		{
+			"key": "system.roll.attack.damage.this",
+			"mode": 2,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
+	"name": "Weapon Attack Damage Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.EBfBPArPRSyLXFPM",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": false,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__5k96o8ZHd5spUP9K.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__5k96o8ZHd5spUP9K.json
@@ -8,7 +8,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__97RtiQtpwhaO7qNb.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__97RtiQtpwhaO7qNb.json
@@ -8,7 +8,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__9ScRP2bW6K4ljUpQ.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__9ScRP2bW6K4ljUpQ.json
@@ -1,12 +1,12 @@
 {
-	"_id": "n3Z0tBxloczqrb2w",
-	"_key": "!items.effects!hcC1kuGgQ2VdnHmj.n3Z0tBxloczqrb2w",
+	"_id": "9ScRP2bW6K4ljUpQ",
+	"_key": "!items.effects!SuPwL1LQKe8DdaRq.9ScRP2bW6K4ljUpQ",
 	"changes": [
 		{
-			"key": "system.languages",
+			"key": "system.roll.attack.damage.this",
 			"mode": 2,
 			"priority": null,
-			"value": "Compendium.shadowdark.languages.Item.b5yBrLaRIl7ZEWKu"
+			"value": "2"
 		}
 	],
 	"description": "",
@@ -22,9 +22,9 @@
 	},
 	"flags": {
 	},
-	"img": "icons/commodities/tech/cog-steel-grey.webp",
-	"name": "Speak & Understand Diabolic",
-	"origin": "Item.WQAnfvteIZallISc",
+	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
+	"name": "Weapon Attack Damage Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.SuPwL1LQKe8DdaRq",
 	"statuses": [
 	],
 	"system": {

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__9ScRP2bW6K4ljUpQ.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__9ScRP2bW6K4ljUpQ.json
@@ -9,7 +9,7 @@
 			"value": "2"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__CaRqa4l3vE2ZALbE.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__CaRqa4l3vE2ZALbE.json
@@ -1,0 +1,35 @@
+{
+	"_id": "CaRqa4l3vE2ZALbE",
+	"_key": "!items.effects!r4V3eAGkZ1klmFe7.CaRqa4l3vE2ZALbE",
+	"changes": [
+		{
+			"key": "system.roll.attack.damage.this",
+			"mode": 2,
+			"priority": null,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"flags": {
+	},
+	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
+	"name": "Weapon Attack Damage Bonus",
+	"origin": "Item.QZDYdbLD9VM4i3Mr",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__CaRqa4l3vE2ZALbE.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__CaRqa4l3vE2ZALbE.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__JeLSOetsunFunEnm.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__JeLSOetsunFunEnm.json
@@ -1,0 +1,35 @@
+{
+	"_id": "JeLSOetsunFunEnm",
+	"_key": "!items.effects!FqhEJHkaKd0emTzn.JeLSOetsunFunEnm",
+	"changes": [
+		{
+			"key": "system.roll.attack.damage.this",
+			"mode": 2,
+			"priority": null,
+			"value": "2"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"flags": {
+	},
+	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
+	"name": "Weapon Attack Damage Bonus",
+	"origin": "Item.wCrCGPDGTPns41gH",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__JeLSOetsunFunEnm.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__JeLSOetsunFunEnm.json
@@ -9,7 +9,7 @@
 			"value": "2"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__LryuYkHDYOAm4I0g.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__LryuYkHDYOAm4I0g.json
@@ -1,0 +1,31 @@
+{
+	"_id": "LryuYkHDYOAm4I0g",
+	"_key": "!items.effects!Zci7qHVAp0lHEYID.LryuYkHDYOAm4I0g",
+	"changes": [
+		{
+			"key": "system.roll.attack.damage.this",
+			"mode": 2,
+			"value": "3"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
+	"name": "Weapon Attack Damage Bonus",
+	"origin": "Item.kUnwNFe9A9PKk4Ri",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": false,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__LryuYkHDYOAm4I0g.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__LryuYkHDYOAm4I0g.json
@@ -8,7 +8,7 @@
 			"value": "3"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__LryuYkHDYOAm4I0g.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__LryuYkHDYOAm4I0g.json
@@ -26,6 +26,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__MYoK22maOIV6Z0VE.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__MYoK22maOIV6Z0VE.json
@@ -24,6 +24,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__MYoK22maOIV6Z0VE.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__MYoK22maOIV6Z0VE.json
@@ -1,0 +1,29 @@
+{
+	"_id": "MYoK22maOIV6Z0VE",
+	"_key": "!items.effects!5vaHRsgVMO4v6ePR.MYoK22maOIV6Z0VE",
+	"changes": [
+		{
+			"key": "system.roll.attack.damage.this",
+			"mode": 2,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
+	"name": "Weapon Attack Damage Bonus",
+	"origin": "Item.B30rw9qP2aK1r73k",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": false,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__MYoK22maOIV6Z0VE.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__MYoK22maOIV6Z0VE.json
@@ -8,7 +8,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__OZskI153kjpkFy09.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__OZskI153kjpkFy09.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__OlbaGSPCczzedFMQ.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__OlbaGSPCczzedFMQ.json
@@ -8,7 +8,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__POfmKSqbE5nitw2s.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__POfmKSqbE5nitw2s.json
@@ -24,6 +24,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__POfmKSqbE5nitw2s.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__POfmKSqbE5nitw2s.json
@@ -8,7 +8,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__POfmKSqbE5nitw2s.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__POfmKSqbE5nitw2s.json
@@ -1,0 +1,29 @@
+{
+	"_id": "POfmKSqbE5nitw2s",
+	"_key": "!items.effects!Nz0Wzbzgwa74gEgQ.POfmKSqbE5nitw2s",
+	"changes": [
+		{
+			"key": "system.roll.attack.damage.this",
+			"mode": 2,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
+	"name": "Weapon Attack Damage Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.Nz0Wzbzgwa74gEgQ",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": false,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__UTm25I1vjFzNqZKZ.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__UTm25I1vjFzNqZKZ.json
@@ -1,0 +1,35 @@
+{
+	"_id": "UTm25I1vjFzNqZKZ",
+	"_key": "!items.effects!DtswEluGPMrFpzW1.UTm25I1vjFzNqZKZ",
+	"changes": [
+		{
+			"key": "system.roll.attack.damage.this",
+			"mode": 2,
+			"priority": null,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"flags": {
+	},
+	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
+	"name": "Weapon Attack Damage Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.DtswEluGPMrFpzW1",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__UTm25I1vjFzNqZKZ.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__UTm25I1vjFzNqZKZ.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__Vn1UKd6iBKvZh0tc.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__Vn1UKd6iBKvZh0tc.json
@@ -24,6 +24,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__Vn1UKd6iBKvZh0tc.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__Vn1UKd6iBKvZh0tc.json
@@ -8,7 +8,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__Vn1UKd6iBKvZh0tc.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__Vn1UKd6iBKvZh0tc.json
@@ -1,0 +1,29 @@
+{
+	"_id": "Vn1UKd6iBKvZh0tc",
+	"_key": "!items.effects!bpJlJ3vnZVmvOEJV.Vn1UKd6iBKvZh0tc",
+	"changes": [
+		{
+			"key": "system.roll.attack.damage.this",
+			"mode": 2,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
+	"name": "Weapon Attack Damage Bonus",
+	"origin": "Item.nfRD48XCs8SvvptW",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": false,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__ZDqSlow0fxMp6JOf.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__ZDqSlow0fxMp6JOf.json
@@ -1,0 +1,35 @@
+{
+	"_id": "ZDqSlow0fxMp6JOf",
+	"_key": "!items.effects!RbAtv4hRODYmOoit.ZDqSlow0fxMp6JOf",
+	"changes": [
+		{
+			"key": "system.roll.attack.damage.this",
+			"mode": 2,
+			"priority": null,
+			"value": "2"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"flags": {
+	},
+	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
+	"name": "Weapon Attack Damage Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.RbAtv4hRODYmOoit",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__ZDqSlow0fxMp6JOf.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__ZDqSlow0fxMp6JOf.json
@@ -9,7 +9,7 @@
 			"value": "2"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__dZkdrikRTlcELylW.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__dZkdrikRTlcELylW.json
@@ -8,7 +8,7 @@
 			"value": "2"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__dZkdrikRTlcELylW.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__dZkdrikRTlcELylW.json
@@ -26,6 +26,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__dZkdrikRTlcELylW.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__dZkdrikRTlcELylW.json
@@ -1,0 +1,31 @@
+{
+	"_id": "dZkdrikRTlcELylW",
+	"_key": "!items.effects!REKbDm3ShTNQouM2.dZkdrikRTlcELylW",
+	"changes": [
+		{
+			"key": "system.roll.attack.damage.this",
+			"mode": 2,
+			"value": "2"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
+	"name": "Weapon Attack Damage Bonus",
+	"origin": "Item.5ayvpKEkkJ70T9Ir",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": false,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__dbXv9ddp6TR15AFk.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__dbXv9ddp6TR15AFk.json
@@ -8,7 +8,7 @@
 			"value": "3"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__dbXv9ddp6TR15AFk.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__dbXv9ddp6TR15AFk.json
@@ -1,0 +1,31 @@
+{
+	"_id": "dbXv9ddp6TR15AFk",
+	"_key": "!items.effects!4BkbHe0cL8Zvsd7a.dbXv9ddp6TR15AFk",
+	"changes": [
+		{
+			"key": "system.roll.attack.damage.this",
+			"mode": 2,
+			"value": "3"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
+	"name": "Weapon Attack Damage Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.4BkbHe0cL8Zvsd7a",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": false,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__doAgFd0Q4WixkRrC.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__doAgFd0Q4WixkRrC.json
@@ -8,7 +8,7 @@
 			"value": "3"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__doAgFd0Q4WixkRrC.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__doAgFd0Q4WixkRrC.json
@@ -1,0 +1,31 @@
+{
+	"_id": "doAgFd0Q4WixkRrC",
+	"_key": "!items.effects!5gdNWsFJjgmtZroK.doAgFd0Q4WixkRrC",
+	"changes": [
+		{
+			"key": "system.roll.attack.damage.this",
+			"mode": 2,
+			"value": "3"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
+	"name": "Weapon Attack Damage Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.5gdNWsFJjgmtZroK",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": false,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__n94S9biW3s0ZHhoR.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__n94S9biW3s0ZHhoR.json
@@ -1,0 +1,31 @@
+{
+	"_id": "n94S9biW3s0ZHhoR",
+	"_key": "!items.effects!ck4lutlGUcVmIE6y.n94S9biW3s0ZHhoR",
+	"changes": [
+		{
+			"key": "system.roll.attack.damage.this",
+			"mode": 2,
+			"value": "3"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
+	"name": "Weapon Attack Damage Bonus",
+	"origin": "Item.Hl8FZ5dUga3pYqH8",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": false,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__n94S9biW3s0ZHhoR.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__n94S9biW3s0ZHhoR.json
@@ -8,7 +8,7 @@
 			"value": "3"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__n94S9biW3s0ZHhoR.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__n94S9biW3s0ZHhoR.json
@@ -26,6 +26,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__tOLeg6MI1ii7c98V.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__tOLeg6MI1ii7c98V.json
@@ -1,12 +1,12 @@
 {
-	"_id": "n3Z0tBxloczqrb2w",
-	"_key": "!items.effects!hcC1kuGgQ2VdnHmj.n3Z0tBxloczqrb2w",
+	"_id": "tOLeg6MI1ii7c98V",
+	"_key": "!items.effects!YITrYmzXxk6Yjxfc.tOLeg6MI1ii7c98V",
 	"changes": [
 		{
-			"key": "system.languages",
+			"key": "system.roll.attack.damage.this",
 			"mode": 2,
 			"priority": null,
-			"value": "Compendium.shadowdark.languages.Item.b5yBrLaRIl7ZEWKu"
+			"value": "1"
 		}
 	],
 	"description": "",
@@ -22,9 +22,9 @@
 	},
 	"flags": {
 	},
-	"img": "icons/commodities/tech/cog-steel-grey.webp",
-	"name": "Speak & Understand Diabolic",
-	"origin": "Item.WQAnfvteIZallISc",
+	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
+	"name": "Weapon Attack Damage Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.YITrYmzXxk6Yjxfc",
 	"statuses": [
 	],
 	"system": {

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__tOLeg6MI1ii7c98V.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__tOLeg6MI1ii7c98V.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__uBVpxbCrrpyNJxZS.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__uBVpxbCrrpyNJxZS.json
@@ -8,7 +8,7 @@
 			"value": "3"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__uBVpxbCrrpyNJxZS.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__uBVpxbCrrpyNJxZS.json
@@ -26,6 +26,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__uBVpxbCrrpyNJxZS.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__uBVpxbCrrpyNJxZS.json
@@ -1,0 +1,31 @@
+{
+	"_id": "uBVpxbCrrpyNJxZS",
+	"_key": "!items.effects!MgWPwzNTzC7cPi7H.uBVpxbCrrpyNJxZS",
+	"changes": [
+		{
+			"key": "system.roll.attack.damage.this",
+			"mode": 2,
+			"value": "3"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
+	"name": "Weapon Attack Damage Bonus",
+	"origin": "Item.IMsCntyKjKOgNteb",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": false,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__3uu1cZFg4jJ9uOBU.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__3uu1cZFg4jJ9uOBU.json
@@ -1,0 +1,35 @@
+{
+	"_id": "3uu1cZFg4jJ9uOBU",
+	"_key": "!items.effects!FqhEJHkaKd0emTzn.3uu1cZFg4jJ9uOBU",
+	"changes": [
+		{
+			"key": "system.roll.attack.bonus.this",
+			"mode": 2,
+			"priority": null,
+			"value": "2"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"flags": {
+	},
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Weapon Attack Roll Bonus",
+	"origin": "Item.wCrCGPDGTPns41gH",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__3uu1cZFg4jJ9uOBU.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__3uu1cZFg4jJ9uOBU.json
@@ -9,7 +9,7 @@
 			"value": "2"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__4JjKaawthhmI2NLb.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__4JjKaawthhmI2NLb.json
@@ -8,7 +8,7 @@
 			"value": "3"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__4JjKaawthhmI2NLb.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__4JjKaawthhmI2NLb.json
@@ -26,6 +26,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__4JjKaawthhmI2NLb.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__4JjKaawthhmI2NLb.json
@@ -1,0 +1,31 @@
+{
+	"_id": "4JjKaawthhmI2NLb",
+	"_key": "!items.effects!Zci7qHVAp0lHEYID.4JjKaawthhmI2NLb",
+	"changes": [
+		{
+			"key": "system.roll.attack.bonus.this",
+			"mode": 2,
+			"value": "3"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Weapon Attack Roll Bonus",
+	"origin": "Item.kUnwNFe9A9PKk4Ri",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": false,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__8DPxbb4aUGGtrGlG.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__8DPxbb4aUGGtrGlG.json
@@ -8,7 +8,7 @@
 			"value": "3"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__8DPxbb4aUGGtrGlG.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__8DPxbb4aUGGtrGlG.json
@@ -1,0 +1,31 @@
+{
+	"_id": "8DPxbb4aUGGtrGlG",
+	"_key": "!items.effects!5gdNWsFJjgmtZroK.8DPxbb4aUGGtrGlG",
+	"changes": [
+		{
+			"key": "system.roll.attack.bonus.this",
+			"mode": 2,
+			"value": "3"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Weapon Attack Roll Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.5gdNWsFJjgmtZroK",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": false,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__CFbdBIST0hT7qCyu.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__CFbdBIST0hT7qCyu.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__ENAyqljvyYqIr8rK.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__ENAyqljvyYqIr8rK.json
@@ -1,0 +1,35 @@
+{
+	"_id": "ENAyqljvyYqIr8rK",
+	"_key": "!items.effects!RbAtv4hRODYmOoit.ENAyqljvyYqIr8rK",
+	"changes": [
+		{
+			"key": "system.roll.attack.bonus.this",
+			"mode": 2,
+			"priority": null,
+			"value": "2"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"flags": {
+	},
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Weapon Attack Roll Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.RbAtv4hRODYmOoit",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__ENAyqljvyYqIr8rK.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__ENAyqljvyYqIr8rK.json
@@ -9,7 +9,7 @@
 			"value": "2"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__HIFDdRlLUKbLS5zK.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__HIFDdRlLUKbLS5zK.json
@@ -8,7 +8,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__HIFDdRlLUKbLS5zK.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__HIFDdRlLUKbLS5zK.json
@@ -24,6 +24,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__HIFDdRlLUKbLS5zK.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__HIFDdRlLUKbLS5zK.json
@@ -1,0 +1,29 @@
+{
+	"_id": "HIFDdRlLUKbLS5zK",
+	"_key": "!items.effects!Nz0Wzbzgwa74gEgQ.HIFDdRlLUKbLS5zK",
+	"changes": [
+		{
+			"key": "system.roll.attack.bonus.this",
+			"mode": 2,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Weapon Attack Roll Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.Nz0Wzbzgwa74gEgQ",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": false,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__HOkTvzEf4v5RBLfx.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__HOkTvzEf4v5RBLfx.json
@@ -1,0 +1,35 @@
+{
+	"_id": "HOkTvzEf4v5RBLfx",
+	"_key": "!items.effects!DtswEluGPMrFpzW1.HOkTvzEf4v5RBLfx",
+	"changes": [
+		{
+			"key": "system.roll.attack.bonus.this",
+			"mode": 2,
+			"priority": null,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"flags": {
+	},
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Weapon Attack Roll Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.DtswEluGPMrFpzW1",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__HOkTvzEf4v5RBLfx.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__HOkTvzEf4v5RBLfx.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__MosrS1dHHXThJ96N.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__MosrS1dHHXThJ96N.json
@@ -1,0 +1,27 @@
+{
+	"_id": "MosrS1dHHXThJ96N",
+	"_key": "!items.effects!SuPwL1LQKe8DdaRq.MosrS1dHHXThJ96N",
+	"changes": [
+		{
+			"key": "system.bonuses.attackBonus",
+			"mode": 2,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Weapon Attack Roll Bonus",
+	"origin": "Item.P0NDz7qmT3RsOhz7",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": false,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__MosrS1dHHXThJ96N.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__MosrS1dHHXThJ96N.json
@@ -8,7 +8,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__Qt03jfl943CxPGeL.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__Qt03jfl943CxPGeL.json
@@ -1,0 +1,35 @@
+{
+	"_id": "Qt03jfl943CxPGeL",
+	"_key": "!items.effects!r4V3eAGkZ1klmFe7.Qt03jfl943CxPGeL",
+	"changes": [
+		{
+			"key": "system.roll.attack.bonus.this",
+			"mode": 2,
+			"priority": null,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startRound": null,
+		"startTime": null,
+		"startTurn": null,
+		"turns": null
+	},
+	"flags": {
+	},
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Weapon Attack Roll Bonus",
+	"origin": "Item.QZDYdbLD9VM4i3Mr",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__Qt03jfl943CxPGeL.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__Qt03jfl943CxPGeL.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__U8i8NfAsHGKpezHN.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__U8i8NfAsHGKpezHN.json
@@ -8,7 +8,7 @@
 			"value": "2"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__U8i8NfAsHGKpezHN.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__U8i8NfAsHGKpezHN.json
@@ -26,6 +26,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__U8i8NfAsHGKpezHN.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__U8i8NfAsHGKpezHN.json
@@ -1,0 +1,31 @@
+{
+	"_id": "U8i8NfAsHGKpezHN",
+	"_key": "!items.effects!3Wgj18VMKb0KmRHI.U8i8NfAsHGKpezHN",
+	"changes": [
+		{
+			"key": "system.roll.attack.bonus.this",
+			"mode": 2,
+			"value": "2"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Weapon Attack Roll Bonus",
+	"origin": "Item.Jsn81bt8tPxZCdmD",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": false,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__WhT5yrk9W2vCWs6X.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__WhT5yrk9W2vCWs6X.json
@@ -1,12 +1,12 @@
 {
-	"_id": "n3Z0tBxloczqrb2w",
-	"_key": "!items.effects!hcC1kuGgQ2VdnHmj.n3Z0tBxloczqrb2w",
+	"_id": "WhT5yrk9W2vCWs6X",
+	"_key": "!items.effects!SuPwL1LQKe8DdaRq.WhT5yrk9W2vCWs6X",
 	"changes": [
 		{
-			"key": "system.languages",
+			"key": "system.roll.attack.bonus.this",
 			"mode": 2,
 			"priority": null,
-			"value": "Compendium.shadowdark.languages.Item.b5yBrLaRIl7ZEWKu"
+			"value": "2"
 		}
 	],
 	"description": "",
@@ -22,9 +22,9 @@
 	},
 	"flags": {
 	},
-	"img": "icons/commodities/tech/cog-steel-grey.webp",
-	"name": "Speak & Understand Diabolic",
-	"origin": "Item.WQAnfvteIZallISc",
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Weapon Attack Roll Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.SuPwL1LQKe8DdaRq",
 	"statuses": [
 	],
 	"system": {

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__WhT5yrk9W2vCWs6X.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__WhT5yrk9W2vCWs6X.json
@@ -9,7 +9,7 @@
 			"value": "2"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__Z4UACwRTky38K63x.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__Z4UACwRTky38K63x.json
@@ -1,0 +1,31 @@
+{
+	"_id": "Z4UACwRTky38K63x",
+	"_key": "!items.effects!4BkbHe0cL8Zvsd7a.Z4UACwRTky38K63x",
+	"changes": [
+		{
+			"key": "system.roll.attack.bonus.this",
+			"mode": 2,
+			"value": "3"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Weapon Attack Roll Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.4BkbHe0cL8Zvsd7a",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": false,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__Z4UACwRTky38K63x.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__Z4UACwRTky38K63x.json
@@ -8,7 +8,7 @@
 			"value": "3"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__apF91F2anJCrmkSm.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__apF91F2anJCrmkSm.json
@@ -1,0 +1,29 @@
+{
+	"_id": "apF91F2anJCrmkSm",
+	"_key": "!items.effects!EiyxS6MOvGlZgG65.apF91F2anJCrmkSm",
+	"changes": [
+		{
+			"key": "system.roll.attack.bonus.this",
+			"mode": 2,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Weapon Attack Roll Bonus",
+	"origin": "Item.u8JqsRuUaGOch5Se",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": false,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__apF91F2anJCrmkSm.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__apF91F2anJCrmkSm.json
@@ -8,7 +8,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__apF91F2anJCrmkSm.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__apF91F2anJCrmkSm.json
@@ -24,6 +24,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__eXpmyWBLi6CfFuTt.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__eXpmyWBLi6CfFuTt.json
@@ -1,12 +1,12 @@
 {
-	"_id": "n3Z0tBxloczqrb2w",
-	"_key": "!items.effects!hcC1kuGgQ2VdnHmj.n3Z0tBxloczqrb2w",
+	"_id": "eXpmyWBLi6CfFuTt",
+	"_key": "!items.effects!YITrYmzXxk6Yjxfc.eXpmyWBLi6CfFuTt",
 	"changes": [
 		{
-			"key": "system.languages",
+			"key": "system.roll.attack.bonus.this",
 			"mode": 2,
 			"priority": null,
-			"value": "Compendium.shadowdark.languages.Item.b5yBrLaRIl7ZEWKu"
+			"value": "1"
 		}
 	],
 	"description": "",
@@ -22,9 +22,9 @@
 	},
 	"flags": {
 	},
-	"img": "icons/commodities/tech/cog-steel-grey.webp",
-	"name": "Speak & Understand Diabolic",
-	"origin": "Item.WQAnfvteIZallISc",
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Weapon Attack Roll Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.YITrYmzXxk6Yjxfc",
 	"statuses": [
 	],
 	"system": {

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__eXpmyWBLi6CfFuTt.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__eXpmyWBLi6CfFuTt.json
@@ -9,7 +9,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__kjwVuIlPksnF2hR1.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__kjwVuIlPksnF2hR1.json
@@ -1,0 +1,31 @@
+{
+	"_id": "kjwVuIlPksnF2hR1",
+	"_key": "!items.effects!ck4lutlGUcVmIE6y.kjwVuIlPksnF2hR1",
+	"changes": [
+		{
+			"key": "system.roll.attack.bonus.this",
+			"mode": 2,
+			"value": "3"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Weapon Attack Roll Bonus",
+	"origin": "Item.Hl8FZ5dUga3pYqH8",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": false,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__kjwVuIlPksnF2hR1.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__kjwVuIlPksnF2hR1.json
@@ -8,7 +8,7 @@
 			"value": "3"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__kjwVuIlPksnF2hR1.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__kjwVuIlPksnF2hR1.json
@@ -26,6 +26,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__l9MlejatmWj0EesQ.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__l9MlejatmWj0EesQ.json
@@ -8,7 +8,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__l9MlejatmWj0EesQ.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__l9MlejatmWj0EesQ.json
@@ -24,6 +24,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__l9MlejatmWj0EesQ.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__l9MlejatmWj0EesQ.json
@@ -1,0 +1,29 @@
+{
+	"_id": "l9MlejatmWj0EesQ",
+	"_key": "!items.effects!bpJlJ3vnZVmvOEJV.l9MlejatmWj0EesQ",
+	"changes": [
+		{
+			"key": "system.roll.attack.bonus.this",
+			"mode": 2,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Weapon Attack Roll Bonus",
+	"origin": "Item.nfRD48XCs8SvvptW",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": false,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__nYIEUngawHOWjKLV.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__nYIEUngawHOWjKLV.json
@@ -8,7 +8,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__nYIEUngawHOWjKLV.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__nYIEUngawHOWjKLV.json
@@ -1,0 +1,29 @@
+{
+	"_id": "nYIEUngawHOWjKLV",
+	"_key": "!items.effects!EBfBPArPRSyLXFPM.nYIEUngawHOWjKLV",
+	"changes": [
+		{
+			"key": "system.roll.attack.bonus.this",
+			"mode": 2,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Weapon Attack Roll Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.EBfBPArPRSyLXFPM",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": false,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__nv1kzlTwOcLqpi7w.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__nv1kzlTwOcLqpi7w.json
@@ -8,7 +8,7 @@
 			"value": "2"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__nv1kzlTwOcLqpi7w.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__nv1kzlTwOcLqpi7w.json
@@ -1,0 +1,31 @@
+{
+	"_id": "nv1kzlTwOcLqpi7w",
+	"_key": "!items.effects!REKbDm3ShTNQouM2.nv1kzlTwOcLqpi7w",
+	"changes": [
+		{
+			"key": "system.roll.attack.bonus.this",
+			"mode": 2,
+			"value": "2"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Weapon Attack Roll Bonus",
+	"origin": "Item.5ayvpKEkkJ70T9Ir",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": false,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__nv1kzlTwOcLqpi7w.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__nv1kzlTwOcLqpi7w.json
@@ -26,6 +26,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__pOdV4x1mBsF4ZJmg.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__pOdV4x1mBsF4ZJmg.json
@@ -8,7 +8,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__qx4j9GoWPYmbbu9g.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__qx4j9GoWPYmbbu9g.json
@@ -8,7 +8,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__qx4j9GoWPYmbbu9g.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__qx4j9GoWPYmbbu9g.json
@@ -1,0 +1,29 @@
+{
+	"_id": "qx4j9GoWPYmbbu9g",
+	"_key": "!items.effects!5vaHRsgVMO4v6ePR.qx4j9GoWPYmbbu9g",
+	"changes": [
+		{
+			"key": "system.roll.attack.bonus.this",
+			"mode": 2,
+			"value": "1"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Weapon Attack Roll Bonus",
+	"origin": "Item.B30rw9qP2aK1r73k",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": false,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__qx4j9GoWPYmbbu9g.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__qx4j9GoWPYmbbu9g.json
@@ -24,6 +24,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__un7hIgJAJuzdyLvo.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__un7hIgJAJuzdyLvo.json
@@ -1,0 +1,31 @@
+{
+	"_id": "un7hIgJAJuzdyLvo",
+	"_key": "!items.effects!MgWPwzNTzC7cPi7H.un7hIgJAJuzdyLvo",
+	"changes": [
+		{
+			"key": "system.roll.attack.bonus.this",
+			"mode": 2,
+			"value": "3"
+		}
+	],
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"combat": null,
+		"rounds": null,
+		"seconds": null,
+		"startTime": null
+	},
+	"flags": {
+	},
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Weapon Attack Roll Bonus",
+	"origin": "Item.IMsCntyKjKOgNteb",
+	"statuses": [
+	],
+	"system": {
+	},
+	"tint": "#ffffff",
+	"transfer": false,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__un7hIgJAJuzdyLvo.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__un7hIgJAJuzdyLvo.json
@@ -8,7 +8,7 @@
 			"value": "3"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__un7hIgJAJuzdyLvo.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__un7hIgJAJuzdyLvo.json
@@ -26,6 +26,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__yMBdo0WUxtzRzji9.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__yMBdo0WUxtzRzji9.json
@@ -8,7 +8,7 @@
 			"value": "1"
 		}
 	],
-	"description": "",
+	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
 		"combat": null,

--- a/data/packs/magic-items.db/well_of_many_worlds__Wpswh8YGofiuBCME.json
+++ b/data/packs/magic-items.db/well_of_many_worlds__Wpswh8YGofiuBCME.json
@@ -1,0 +1,51 @@
+{
+	"_id": "Wpswh8YGofiuBCME",
+	"_key": "!items!Wpswh8YGofiuBCME",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/commodities/cloth/cloth-bolt-gold-orange.webp",
+	"name": "Well of Many Worlds",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>A dark circle of cloth that seems to create a tunnel through the surface it lies upon.</em></p><p><strong>Benefit.</strong> The Well of Many Worlds folds open on a flat surface into a 6-foot wide hole. Creatures can jump into the hole once per day each to be transported to a random plane of existence.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/wraith_chain__nn46QlpIOUb9w7x6.json
+++ b/data/packs/magic-items.db/wraith_chain__nn46QlpIOUb9w7x6.json
@@ -1,0 +1,47 @@
+{
+	"_id": "nn46QlpIOUb9w7x6",
+	"_key": "!items!nn46QlpIOUb9w7x6",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/equipment/chest/breastplate-scale-grey.webp",
+	"name": "Wraith Chain",
+	"system": {
+		"ac": {
+			"attribute": "dex",
+			"base": 13,
+			"modifier": 1
+		},
+		"baseArmor": "chainmail",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 240,
+			"sp": 0
+		},
+		"description": "<p><em>A chainmail shirt of black, mithral links that trails a long cloak of writhing shadows.</em></p><p><strong>Bonus.</strong> +1 mithral chainmail.</p><p><strong>Benefit.</strong> Once per day, you may cause an attack that hits you to miss instead.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": "Identified Name"
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "core-rules"
+		},
+		"stashed": false
+	},
+	"type": "Armor"
+}


### PR DESCRIPTION
> [!NOTE]
> This is a re-targeting of the now closed #1259 to now target v4.0.0

This includes all of the magic items from the Shadowdark Core Rules, as well as some changes to the "source" of a few items which were listed as coming from the core rules but actually only exist in the starter set. 

## Limitations

1. In cases where an item has different bonuses or effects depending on certain situations — for example the "Warhammer of the Dwarf Lords" which has a larger bonus to hit & damage when being wielded by a dwarf, or Memnon's Blazing Javelin, Memnon's Discordant Blade & Memnon's Entripic Armor which go from being +1 to +3 if you have all 3 of them — I have simply made two copies of the item, one named as the base item, and one named as the base item with parentheses explaining the difference — e.g. "Memnon's Blazing Javelin (Completed Set)"
2. In places where items give you a bonus or advantage in a very specific situation — e.g. the "Thrice-Blessed Sword" granting double damage only against demons, devils & undead I have added situational effects. 