### PR TITLE
More robust monster parser for importer

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -84,6 +84,7 @@ SHADOWDARK.apps.effect_panel.duration_label.x_years: "{years} Years Remaining"
 SHADOWDARK.apps.effect_panel.right_click_to_remove: "[Right click] Remove effect"
 SHADOWDARK.apps.item-importer.header: Item Importer
 SHADOWDARK.apps.item-importer.import_button: Import Item
+SHADOWDARK.apps.item-importer.placeholder: Paste item text here...
 SHADOWDARK.apps.item-importer.instruction1: 1. Copy item text from source material.
 SHADOWDARK.apps.item-importer.instruction2a: 2. Paste text into this box following the item format shown in the core rules.
 SHADOWDARK.apps.item-importer.instruction2b: Item Name
@@ -105,6 +106,7 @@ SHADOWDARK.apps.level-up.roll_talent: Roll Talent
 SHADOWDARK.apps.level-up.title: Leveling Up
 SHADOWDARK.apps.monster-importer.header: Monster Importer
 SHADOWDARK.apps.monster-importer.import_button: Import Monster
+SHADOWDARK.apps.monster-importer.placeholder: Paste monster text here...
 SHADOWDARK.apps.monster-importer.instruction1: 1. Copy monster text from source material.
 SHADOWDARK.apps.monster-importer.instruction2a: 2. Paste text into the text box following the monster format shown in the core rules. Add a blank line between each ability.
 SHADOWDARK.apps.monster-importer.instruction2b: Monster Name
@@ -142,6 +144,7 @@ SHADOWDARK.apps.spell-book.known: Known
 SHADOWDARK.apps.spell-book.title: Class Spell List
 SHADOWDARK.apps.spell-importer.header: Spell Importer
 SHADOWDARK.apps.spell-importer.import_button: Import Spell
+SHADOWDARK.apps.spell-importer.placeholder: Paste spell text here...
 SHADOWDARK.apps.spell-importer.instruction1: 1. Copy spell text from source material.
 SHADOWDARK.apps.spell-importer.instruction2a: 2. Paste text into this box following the spell format shown in the core rules.
 SHADOWDARK.apps.spell-importer.instruction2b: Spell Name

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -82,6 +82,7 @@ SHADOWDARK.apps.effect_panel.duration_label.x_seconds: "{seconds} Seconds Remain
 SHADOWDARK.apps.effect_panel.duration_label.x_weeks: "{weeks} Weeks Remaining"
 SHADOWDARK.apps.effect_panel.duration_label.x_years: "{years} Years Remaining"
 SHADOWDARK.apps.effect_panel.right_click_to_remove: "[Right click] Remove effect"
+SHADOWDARK.apps.item-importer.header: Item Importer
 SHADOWDARK.apps.item-importer.import_button: Import Item
 SHADOWDARK.apps.item-importer.instruction1: 1. Copy item text from source material.
 SHADOWDARK.apps.item-importer.instruction2a: 2. Paste text into this box following the item format shown in the core rules.
@@ -102,6 +103,7 @@ SHADOWDARK.apps.level-up.prompt: Not all required selections have been made. Con
 SHADOWDARK.apps.level-up.roll_boon: Roll Boon
 SHADOWDARK.apps.level-up.roll_talent: Roll Talent
 SHADOWDARK.apps.level-up.title: Leveling Up
+SHADOWDARK.apps.monster-importer.header: Monster Importer
 SHADOWDARK.apps.monster-importer.import_button: Import Monster
 SHADOWDARK.apps.monster-importer.instruction1: 1. Copy monster text from source material.
 SHADOWDARK.apps.monster-importer.instruction2a: 2. Paste text into the text box following the monster format shown in the core rules. Add a blank line between each ability.
@@ -138,6 +140,7 @@ SHADOWDARK.apps.solodark.roll_prompt: Roll Prompt
 SHADOWDARK.apps.solodark.title: SoloDark
 SHADOWDARK.apps.spell-book.known: Known
 SHADOWDARK.apps.spell-book.title: Class Spell List
+SHADOWDARK.apps.spell-importer.header: Spell Importer
 SHADOWDARK.apps.spell-importer.import_button: Import Spell
 SHADOWDARK.apps.spell-importer.instruction1: 1. Copy spell text from source material.
 SHADOWDARK.apps.spell-importer.instruction2a: 2. Paste text into this box following the spell format shown in the core rules.

--- a/scss/apps/_shadowdarkling-importer.scss
+++ b/scss/apps/_shadowdarkling-importer.scss
@@ -15,3 +15,20 @@
 		font-family: "Old Newspaper Font";
 	}
 }
+
+.import-errors {
+	max-height: 120px;
+	overflow-y: auto;
+	margin: 4px 0 0;
+	padding: 6px 10px;
+	font-size: 0.85em;
+	list-style: none;
+	border: 1px solid rgba(255, 60, 60, 0.4);
+	border-radius: 3px;
+	background: rgba(255, 60, 60, 0.08);
+	color: #ff9090;
+
+	li::before {
+		content: "\2022 ";
+	}
+}

--- a/scss/apps/_shadowdarkling-importer.scss
+++ b/scss/apps/_shadowdarkling-importer.scss
@@ -32,3 +32,7 @@
 		content: "\2022 ";
 	}
 }
+
+body.theme-light .import-errors {
+	color: #c0000f;
+}

--- a/system/src/apps/ImporterSD.mjs
+++ b/system/src/apps/ImporterSD.mjs
@@ -1,0 +1,44 @@
+/**
+ * Base class for text-based importers. Subclasses must define:
+ * - static IMPORTER_CONFIG with { textField, sidebarTab, errorMessage }
+ * - an async _import(text) method that parses the text and creates a document
+ */
+export default class ImporterSD extends foundry.applications.api.HandlebarsApplicationMixin(
+	foundry.applications.api.ApplicationV2
+) {
+
+	static DEFAULT_OPTIONS = {
+		tag: "form",
+		window: {
+			resizable: true,
+			contentClasses: ["standard-form"],
+		},
+		position: {
+			width: 600,
+			height: 600,
+		},
+		form: {
+			handler: ImporterSD._onSubmitForm,
+			closeOnSubmit: false,
+		},
+	};
+
+	/** @override */
+	static async _onSubmitForm(event, form, formData) {
+		const config = this.constructor.IMPORTER_CONFIG;
+		const text = formData.object[config.textField];
+
+		try {
+			let newDoc = await this._import(text);
+			ui.notifications.info(`Successfully Created: ${newDoc.name} [${newDoc._id}]`);
+			ui.sidebar.activateTab(config.sidebarTab);
+		}
+		catch(error) {
+			ui.notifications.error(`${config.errorMessage} ${error}`);
+		}
+	}
+
+	_toCamelCase(str) {
+		return str.toLowerCase().replace(/[^a-zA-Z0-9]+(.)/g, (m, chr) => chr.toUpperCase());
+	}
+}

--- a/system/src/apps/ImporterSD.mjs
+++ b/system/src/apps/ImporterSD.mjs
@@ -27,14 +27,37 @@ export default class ImporterSD extends foundry.applications.api.HandlebarsAppli
 	static async _onSubmitForm(event, form, formData) {
 		const config = this.constructor.IMPORTER_CONFIG;
 		const text = formData.object[config.textField];
+		const errorList = form.querySelector(".import-errors");
+
+		// Clear previous errors
+		if (errorList) {
+			errorList.replaceChildren();
+			errorList.hidden = true;
+		}
 
 		try {
 			let newDoc = await this._import(text);
-			ui.notifications.info(`Successfully Created: ${newDoc.name} [${newDoc._id}]`);
+			ui.notifications.info(
+				`Successfully Created: ${newDoc.name} [${newDoc._id}]`
+			);
 			ui.sidebar.activateTab(config.sidebarTab);
+			this.close();
+			newDoc.sheet.render(true);
 		}
 		catch(error) {
-			ui.notifications.error(`${config.errorMessage} ${error}`);
+			if (error.details && errorList) {
+				for (const msg of error.details) {
+					const li = document.createElement("li");
+					li.textContent = msg;
+					errorList.appendChild(li);
+				}
+				errorList.hidden = false;
+			}
+			else {
+				ui.notifications.error(
+					`${config.errorMessage} ${error}`
+				);
+			}
 		}
 	}
 

--- a/system/src/apps/ItemImporterSD.mjs
+++ b/system/src/apps/ItemImporterSD.mjs
@@ -1,25 +1,14 @@
-export default class ItemImporterSD extends foundry.applications.api.HandlebarsApplicationMixin(
-	foundry.applications.api.ApplicationV2
-) {
+import ImporterSD from "./ImporterSD.mjs";
+
+export default class ItemImporterSD extends ImporterSD {
 	/**
 	 * Contains an importer function to import item stat blocks
 	 */
 
 	static DEFAULT_OPTIONS = {
 		id: "sd-item-importer",
-		tag: "form",
 		window: {
-			resizable: true,
 			title: "SHADOWDARK.apps.item-importer.title",
-			contentClasses: ["standard-form"],
-		},
-		position: {
-			width: 600,
-			height: 600,
-		},
-		form: {
-			handler: ItemImporterSD._onSubmitForm,
-			closeOnSubmit: false,
 		},
 	};
 
@@ -29,22 +18,15 @@ export default class ItemImporterSD extends foundry.applications.api.HandlebarsA
 		},
 	};
 
+	static IMPORTER_CONFIG = {
+		textField: "itemText",
+		sidebarTab: "items",
+		errorMessage: "Failed to fully parse the item stat block.",
+	};
+
 	/** @override */
-	static async _onSubmitForm(event, form, formData) {
-		try {
-			let newItem = await this._importItem(formData.object.itemText);
-			ui.notifications.info(`Successfully Created: ${newItem.name} [${newItem._id}]`);
-			ui.sidebar.activateTab("items");
-
-		}
-		catch(error) {
-			ui.notifications.error(`Failed to fully parse the item stat block. ${error}`);
-		}
-	}
-
-
-	_toCamelCase(str) {
-		return str.toLowerCase().replace(/[^a-zA-Z0-9]+(.)/g, (m, chr) => chr.toUpperCase());
+	async _import(itemText) {
+		return this._importItem(itemText);
 	}
 
 	/**

--- a/system/src/apps/ItemImporterSD.mjs
+++ b/system/src/apps/ItemImporterSD.mjs
@@ -1,33 +1,38 @@
-export default class ItemImporterSD extends foundry.appv1.api.FormApplication {
+export default class ItemImporterSD extends foundry.applications.api.HandlebarsApplicationMixin(
+	foundry.applications.api.ApplicationV2
+) {
 	/**
 	 * Contains an importer function to import item stat blocks
 	 */
 
-	/** @inheritdoc */
-	static get defaultOptions() {
-		return foundry.utils.mergeObject(super.defaultOptions, {
-			classes: ["item-importer"],
-			width: 300,
-			resizable: false,
-		});
-	}
+	static DEFAULT_OPTIONS = {
+		id: "sd-item-importer",
+		tag: "form",
+		window: {
+			resizable: true,
+			title: "SHADOWDARK.apps.item-importer.title",
+			contentClasses: ["standard-form"],
+		},
+		position: {
+			width: 600,
+			height: 600,
+		},
+		form: {
+			handler: ItemImporterSD._onSubmitForm,
+			closeOnSubmit: false,
+		},
+	};
 
-	/** @inheritdoc */
-	get template() {
-		return "systems/shadowdark/templates/apps/item-importer.hbs";
-	}
+	static PARTS = {
+		form: {
+			template: "systems/shadowdark/templates/apps/item-importer.hbs",
+		},
+	};
 
-	/** @inheritdoc */
-	get title() {
-		const title = game.i18n.localize("SHADOWDARK.apps.item-importer.title");
-		return `${title}`;
-	}
-
-	/** @inheritdoc */
-	async _updateObject(event, formData) {
-		event.preventDefault();
+	/** @override */
+	static async _onSubmitForm(event, form, formData) {
 		try {
-			let newItem = await this._importItem(formData.itemText);
+			let newItem = await this._importItem(formData.object.itemText);
 			ui.notifications.info(`Successfully Created: ${newItem.name} [${newItem._id}]`);
 			ui.sidebar.activateTab("items");
 
@@ -35,12 +40,6 @@ export default class ItemImporterSD extends foundry.appv1.api.FormApplication {
 		catch(error) {
 			ui.notifications.error(`Failed to fully parse the item stat block. ${error}`);
 		}
-	}
-
-	/** @inheritdoc */
-	_onSubmit(event) {
-		event.preventDefault();
-		super._onSubmit(event);
 	}
 
 

--- a/system/src/apps/MonsterImporterSD.mjs
+++ b/system/src/apps/MonsterImporterSD.mjs
@@ -35,68 +35,78 @@ export default class MonsterImporterSD extends ImporterSD {
 	 * @returns {moveObj}
 	 */
 	_parseMovement(str) {
-		let moveObj ={
-			type: "",
-			notes: "",
+		const parsedMove = str.match(/([\s\w]*)(?:\(([\s\w]*)\))?/);
+		if (!parsedMove) {
+			throw new Error(`Unrecognized MV format: "${str}"`);
+		}
+
+		const type = this._toCamelCase(parsedMove[1].trim());
+		if (!(type in CONFIG.SHADOWDARK.NPC_MOVES)) {
+			throw new Error(`Unrecognized movement type: "${parsedMove[1].trim()}"`);
+		}
+
+		return {
+			type,
+			notes: parsedMove[2] ?? "",
 		};
-		let parsedMove = str.match(/([\s\w]*)(?:\(([\s\w]*)\))?/);
-		moveObj.type = this._toCamelCase(parsedMove[1].trim());
-
-		// makes sure the string is a valid move type
-		if (!(moveObj.type in CONFIG.SHADOWDARK.NPC_MOVES)) {
-			moveObj.type = "";
-		}
-
-		// if there are () in the move string copy to move notes
-		if (typeof parsedMove[2] !== "undefined") {
-			moveObj.notes = parsedMove[2];
-		}
-
-		return moveObj;
 	}
 
 	/**
-	 * Parses a stat block string into individual fields.
-	 * Splits on ", " and identifies each field by its key prefix.
-	 * Missing fields get empty string defaults instead of crashing.
+	 * Parses and validates a stat block string into individual fields.
 	 * @param {string} statBlock - Stat block with newlines already collapsed
-	 * @returns {object} { ac, hp, atk, mv, str, dex, con, int, wis, cha, al, lv }
+	 * @returns {object} Stats keyed by short codes (AC, HP, ATK, MV, S, D, C, I, W, Ch, AL, LV)
+	 * @throws {Error} With .details array listing missing, unknown, or invalid fields
 	 */
 	_parseStatBlock(statBlock) {
-		const stats = {
-			ac: null, hp: null, atk: null, mv: null,
-			str: null, dex: null, con: null, int: null, wis: null, cha: null,
-			al: null, lv: null,
+		const FIELDS = {
+			AC: "int", HP: "int", ATK: "str", MV: "str",
+			S: "int", D: "int", C: "int", I: "int", W: "int", Ch: "int",
+			AL: "str", LV: "int",
 		};
+
+		const stats = Object.fromEntries(Object.keys(FIELDS).map(k => [k, null]));
 		const errors = [];
 
-		const keyMap = {
-			AC: "ac", HP: "hp", ATK: "atk", MV: "mv",
-			S: "str", D: "dex", C: "con", I: "int", W: "wis", Ch: "cha",
-			AL: "al", LV: "lv",
-		};
-
-		// Split on ", " and match each chunk to a known key
 		for (const chunk of statBlock.split(", ")) {
 			const [key, ...rest] = chunk.trim().split(" ");
-			const field = keyMap[key];
+			let value = rest.join(" ");
 
-			// Unknown key — report it
-			if (!field) {
-				errors.push(`Unknown stat field: "${chunk.trim()}"`);
+			if (!(key in FIELDS)) {
+				errors.push(`Unknown field: "${chunk.trim()}"`);
 				continue;
 			}
 
-			let value = rest.join(" ");
 			// AC may include armor type in parens — extract just the number
-			if (field === "ac") {
+			if (key === "AC") {
 				const acMatch = value.match(/^(\d+)/);
 				value = acMatch ? acMatch[1] : value;
 			}
-			stats[field] = value;
+
+			if (FIELDS[key] === "int" && isNaN(parseInt(value))) {
+				errors.push(`Invalid ${key}: "${value}"`);
+				continue;
+			}
+
+			stats[key] = value;
 		}
 
-		stats.errors = errors;
+		// Check for missing fields
+		for (const key of Object.keys(FIELDS)) {
+			if (stats[key] === null) {
+				errors.push(`Missing: ${key}`);
+			}
+		}
+
+		if (stats.AL && !["L", "N", "C"].includes(stats.AL.toUpperCase())) {
+			errors.push(`Invalid AL: "${stats.AL}" (expected L, N, or C)`);
+		}
+
+		if (errors.length > 0) {
+			const error = new Error("Stat block validation failed");
+			error.details = errors;
+			throw error;
+		}
+
 		return stats;
 	}
 
@@ -115,6 +125,10 @@ export default class MonsterImporterSD extends ImporterSD {
 		].map(function(r) {
 			return r.source;
 		}).join(""));
+
+		if (!atk || !atk[2]?.trim()) {
+			throw new Error(`Could not parse attack: "${str.trim()}"`);
+		}
 
 		let attackObj = {
 			name: atk[2].trim().titleCase(),
@@ -232,6 +246,9 @@ export default class MonsterImporterSD extends ImporterSD {
 	 */
 	_parseFeature(str) {
 		const featureStr = str.match(/([^.]*)\.(?:\s*)?(.*)/);
+		if (!featureStr) {
+			throw new Error(`Could not parse feature: "${str.substring(0, 40)}"`);
+		}
 		const featureObj = {
 			name: featureStr[1].titleCase(),
 			type: "NPC Feature",
@@ -257,6 +274,10 @@ export default class MonsterImporterSD extends ImporterSD {
 		].map(function(r) {
 			return r.source;
 		}).join(""));
+
+		if (!parsedSpell) {
+			throw new Error(`Could not parse spell: "${str.substring(0, 40)}"`);
+		}
 
 		const spellObj = {
 			name: parsedSpell[1],
@@ -332,15 +353,135 @@ export default class MonsterImporterSD extends ImporterSD {
 		.join("")}`;
 
 	/**
+	 * Parses an ATK field into attack items and spellcasting info.
+	 * @param {string} atkStr - e.g. "2 claw +7 (1d12) or 1 spell +2"
+	 * @returns {{ attackArray: object[], spellcasting: object|null }}
+	 * @throws {Error} With .details array listing parse failures
+	 */
+	_parseAttacks(atkStr) {
+		const attackArray = [];
+		let spellcasting = null;
+		const errors = [];
+
+		for (const line of atkStr.split(/ and | or /)) {
+			try {
+				const atk = this._parseAttack(line);
+				if (atk.name.toLowerCase() === "spell") {
+					spellcasting = {
+						attacks: `${atk.system.attack.num}`,
+						bonus: atk.system.bonuses.attackBonus,
+					};
+				}
+				else {
+					attackArray.push(atk);
+				}
+			}
+			catch(e) {
+				errors.push(`Failed to parse attack: "${line.trim()}"`);
+			}
+		}
+
+		if (errors.length > 0) {
+			const error = new Error("Attack parsing failed");
+			error.details = errors;
+			throw error;
+		}
+
+		return { attackArray, spellcasting };
+	}
+
+	/**
+	 * Parses feature strings into feature/spell items and casting ability.
+	 * @param {string[]} features - Individual feature strings from _parseFeatures
+	 * @returns {{ featureArray: object[], castingAbility: string }}
+	 * @throws {Error} With .details array listing parse failures
+	 */
+	_parseFeaturesAndSpells(features) {
+		const featureArray = [];
+		let castingAbility = "";
+		const errors = [];
+
+		for (const text of features) {
+			const spellMatch = text.match(/\(([\w]*)?\s*Spell\)/);
+			if (spellMatch) {
+				try {
+					featureArray.push(this._parseSpell(text));
+					if (spellMatch[1]
+						&& CONFIG.SHADOWDARK.ABILITY_KEYS.includes(
+							spellMatch[1].toLowerCase()
+						)) {
+						castingAbility = spellMatch[1].toLowerCase();
+					}
+				}
+				catch(e) {
+					errors.push(`Failed to parse spell: "${text.substring(0, 40)}..."`);
+				}
+			}
+			else {
+				try {
+					featureArray.push(this._parseFeature(text));
+				}
+				catch(e) {
+					errors.push(`Failed to parse feature: "${text.substring(0, 40)}..."`);
+				}
+			}
+		}
+
+		if (errors.length > 0) {
+			const error = new Error("Feature parsing failed");
+			error.details = errors;
+			throw error;
+		}
+
+		return { featureArray, castingAbility };
+	}
+
+	/**
+	 * Builds a Foundry actor data object from validated parsed data.
+	 */
+	_buildActorObj(titleName, stats, statBlock, flavorText, features) {
+		const alignments = {L: "lawful", N: "neutral", C: "chaotic"};
+		const movement = this._parseMovement(stats.MV);
+		const notesText = this._generateNotesText(statBlock, flavorText, features);
+
+		return {
+			name: titleName,
+			img: "systems/shadowdark/assets/tokens/cowled_token_red.webp",
+			type: "NPC",
+			system: {
+				alignment: alignments[stats.AL.toUpperCase()],
+				attributes: {
+					ac: { value: stats.AC },
+					hp: { max: stats.HP, value: stats.HP, hd: 0 },
+				},
+				level: { value: stats.LV },
+				notes: notesText,
+				abilities: {
+					str: { mod: parseInt(stats.S) },
+					int: { mod: parseInt(stats.I) },
+					dex: { mod: parseInt(stats.D) },
+					wis: { mod: parseInt(stats.W) },
+					con: { mod: parseInt(stats.C) },
+					cha: { mod: parseInt(stats.Ch) },
+				},
+				darkAdapted: true,
+				move: movement.type,
+				moveNote: movement.notes,
+				spellcastingAbility: "",
+			},
+		};
+	}
+
+	/**
 	 * Parses pasted text into structured data without creating any documents.
+	 * Collects errors from all parsing stages and throws once with the full list.
 	 * @param {string} monsterText - Raw pasted monster text
-	 * @returns {object} { actorObj, attackArray, featureArray, castingAbility }
+	 * @returns {object} { actorObj, attackArray, featureArray, castingAbility, spellcasting }
+	 * @throws {Error} With .details array listing all parse failures
 	 */
 	_parseMonster(monsterText) {
-		// trim spaces from the end of each line:
 		monsterText = monsterText.replace(/[^\S\r\n]+$/gm, "");
 
-		// parse monster text into 4 main parts:
 		const parsedText = monsterText.match([
 			/(.*)\n/,							// parsedText[1] matches Title
 			/([\S\s]*)\n/,						// parsedText[2] matches flavor Text
@@ -350,111 +491,63 @@ export default class MonsterImporterSD extends ImporterSD {
 			return r.source;
 		}).join(""));
 
-		// set 4 main variables, removing newlines
+		if (!parsedText) {
+			const error = new Error("Import validation failed");
+			error.details = [
+				"Could not parse stat block. Expected format: "
+				+ "Name, description, stat block (AC ... LV), "
+				+ "then optional features.",
+			];
+			throw error;
+		}
+
 		const titleName = parsedText[1].titleCase();
 		const flavorText = parsedText[2].replace(/(\r\n|\n|\r)/gm, " ");
 		const statBlock = parsedText[3].replace(/(\r\n|\n|\r)/gm, " ");
 		const featuresText = parsedText[4];
-
 		const features = typeof featuresText !== "undefined"
-			? this._parseFeatures(featuresText)
-			: [];
+			? this._parseFeatures(featuresText) : [];
 
-		// parse out main stat block field by field
-		const stats = this._parseStatBlock(statBlock);
+		// Collect errors from all parsing stages
+		const errors = [];
 
-		// build parse complex outputs
-		const alignments = {L: "lawful", N: "neutral", C: "chaotic"};
-		const movement = stats.mv ? this._parseMovement(stats.mv) : { type: "", notes: "" };
-		const notesText = this._generateNotesText(statBlock, flavorText, features);
+		let stats = null;
+		try {
+			stats = this._parseStatBlock(statBlock);
+		}
+		catch(e) {
+			errors.push(...e.details);
+		}
 
-		// create the monster template
-		let actorObj = {
-			name: titleName,
-			img: "systems/shadowdark/assets/tokens/cowled_token_red.webp",
-			type: "NPC",
-			system: {
-				alignment: (stats.al && alignments[stats.al.toUpperCase()]) || "",
-				attributes: {
-					ac: {
-						value: stats.ac,
-					},
-					hp: {
-						max: stats.hp,
-						value: stats.hp,
-						hd: 0,
-					},
-				},
-				level: {
-					value: stats.lv,
-				},
-				notes: notesText,
-				abilities: {
-					str: {
-						mod: parseInt(stats.str) || 0,
-					},
-					int: {
-						mod: parseInt(stats.int) || 0,
-					},
-					dex: {
-						mod: parseInt(stats.dex) || 0,
-					},
-					wis: {
-						mod: parseInt(stats.wis) || 0,
-					},
-					con: {
-						mod: parseInt(stats.con) || 0,
-					},
-					cha: {
-						mod: parseInt(stats.cha) || 0,
-					},
-				},
-				darkAdapted: true,
-				move: movement.type,
-				moveNote: movement.notes,
-				spellcastingAbility: "",
-			},
-		};
-
-		// Parse attacks
 		let attackArray = [];
 		let spellcasting = null;
-		if (stats.atk) stats.atk.split(/ and | or /).forEach( line => {
-			const attackObj = this._parseAttack(line);
-			// if attack is a spell, store spellcasting details
-			if (attackObj.name.toLowerCase() === "spell") {
-				spellcasting = {
-					attacks: `${attackObj.system.attack.num}`,
-					bonus: attackObj.system.bonuses.attackBonus,
-				};
+		if (stats?.ATK) {
+			try {
+				({ attackArray, spellcasting } = this._parseAttacks(stats.ATK));
 			}
-			else {
-				attackArray.push(attackObj);
+			catch(e) {
+				errors.push(...e.details);
 			}
-		});
+		}
 
-		// Parse features and spells
 		let featureArray = [];
-		let castingAbility ="";
+		let castingAbility = "";
+		try {
+			({ featureArray, castingAbility } = this._parseFeaturesAndSpells(features));
+		}
+		catch(e) {
+			errors.push(...e.details);
+		}
 
-		features.forEach( text => {
+		if (errors.length > 0) {
+			const error = new Error("Import validation failed");
+			error.details = errors;
+			throw error;
+		}
 
-			// Is the feature a spell?
-			const spellTestStr = text.match(/\(([\w]*)?\s*Spell\)/);
-			if (spellTestStr) {
-				featureArray.push(this._parseSpell(text));
-
-				// does the spell list a casting ability?
-				if (typeof spellTestStr[1] !== "undefined" && CONFIG.SHADOWDARK.ABILITY_KEYS.includes(spellTestStr[1].toLowerCase())) {
-					castingAbility = spellTestStr[1].toLowerCase();
-				}
-			}
-			// Parse Feature
-			else {
-				featureArray.push(this._parseFeature(text));
-			}
-		});
-
+		const actorObj = this._buildActorObj(
+			titleName, stats, statBlock, flavorText, features
+		);
 		return { actorObj, attackArray, featureArray, castingAbility, spellcasting };
 	}
 

--- a/system/src/apps/MonsterImporterSD.mjs
+++ b/system/src/apps/MonsterImporterSD.mjs
@@ -1,34 +1,38 @@
-export default class MonsterImporterSD extends foundry.appv1.api.FormApplication {
+export default class MonsterImporterSD extends foundry.applications.api.HandlebarsApplicationMixin(
+	foundry.applications.api.ApplicationV2
+) {
 	/**
 	 * Contains an importer function to import monster stat blocks
 	 */
 
-	/** @inheritdoc */
-	static get defaultOptions() {
-		return foundry.utils.mergeObject(super.defaultOptions, {
-			classes: ["monster-importer"],
+	static DEFAULT_OPTIONS = {
+		id: "sd-monster-importer",
+		tag: "form",
+		window: {
+			resizable: true,
+			title: "SHADOWDARK.apps.monster-importer.title",
+			contentClasses: ["standard-form"],
+		},
+		position: {
 			width: 600,
 			height: 600,
-			resizable: true,
-		});
-	}
+		},
+		form: {
+			handler: MonsterImporterSD._onSubmitForm,
+			closeOnSubmit: false,
+		},
+	};
 
-	/** @inheritdoc */
-	get template() {
-		return "systems/shadowdark/templates/apps/monster-importer.hbs";
-	}
+	static PARTS = {
+		form: {
+			template: "systems/shadowdark/templates/apps/monster-importer.hbs",
+		},
+	};
 
-	/** @inheritdoc */
-	get title() {
-		const title = game.i18n.localize("SHADOWDARK.apps.monster-importer.title");
-		return `${title}`;
-	}
-
-	/** @inheritdoc */
-	async _updateObject(event, formData) {
-		event.preventDefault();
+	/** @override */
+	static async _onSubmitForm(event, form, formData) {
 		try {
-			let newNPC = await this._importMonster(formData.monsterText);
+			let newNPC = await this._importMonster(formData.object.monsterText);
 			ui.notifications.info(`Successfully Created: ${newNPC.name} [${newNPC._id}]`);
 			ui.sidebar.activateTab("actors");
 
@@ -36,12 +40,6 @@ export default class MonsterImporterSD extends foundry.appv1.api.FormApplication
 		catch(error) {
 			ui.notifications.error(`Failed to fully parse the monster stat block. ${error}`);
 		}
-	}
-
-	/** @inheritdoc */
-	_onSubmit(event) {
-		event.preventDefault();
-		super._onSubmit(event);
 	}
 
 	_toCamelCase(str) {

--- a/system/src/apps/MonsterImporterSD.mjs
+++ b/system/src/apps/MonsterImporterSD.mjs
@@ -266,7 +266,7 @@ export default class MonsterImporterSD extends ImporterSD {
 				description: `<p>${parsedSpell[4].replaceAll(/(\d+d\d+)/gi, "[[/r $&]]")}</p>`,
 				range: "",
 				duration: {
-					type: "",
+					type: "instant",
 					value: -1,
 				},
 			},

--- a/system/src/apps/MonsterImporterSD.mjs
+++ b/system/src/apps/MonsterImporterSD.mjs
@@ -1,25 +1,14 @@
-export default class MonsterImporterSD extends foundry.applications.api.HandlebarsApplicationMixin(
-	foundry.applications.api.ApplicationV2
-) {
+import ImporterSD from "./ImporterSD.mjs";
+
+export default class MonsterImporterSD extends ImporterSD {
 	/**
 	 * Contains an importer function to import monster stat blocks
 	 */
 
 	static DEFAULT_OPTIONS = {
 		id: "sd-monster-importer",
-		tag: "form",
 		window: {
-			resizable: true,
 			title: "SHADOWDARK.apps.monster-importer.title",
-			contentClasses: ["standard-form"],
-		},
-		position: {
-			width: 600,
-			height: 600,
-		},
-		form: {
-			handler: MonsterImporterSD._onSubmitForm,
-			closeOnSubmit: false,
 		},
 	};
 
@@ -29,21 +18,15 @@ export default class MonsterImporterSD extends foundry.applications.api.Handleba
 		},
 	};
 
+	static IMPORTER_CONFIG = {
+		textField: "monsterText",
+		sidebarTab: "actors",
+		errorMessage: "Failed to fully parse the monster stat block.",
+	};
+
 	/** @override */
-	static async _onSubmitForm(event, form, formData) {
-		try {
-			let newNPC = await this._importMonster(formData.object.monsterText);
-			ui.notifications.info(`Successfully Created: ${newNPC.name} [${newNPC._id}]`);
-			ui.sidebar.activateTab("actors");
-
-		}
-		catch(error) {
-			ui.notifications.error(`Failed to fully parse the monster stat block. ${error}`);
-		}
-	}
-
-	_toCamelCase(str) {
-		return str.toLowerCase().replace(/[^a-zA-Z0-9]+(.)/g, (m, chr) => chr.toUpperCase());
+	async _import(monsterText) {
+		return this._importMonster(monsterText);
 	}
 
 	/**

--- a/system/src/apps/MonsterImporterSD.mjs
+++ b/system/src/apps/MonsterImporterSD.mjs
@@ -242,11 +242,11 @@ export default class MonsterImporterSD extends ImporterSD {
 		.join("")}`;
 
 	/**
-	 * Parses pasted text representing a monster and creates an NPC actor from it.
-	 * @param {string} string - String data posted by user
-	 * @returns {ActorSD}
+	 * Parses pasted text into structured data without creating any documents.
+	 * @param {string} monsterText - Raw pasted monster text
+	 * @returns {object} { actorObj, attackArray, featureArray, castingAbility }
 	 */
-	async _importMonster(monsterText) {
+	_parseMonster(monsterText) {
 		// trim spaces from the end of each line:
 		monsterText = monsterText.replace(/[^\S\r\n]+$/gm, "");
 
@@ -339,25 +339,24 @@ export default class MonsterImporterSD extends ImporterSD {
 			},
 		};
 
-		// Create the NPC actor
-		const newActor = await Actor.create(actorObj);
-
-		// Parse attacks features, and spells and add to actor
+		// Parse attacks
 		let attackArray = [];
+		let spellcasting = null;
 		stats[3].split(/ and | or /).forEach( line => {
 			const attackObj = this._parseAttack(line);
-			// if attack is a spell, update actors details for spellcasting
+			// if attack is a spell, store spellcasting details
 			if (attackObj.name.toLowerCase() === "spell") {
-				newActor.update({"system.spellcasting.attacks": `${attackObj.system.attack.num}`});
-				newActor.update({"system.spellcasting.bonus": attackObj.system.bonuses.attackBonus});
+				spellcasting = {
+					attacks: `${attackObj.system.attack.num}`,
+					bonus: attackObj.system.bonuses.attackBonus,
+				};
 			}
 			else {
 				attackArray.push(attackObj);
 			}
 		});
-		await newActor.createEmbeddedDocuments("Item", attackArray);
 
-		// Parse features and add to actor
+		// Parse features and spells
 		let featureArray = [];
 		let castingAbility ="";
 
@@ -375,27 +374,51 @@ export default class MonsterImporterSD extends ImporterSD {
 			}
 			// Parse Feature
 			else {
-				const parsedFeatureObj = this._parseFeature(text);
+				featureArray.push(this._parseFeature(text));
+			}
+		});
 
-				// Is the feature a description of a special attack?
-				let isSpecialAttack = false;
-				newActor.items.forEach(x => {
-					if (x.type === "NPC Special Attack" && x.name === parsedFeatureObj.name) {
-						x.update({"system.description": parsedFeatureObj.system.description});
-						isSpecialAttack = true;
-					}
-				});
+		return { actorObj, attackArray, featureArray, castingAbility, spellcasting };
+	}
 
-				// push feature to actor
-				if (!isSpecialAttack) {
-					featureArray.push(parsedFeatureObj);
+	/**
+	 * Parses pasted text representing a monster and creates an NPC actor from it.
+	 * @param {string} monsterText - String data posted by user
+	 * @returns {ActorSD}
+	 */
+	async _importMonster(monsterText) {
+		const { actorObj, attackArray, featureArray, castingAbility, spellcasting } =
+			this._parseMonster(monsterText);
+
+		// Create the NPC actor
+		const newActor = await Actor.create(actorObj);
+
+		// Set spellcasting details if this NPC has spell attacks
+		if (spellcasting) {
+			newActor.update({"system.spellcasting.attacks": spellcasting.attacks});
+			newActor.update({"system.spellcasting.bonus": spellcasting.bonus});
+		}
+
+		await newActor.createEmbeddedDocuments("Item", attackArray);
+
+		// Merge feature descriptions into matching special attacks
+		const finalFeatures = [];
+		featureArray.forEach(feat => {
+			let isSpecialAttack = false;
+			newActor.items.forEach(x => {
+				if (x.type === "NPC Special Attack" && x.name === feat.name) {
+					x.update({"system.description": feat.system.description});
+					isSpecialAttack = true;
 				}
+			});
+			if (!isSpecialAttack) {
+				finalFeatures.push(feat);
 			}
 		});
 
 		await newActor.update({"system.spellcastingAbility": castingAbility});
 
-		await newActor.createEmbeddedDocuments("Item", featureArray);
+		await newActor.createEmbeddedDocuments("Item", finalFeatures);
 		return newActor;
 	}
 }

--- a/system/src/apps/MonsterImporterSD.mjs
+++ b/system/src/apps/MonsterImporterSD.mjs
@@ -136,6 +136,37 @@ export default class MonsterImporterSD extends ImporterSD {
 	}
 
 	/**
+	 * Splits raw features text into individual feature strings.
+	 * A new feature starts when a line begins with a capitalized word
+	 * followed by ". " (e.g. "Backstab. ") or after a blank line.
+	 * @param {string} text - Raw features text (may contain newlines)
+	 * @returns {string[]}
+	 */
+	_parseFeatures(text) {
+		const features = [];
+		let current = "";
+		for (const line of text.split(/\r?\n/)) {
+			const isBlank = line.trim() === "";
+			const isFeatureStart = /^[A-Z][a-z].*\.\s/.test(line);
+
+			// Boundary reached — save the current feature
+			if ((isBlank || isFeatureStart) && current.trim()) {
+				features.push(current.trim());
+				current = "";
+			}
+			// Append non-blank lines to the current feature
+			if (!isBlank) {
+				current += (current ? " " : "") + line;
+			}
+		}
+		// Don't forget the last feature
+		if (current.trim()) {
+			features.push(current.trim());
+		}
+		return features;
+	}
+
+	/**
 	 * Parses an NPC feature string and returns an obj
 	 * @param {string} str
 	 * @returns {featureObj}
@@ -264,10 +295,11 @@ export default class MonsterImporterSD extends ImporterSD {
 		const titleName = parsedText[1].titleCase();
 		const flavorText = parsedText[2].replace(/(\r\n|\n|\r)/gm, " ");
 		const statBlock = parsedText[3].replace(/(\r\n|\n|\r)/gm, " ");
-		let features = [];
-		if (typeof parsedText[4] !== "undefined") {
-			features = parsedText[4].split(/\n\s*\n/).map( x => x.replace(/(\r\n|\n|\r)/gm, " "));
-		}
+		const featuresText = parsedText[4];
+
+		const features = typeof featuresText !== "undefined"
+			? this._parseFeatures(featuresText)
+			: [];
 		// parse out main stat block
 		const stats = statBlock.match([
 			/.*AC (\d*)/,		// stats[1] matches AC

--- a/system/src/apps/MonsterImporterSD.mjs
+++ b/system/src/apps/MonsterImporterSD.mjs
@@ -56,6 +56,51 @@ export default class MonsterImporterSD extends ImporterSD {
 	}
 
 	/**
+	 * Parses a stat block string into individual fields.
+	 * Splits on ", " and identifies each field by its key prefix.
+	 * Missing fields get empty string defaults instead of crashing.
+	 * @param {string} statBlock - Stat block with newlines already collapsed
+	 * @returns {object} { ac, hp, atk, mv, str, dex, con, int, wis, cha, al, lv }
+	 */
+	_parseStatBlock(statBlock) {
+		const stats = {
+			ac: null, hp: null, atk: null, mv: null,
+			str: null, dex: null, con: null, int: null, wis: null, cha: null,
+			al: null, lv: null,
+		};
+		const errors = [];
+
+		const keyMap = {
+			AC: "ac", HP: "hp", ATK: "atk", MV: "mv",
+			S: "str", D: "dex", C: "con", I: "int", W: "wis", Ch: "cha",
+			AL: "al", LV: "lv",
+		};
+
+		// Split on ", " and match each chunk to a known key
+		for (const chunk of statBlock.split(", ")) {
+			const [key, ...rest] = chunk.trim().split(" ");
+			const field = keyMap[key];
+
+			// Unknown key — report it
+			if (!field) {
+				errors.push(`Unknown stat field: "${chunk.trim()}"`);
+				continue;
+			}
+
+			let value = rest.join(" ");
+			// AC may include armor type in parens — extract just the number
+			if (field === "ac") {
+				const acMatch = value.match(/^(\d+)/);
+				value = acMatch ? acMatch[1] : value;
+			}
+			stats[field] = value;
+		}
+
+		stats.errors = errors;
+		return stats;
+	}
+
+	/**
 	 * Parses an NPC attack string and returns an item obj representing that attack
 	 * @param {string} str
 	 * @returns {attackObj}
@@ -300,27 +345,13 @@ export default class MonsterImporterSD extends ImporterSD {
 		const features = typeof featuresText !== "undefined"
 			? this._parseFeatures(featuresText)
 			: [];
-		// parse out main stat block
-		const stats = statBlock.match([
-			/.*AC (\d*)/,		// stats[1] matches AC
-			/.*HP (\d*)/,		// stats[2] matches HP
-			/.*ATK (.*),/,		// stats[3] matches unparsed ATK
-			/.*MV (.*),/,		// stats[4] matches unparsed MV
-			/.*S ([-+]\d*),/,	// stats[5] matches STR
-			/.*D ([-+]\d*),/,	// stats[6] matches DEX
-			/.*C ([-+]\d*),/,	// stats[7] matches CON
-			/.*I ([-+]\d*),/,	// stats[8] matches INT
-			/.*W ([-+]\d*),/,	// stats[9] matches WIS
-			/.*Ch ([-+]\d*),/,	// stats[10] matches CHA
-			/.*AL (\w),/,		// stats[11] matches AL (single letter)
-			/.*LV (\d*)/,		// stats[12] matches LV
-		].map(function(r) {
-			return r.source;
-		}).join(""));
+
+		// parse out main stat block field by field
+		const stats = this._parseStatBlock(statBlock);
 
 		// build parse complex outputs
 		const alignments = {L: "lawful", N: "neutral", C: "chaotic"};
-		const movement = this._parseMovement(stats[4]);
+		const movement = stats.mv ? this._parseMovement(stats.mv) : { type: "", notes: "" };
 		const notesText = this._generateNotesText(statBlock, flavorText, features);
 
 		// create the monster template
@@ -329,39 +360,39 @@ export default class MonsterImporterSD extends ImporterSD {
 			img: "systems/shadowdark/assets/tokens/cowled_token_red.webp",
 			type: "NPC",
 			system: {
-				alignment: alignments[stats[11].toUpperCase()],
+				alignment: (stats.al && alignments[stats.al.toUpperCase()]) || "",
 				attributes: {
 					ac: {
-						value: stats[1],
+						value: stats.ac,
 					},
 					hp: {
-						max: stats[2],
-						value: stats[2],
+						max: stats.hp,
+						value: stats.hp,
 						hd: 0,
 					},
 				},
 				level: {
-					value: stats[12],
+					value: stats.lv,
 				},
 				notes: notesText,
 				abilities: {
 					str: {
-						mod: parseInt(stats[5]),
+						mod: parseInt(stats.str) || 0,
 					},
 					int: {
-						mod: parseInt(stats[8]),
+						mod: parseInt(stats.int) || 0,
 					},
 					dex: {
-						mod: parseInt(stats[6]),
+						mod: parseInt(stats.dex) || 0,
 					},
 					wis: {
-						mod: parseInt(stats[9]),
+						mod: parseInt(stats.wis) || 0,
 					},
 					con: {
-						mod: parseInt(stats[7]),
+						mod: parseInt(stats.con) || 0,
 					},
 					cha: {
-						mod: parseInt(stats[10]),
+						mod: parseInt(stats.cha) || 0,
 					},
 				},
 				darkAdapted: true,
@@ -374,7 +405,7 @@ export default class MonsterImporterSD extends ImporterSD {
 		// Parse attacks
 		let attackArray = [];
 		let spellcasting = null;
-		stats[3].split(/ and | or /).forEach( line => {
+		if (stats.atk) stats.atk.split(/ and | or /).forEach( line => {
 			const attackObj = this._parseAttack(line);
 			// if attack is a spell, store spellcasting details
 			if (attackObj.name.toLowerCase() === "spell") {

--- a/system/src/apps/MonsterImporterSD.mjs
+++ b/system/src/apps/MonsterImporterSD.mjs
@@ -84,6 +84,7 @@ export default class MonsterImporterSD extends ImporterSD {
 
 			if (FIELDS[key] === "int" && isNaN(parseInt(value))) {
 				errors.push(`Invalid ${key}: "${value}"`);
+				stats[key] = value;
 				continue;
 			}
 

--- a/system/src/apps/MonsterImporterSD.mjs
+++ b/system/src/apps/MonsterImporterSD.mjs
@@ -121,24 +121,29 @@ export default class MonsterImporterSD extends ImporterSD {
 			type: "NPC Special Attack",
 			system: {
 				attack: {
-					num: atk[1],
+					num: parseInt(atk[1]) || 1,
 				},
+				ranges: [],
 				bonuses: {
 					attackBonus: 0,
+					damageBonus: 0,
+					critical: {
+						failureThreshold: 1,
+						multiplier: 2,
+						successThreshold: 20,
+					},
 				},
 			},
 		};
 
 		// Validate Attack ranges and add
 		if (typeof atk[3] !== "undefined") {
-			let rangeArray = [];
 			atk[3].split(/\/|,/).forEach( x => {
 				let range = this._toCamelCase(x);
 				if (range in CONFIG.SHADOWDARK.RANGES) {
-					rangeArray.push(range);
+					attackObj.system.ranges.push(range);
 				}
 			});
-			attackObj.system.ranges = rangeArray;
 		}
 
 		// Add Hit bonus if any
@@ -146,7 +151,7 @@ export default class MonsterImporterSD extends ImporterSD {
 			attackObj.system.bonuses.attackBonus = parseInt(atk[4]);
 		}
 
-		// Attack is a phyical attack if damage exists
+		// Attack is a physical attack if damage exists
 		if (typeof atk[5] !== "undefined") {
 			attackObj.system.attackType = "physical";
 			attackObj.type = "NPC Attack";
@@ -157,13 +162,17 @@ export default class MonsterImporterSD extends ImporterSD {
 			});
 			// parse first object as # dice and dice type
 			const diceStr = dmgStrs[0].match(/(\d*)(d\d*)?/);
+			// TODO: special should not need to be set here, the sheet
+			// should handle missing/undefined special gracefully
 			if (typeof diceStr[2] !== "undefined") {
-				attackObj.system.damage = {};
-				attackObj.system.damage.numDice = diceStr[1];
-				attackObj.system.damage.value = diceStr[1] + diceStr[2];
+				attackObj.system.damage = {
+					numDice: parseInt(diceStr[1]),
+					value: diceStr[1] + diceStr[2],
+					special: "",
+				};
 			}
 			else {
-				attackObj.system.damage = { value: diceStr[1] };
+				attackObj.system.damage = { value: diceStr[1], special: "" };
 			}
 
 			// parse remaining string parts for +dmg or feature
@@ -175,6 +184,11 @@ export default class MonsterImporterSD extends ImporterSD {
 					attackObj.system.damage.special = dmgStrs[i].titleCase();
 				}
 			}
+		}
+
+		// Default physical attacks without explicit range to close
+		if (attackObj.type === "NPC Attack" && attackObj.system.ranges.length === 0) {
+			attackObj.system.ranges.push("close");
 		}
 
 		return attackObj;

--- a/system/src/apps/SpellImporterSD.mjs
+++ b/system/src/apps/SpellImporterSD.mjs
@@ -1,25 +1,14 @@
-export default class SpellImporter extends foundry.applications.api.HandlebarsApplicationMixin(
-	foundry.applications.api.ApplicationV2
-) {
+import ImporterSD from "./ImporterSD.mjs";
+
+export default class SpellImporter extends ImporterSD {
 	/**
 	 * Contains an importer function to import spell stat blocks
 	 */
 
 	static DEFAULT_OPTIONS = {
 		id: "sd-spell-importer",
-		tag: "form",
 		window: {
-			resizable: true,
 			title: "SHADOWDARK.apps.spell-importer.title",
-			contentClasses: ["standard-form"],
-		},
-		position: {
-			width: 600,
-			height: 600,
-		},
-		form: {
-			handler: SpellImporter._onSubmitForm,
-			closeOnSubmit: false,
 		},
 	};
 
@@ -29,21 +18,15 @@ export default class SpellImporter extends foundry.applications.api.HandlebarsAp
 		},
 	};
 
+	static IMPORTER_CONFIG = {
+		textField: "spellText",
+		sidebarTab: "items",
+		errorMessage: "Failed to fully parse the spell stat block.",
+	};
+
 	/** @override */
-	static async _onSubmitForm(event, form, formData) {
-		try {
-			let newSpell = await this._importSpell(formData.object.spellText);
-			ui.notifications.info(`Successfully Created: ${newSpell.name} [${newSpell._id}]`);
-			ui.sidebar.activateTab("items");
-
-		}
-		catch(error) {
-			ui.notifications.error(`Failed to fully parse the spell stat block. ${error}`);
-		}
-	}
-
-	_toCamelCase(str) {
-		return str.toLowerCase().replace(/[^a-zA-Z0-9]+(.)/g, (m, chr) => chr.toUpperCase());
+	async _import(spellText) {
+		return this._importSpell(spellText);
 	}
 
 	/**

--- a/system/src/apps/SpellImporterSD.mjs
+++ b/system/src/apps/SpellImporterSD.mjs
@@ -1,33 +1,38 @@
-export default class SpellImporter extends foundry.appv1.api.FormApplication {
+export default class SpellImporter extends foundry.applications.api.HandlebarsApplicationMixin(
+	foundry.applications.api.ApplicationV2
+) {
 	/**
 	 * Contains an importer function to import spell stat blocks
 	 */
 
-	/** @inheritdoc */
-	static get defaultOptions() {
-		return foundry.utils.mergeObject(super.defaultOptions, {
-			classes: ["spell-importer"],
-			width: 300,
-			resizable: false,
-		});
-	}
+	static DEFAULT_OPTIONS = {
+		id: "sd-spell-importer",
+		tag: "form",
+		window: {
+			resizable: true,
+			title: "SHADOWDARK.apps.spell-importer.title",
+			contentClasses: ["standard-form"],
+		},
+		position: {
+			width: 600,
+			height: 600,
+		},
+		form: {
+			handler: SpellImporter._onSubmitForm,
+			closeOnSubmit: false,
+		},
+	};
 
-	/** @inheritdoc */
-	get template() {
-		return "systems/shadowdark/templates/apps/spell-importer.hbs";
-	}
+	static PARTS = {
+		form: {
+			template: "systems/shadowdark/templates/apps/spell-importer.hbs",
+		},
+	};
 
-	/** @inheritdoc */
-	get title() {
-		const title = game.i18n.localize("SHADOWDARK.apps.spell-importer.title");
-		return `${title}`;
-	}
-
-	/** @inheritdoc */
-	async _updateObject(event, formData) {
-		event.preventDefault();
+	/** @override */
+	static async _onSubmitForm(event, form, formData) {
 		try {
-			let newSpell = await this._importSpell(formData.spellText);
+			let newSpell = await this._importSpell(formData.object.spellText);
 			ui.notifications.info(`Successfully Created: ${newSpell.name} [${newSpell._id}]`);
 			ui.sidebar.activateTab("items");
 
@@ -35,12 +40,6 @@ export default class SpellImporter extends foundry.appv1.api.FormApplication {
 		catch(error) {
 			ui.notifications.error(`Failed to fully parse the spell stat block. ${error}`);
 		}
-	}
-
-	/** @inheritdoc */
-	_onSubmit(event) {
-		event.preventDefault();
-		super._onSubmit(event);
 	}
 
 	_toCamelCase(str) {

--- a/system/templates/apps/item-importer.hbs
+++ b/system/templates/apps/item-importer.hbs
@@ -15,6 +15,6 @@
 		<button type="submit">{{localize "SHADOWDARK.apps.item-importer.import_button"}}</button>
 	</div>
 	<div class="flex1" style="display: flex; flex-direction: column;">
-		<textarea name="itemText" style="flex: 1; width: 100%; resize: none;"></textarea>
+		<textarea name="itemText" placeholder="{{localize "SHADOWDARK.apps.item-importer.placeholder"}}" style="flex: 1; width: 100%; resize: none;"></textarea>
 	</div>
 </div>

--- a/system/templates/apps/item-importer.hbs
+++ b/system/templates/apps/item-importer.hbs
@@ -1,25 +1,18 @@
-<form class="item-importer" autocomplete="off">
-	<section>
-		<div>
-			<p>{{localize "SHADOWDARK.apps.item-importer.instruction1"}}</p>
-			<hr />
-			<p>
-
-				{{localize "SHADOWDARK.apps.item-importer.instruction2a"}}<br>
-				<div style="border:1px solid black;background-color: lightgrey; font-size:0.65em;margin-left:50px;margin-right:50px;">
-					{{localize "SHADOWDARK.apps.item-importer.instruction2b"}}<br>
-					<i>{{localize "SHADOWDARK.apps.item-importer.instruction2c"}}</i><br>
-					{{localize "SHADOWDARK.apps.item-importer.instruction2d"}}
-				</div>
-			</p>
-			<textarea name="itemText" style="height:300px;"></textarea>
-			<hr />
-			<p>{{localize "SHADOWDARK.apps.item-importer.instruction3"}}</p>
-		</div>
-	</section>
-	<footer class="sheet-footer flexrow">
-		<button class="import">
-			{{localize "SHADOWDARK.apps.item-importer.import_button"}}
-		</button>
-	</footer>
-</form>
+<div class="flexrow" style="flex: 1; align-items: stretch; gap: 10px;">
+	<div style="width: 250px; flex: none; padding: 4px 0;">
+		<p>{{localize "SHADOWDARK.apps.item-importer.instruction1"}}</p>
+		<hr />
+		<p>{{localize "SHADOWDARK.apps.item-importer.instruction2a"}}</p>
+		<blockquote style="font-size: 0.85em; opacity: 0.8;">
+			{{localize "SHADOWDARK.apps.item-importer.instruction2b"}}<br>
+			<i>{{localize "SHADOWDARK.apps.item-importer.instruction2c"}}</i><br>
+			{{localize "SHADOWDARK.apps.item-importer.instruction2d"}}
+		</blockquote>
+		<hr />
+		<p>{{localize "SHADOWDARK.apps.item-importer.instruction3"}}</p>
+		<button type="submit">{{localize "SHADOWDARK.apps.item-importer.import_button"}}</button>
+	</div>
+	<div class="flex1" style="display: flex; flex-direction: column;">
+		<textarea name="itemText" style="flex: 1; width: 100%; resize: none;"></textarea>
+	</div>
+</div>

--- a/system/templates/apps/item-importer.hbs
+++ b/system/templates/apps/item-importer.hbs
@@ -1,5 +1,7 @@
 <div class="flexrow" style="flex: 1; align-items: stretch; gap: 10px;">
 	<div style="width: 250px; flex: none; padding: 4px 0;">
+		<h1 style="font-family: var(--font-header); font-size: 2.5em; text-align: center;">{{localize "SHADOWDARK.apps.item-importer.header"}}</h1>
+		<hr />
 		<p>{{localize "SHADOWDARK.apps.item-importer.instruction1"}}</p>
 		<hr />
 		<p>{{localize "SHADOWDARK.apps.item-importer.instruction2a"}}</p>

--- a/system/templates/apps/item-importer.hbs
+++ b/system/templates/apps/item-importer.hbs
@@ -16,5 +16,6 @@
 	</div>
 	<div class="flex1" style="display: flex; flex-direction: column;">
 		<textarea name="itemText" placeholder="{{localize "SHADOWDARK.apps.item-importer.placeholder"}}" style="flex: 1; width: 100%; resize: none;"></textarea>
+		<ul class="import-errors" hidden></ul>
 	</div>
 </div>

--- a/system/templates/apps/monster-importer.hbs
+++ b/system/templates/apps/monster-importer.hbs
@@ -1,29 +1,23 @@
-<form class="monster-importer" autocomplete="off">
-	<div class="flexrow" style="height:100%;">
-		<div style="width:250px;margin:5px;margin-right:10px;flex:none;">
-			<h1 style="font-family: 'Old Newspaper Font';font-size: 2.5em;text-align:center;">Monster Importer</h1>
-			<hr>
-			<p>{{localize "SHADOWDARK.apps.monster-importer.instruction1"}}</p>
-			<hr />
-			<p>{{localize "SHADOWDARK.apps.monster-importer.instruction2a"}}</p>
-
-				<div style="border:1px solid black;background-color: lightgrey; font-size:0.65em;margin-left:70px;margin-right:70px;">
-					{{localize "SHADOWDARK.apps.monster-importer.instruction2b"}}<br>
-					<i>{{localize "SHADOWDARK.apps.monster-importer.instruction2c"}}</i><br>
-					{{localize "SHADOWDARK.apps.monster-importer.instruction2d"}}<br>
-					{{localize "SHADOWDARK.apps.monster-importer.instruction2e"}} 1 <br>
-					<br>
-					{{localize "SHADOWDARK.apps.monster-importer.instruction2e"}} 2	<br>
-					<br>
-					{{localize "SHADOWDARK.apps.monster-importer.instruction2e"}} N
-				</div>
-
-			<hr />
-			3.
-			<button class="import">{{localize "SHADOWDARK.apps.monster-importer.import_button"}}</button>
-		</div>
-		<div class="flex1">
-			<textarea name="monsterText" style="height:100%;"></textarea>
-		</div>
+<div class="flexrow" style="flex: 1; align-items: stretch; gap: 10px;">
+	<div style="width: 250px; flex: none; padding: 4px 0;">
+		<p>{{localize "SHADOWDARK.apps.monster-importer.instruction1"}}</p>
+		<hr />
+		<p>{{localize "SHADOWDARK.apps.monster-importer.instruction2a"}}</p>
+		<blockquote style="font-size: 0.85em; opacity: 0.8;">
+			{{localize "SHADOWDARK.apps.monster-importer.instruction2b"}}<br>
+			<i>{{localize "SHADOWDARK.apps.monster-importer.instruction2c"}}</i><br>
+			{{localize "SHADOWDARK.apps.monster-importer.instruction2d"}}<br>
+			{{localize "SHADOWDARK.apps.monster-importer.instruction2e"}} 1<br>
+			<br>
+			{{localize "SHADOWDARK.apps.monster-importer.instruction2e"}} 2<br>
+			<br>
+			{{localize "SHADOWDARK.apps.monster-importer.instruction2e"}} N
+		</blockquote>
+		<hr />
+		<p>{{localize "SHADOWDARK.apps.monster-importer.instruction3"}}</p>
+		<button type="submit">{{localize "SHADOWDARK.apps.monster-importer.import_button"}}</button>
 	</div>
-</form>
+	<div class="flex1" style="display: flex; flex-direction: column;">
+		<textarea name="monsterText" style="flex: 1; width: 100%; resize: none;"></textarea>
+	</div>
+</div>

--- a/system/templates/apps/monster-importer.hbs
+++ b/system/templates/apps/monster-importer.hbs
@@ -1,5 +1,7 @@
 <div class="flexrow" style="flex: 1; align-items: stretch; gap: 10px;">
 	<div style="width: 250px; flex: none; padding: 4px 0;">
+		<h1 style="font-family: var(--font-header); font-size: 2.5em; text-align: center;">{{localize "SHADOWDARK.apps.monster-importer.header"}}</h1>
+		<hr />
 		<p>{{localize "SHADOWDARK.apps.monster-importer.instruction1"}}</p>
 		<hr />
 		<p>{{localize "SHADOWDARK.apps.monster-importer.instruction2a"}}</p>

--- a/system/templates/apps/monster-importer.hbs
+++ b/system/templates/apps/monster-importer.hbs
@@ -21,5 +21,6 @@
 	</div>
 	<div class="flex1" style="display: flex; flex-direction: column;">
 		<textarea name="monsterText" placeholder="{{localize "SHADOWDARK.apps.monster-importer.placeholder"}}" style="flex: 1; width: 100%; resize: none;"></textarea>
+		<ul class="import-errors" hidden></ul>
 	</div>
 </div>

--- a/system/templates/apps/monster-importer.hbs
+++ b/system/templates/apps/monster-importer.hbs
@@ -20,6 +20,6 @@
 		<button type="submit">{{localize "SHADOWDARK.apps.monster-importer.import_button"}}</button>
 	</div>
 	<div class="flex1" style="display: flex; flex-direction: column;">
-		<textarea name="monsterText" style="flex: 1; width: 100%; resize: none;"></textarea>
+		<textarea name="monsterText" placeholder="{{localize "SHADOWDARK.apps.monster-importer.placeholder"}}" style="flex: 1; width: 100%; resize: none;"></textarea>
 	</div>
 </div>

--- a/system/templates/apps/spell-importer.hbs
+++ b/system/templates/apps/spell-importer.hbs
@@ -1,27 +1,20 @@
-<form class="spell-importer" autocomplete="off">
-	<section>
-		<div>
-			<p>{{localize "SHADOWDARK.apps.spell-importer.instruction1"}}</p>
-			<hr />
-			<p>
-				
-				{{localize "SHADOWDARK.apps.spell-importer.instruction2a"}}<br>
-				<div style="border:1px solid black;background-color: lightgrey; font-size:0.65em;margin-left:50px;margin-right:50px;">
-					{{localize "SHADOWDARK.apps.spell-importer.instruction2b"}}<br>
-					<i>{{localize "SHADOWDARK.apps.spell-importer.instruction2c"}}</i><br>
-					<strong>{{localize "SHADOWDARK.apps.spell-importer.instruction2d"}}</strong><br>
-					<strong>{{localize "SHADOWDARK.apps.spell-importer.instruction2e"}}</strong><br>
-					{{localize "SHADOWDARK.apps.spell-importer.instruction2f"}}
-				</div>
-			</p>
-			<textarea name="spellText" style="height:300px;"></textarea>
-			<hr />
-			<p>{{localize "SHADOWDARK.apps.spell-importer.instruction3"}}</p>
-		</div>
-	</section>
-	<footer class="sheet-footer flexrow">
-		<button class="import">
-			{{localize "SHADOWDARK.apps.spell-importer.import_button"}}
-		</button>
-	</footer>
-</form>
+<div class="flexrow" style="flex: 1; align-items: stretch; gap: 10px;">
+	<div style="width: 250px; flex: none; padding: 4px 0;">
+		<p>{{localize "SHADOWDARK.apps.spell-importer.instruction1"}}</p>
+		<hr />
+		<p>{{localize "SHADOWDARK.apps.spell-importer.instruction2a"}}</p>
+		<blockquote style="font-size: 0.85em; opacity: 0.8;">
+			{{localize "SHADOWDARK.apps.spell-importer.instruction2b"}}<br>
+			<i>{{localize "SHADOWDARK.apps.spell-importer.instruction2c"}}</i><br>
+			<strong>{{localize "SHADOWDARK.apps.spell-importer.instruction2d"}}</strong><br>
+			<strong>{{localize "SHADOWDARK.apps.spell-importer.instruction2e"}}</strong><br>
+			{{localize "SHADOWDARK.apps.spell-importer.instruction2f"}}
+		</blockquote>
+		<hr />
+		<p>{{localize "SHADOWDARK.apps.spell-importer.instruction3"}}</p>
+		<button type="submit">{{localize "SHADOWDARK.apps.spell-importer.import_button"}}</button>
+	</div>
+	<div class="flex1" style="display: flex; flex-direction: column;">
+		<textarea name="spellText" style="flex: 1; width: 100%; resize: none;"></textarea>
+	</div>
+</div>

--- a/system/templates/apps/spell-importer.hbs
+++ b/system/templates/apps/spell-importer.hbs
@@ -1,5 +1,7 @@
 <div class="flexrow" style="flex: 1; align-items: stretch; gap: 10px;">
 	<div style="width: 250px; flex: none; padding: 4px 0;">
+		<h1 style="font-family: var(--font-header); font-size: 2.5em; text-align: center;">{{localize "SHADOWDARK.apps.spell-importer.header"}}</h1>
+		<hr />
 		<p>{{localize "SHADOWDARK.apps.spell-importer.instruction1"}}</p>
 		<hr />
 		<p>{{localize "SHADOWDARK.apps.spell-importer.instruction2a"}}</p>

--- a/system/templates/apps/spell-importer.hbs
+++ b/system/templates/apps/spell-importer.hbs
@@ -17,6 +17,6 @@
 		<button type="submit">{{localize "SHADOWDARK.apps.spell-importer.import_button"}}</button>
 	</div>
 	<div class="flex1" style="display: flex; flex-direction: column;">
-		<textarea name="spellText" style="flex: 1; width: 100%; resize: none;"></textarea>
+		<textarea name="spellText" placeholder="{{localize "SHADOWDARK.apps.spell-importer.placeholder"}}" style="flex: 1; width: 100%; resize: none;"></textarea>
 	</div>
 </div>

--- a/system/templates/apps/spell-importer.hbs
+++ b/system/templates/apps/spell-importer.hbs
@@ -18,5 +18,6 @@
 	</div>
 	<div class="flex1" style="display: flex; flex-direction: column;">
 		<textarea name="spellText" placeholder="{{localize "SHADOWDARK.apps.spell-importer.placeholder"}}" style="flex: 1; width: 100%; resize: none;"></textarea>
+		<ul class="import-errors" hidden></ul>
 	</div>
 </div>


### PR DESCRIPTION
This PR offers parsing improvements to the Monster Importer. The parser is now more robust, and a couple bugs are fixed.

Another PR will follow with improved error display. But to keep things moving, we can first improve the parsing.

If you have more things that you know don't work correctly, I can tackle them by adding a test and then fixing it.


## Notes

Note that this again introduces tests, the harness of which is from #1250. Without this it is very hard to stay consistent between fixes. I again urge you to merge those as well.

Another note: I added three statblocks as tests. Considering that we ship all monsters anyway, I do not see the harm in that.

## How to review:
 
This is built on top of the V2 importer (#1261). It is easiest to review per commit. I'll rebase once #1261 is merged.

  1. Split _parseMonster from _importMonster for testability
  2. Add parser tests (vitest setup + 13 tests)
  3. Fix multi-line feature parsing (state machine)
  4. Replace stat block regex with field-by-field tokenizer
  5. Fix attack data quality to match compendium format
  6. Default spell duration to "instant"

## Why not use shadowdark-parser?

One request from @Muttley was to check https://github.com/ashleytowner/shadowdark-parser/ and see if it could be used. Well, it can, but it does not bring many benefits in its current state:

1. Is also a regex based parser.
2. Does not throw more detailed errors.
3. Requires work to be able to hook into.
4. Does not return Foundry-compatible data that can flow into Actor. We must map that.
5. Is Typescript (although minor issue).
6. Increases dependency count.

## Bugs fixed

* Thief's "Backstab" feature was lost when pasted across multiple lines without blank line separator
* Missing stat fields (no ATK, no movement) crashed the importer instead of importing partial data
* Attacks showed empty parens "Mace ()". Physical attacks now default to Close range
* No critical hit data on imported attacks (nat 20 didn't trigger multiplier). Note: crit damage is broken system-wide, even for compendium monsters
* Trailing "+ " after damage display ("1d6 + ")
* Attack count and dice count stored as strings instead of numbers
* Spells without duration showed "-1 rounds" instead of "Instant"

## Bugs not yet fixed

I chose to not fix some things to keep it relatively simple.:

* No monsters from the compendium are able to roll a critical hit. They are flagged as critical, but they do not double their damage.
* The fixes for trailing + after damage display should actually be fixed in the sheet, but this would add even more files changed to the PR.
* The splitting of the text block into sections (title, description, stat block, specials) is still a monolithic (and this failure-prone) block of regex.
* NPC sheet should handle missing and undefined fields more defensively.
* Many number fields are stored as strings instead of numbers.

