### PR TITLE
Fix wands & Scrolls

### DIFF
--- a/system/src/macro.mjs
+++ b/system/src/macro.mjs
@@ -119,7 +119,7 @@ export default class ShadowdarkMacro {
 					})
 				);
 			}
-			actor.castSpell(items[0]._id, options);
+			actor.castSpell(items[0].uuid, options);
 		}
 
 		// Use class ability

--- a/system/src/models/items/ScrollSD.mjs
+++ b/system/src/models/items/ScrollSD.mjs
@@ -19,4 +19,8 @@ export default class ScrollSD extends PhysicalItemSD {
 	get isRollable() {
 		return true;
 	}
+
+	get isSpell() {
+		return true;
+	}
 }

--- a/system/src/models/items/WandSD.mjs
+++ b/system/src/models/items/WandSD.mjs
@@ -18,4 +18,8 @@ export default class WandSD extends PhysicalItemSD {
 	get isRollable() {
 		return true;
 	}
+
+	get isSpell() {
+		return true;
+	}
 }

--- a/system/templates/actors/player/spells.hbs
+++ b/system/templates/actors/player/spells.hbs
@@ -103,7 +103,7 @@
 								<a
 									data-action="focus-spell"
 									data-item-id="{{item._id}}"
-									data-item-uuid="{{spell.uuid}}"
+									data-item-uuid="{{item.uuid}}"
 									data-tooltip="{{localize 'SHADOWDARK.sheet.player.tooltip.focus_on_spell'}}"
 								>
 									<i class="fa-solid fa-brain"></i>
@@ -113,7 +113,7 @@
 								<a
 									data-action="cast-spell"
 									data-item-id="{{item._id}}"
-									data-item-uuid="{{spell.uuid}}"
+									data-item-uuid="{{item.uuid}}"
 									data-tooltip="{{localize 'SHADOWDARK.sheet.player.tooltip.use_wand'}}"
 								>
 									<i class="fa-solid fa-wand-magic-sparkles"></i>
@@ -123,7 +123,7 @@
 							<a
 								data-action="toggle-lost"
 								data-item-id="{{item._id}}"
-								data-item-uuid="{{spell.uuid}}"
+								data-item-uuid="{{item.uuid}}"
 								data-tooltip="{{localize "SHADOWDARK.sheet.player.toggle_spell_lost"}}"
 							>
 								{{#if item.system.lost}}
@@ -152,7 +152,7 @@
 						<div class="item-image" style="background-image: url({{item.system.spellImg}})">
 							<i class="fas fa-comment fa-lg"></i>
 						</div>
-						<a class="item-name {{#if spell.system.lost}}strike-through{{/if}}" data-action="show-details">
+						<a class="item-name {{#if item.system.lost}}strike-through{{/if}}" data-action="show-details">
 							{{item.system.spellName}}
 						</a>
 						<div class="duration">
@@ -166,7 +166,7 @@
 									<a
 										data-action="focus-spell"
 										data-item-id="{{item._id}}"
-										data-item-uuid="{{spell.uuid}}"
+										data-item-uuid="{{item.uuid}}"
 										data-tooltip="{{localize 'SHADOWDARK.sheet.player.tooltip.focus_on_spell'}}"
 									>
 										<i class="fa-solid fa-brain"></i>
@@ -175,7 +175,7 @@
 								<a
 									data-action="cast-spell"
 									data-item-id="{{item._id}}"
-									data-item-uuid="{{spell.uuid}}"
+									data-item-uuid="{{item.uuid}}"
 									data-tooltip="{{localize 'SHADOWDARK.sheet.player.tooltip.use_scroll'}}"
 								>
 									<i class="fa-solid fa-scroll"></i>
@@ -184,7 +184,7 @@
 									<a
 										data-action="learn-spell"
 										data-item-id="{{item._id}}"
-										data-item-uuid="{{spell.uuid}}"
+										data-item-uuid="{{item.uuid}}"
 										data-tooltip="{{localize 'SHADOWDARK.sheet.player.tooltip.learn_spell'}}"
 									>
 										<i class="fa-solid fa-graduation-cap"></i>


### PR DESCRIPTION
This PR fixes #1269 

Basically there were 2 issues:

1. When wands/scrolls were added to the character sheet, the full UUID wasn't being included because the handlebars template was referencing `spell.uuid` instead of `item.uuid`
2. Once I got them registered properly, they still weren't being detected as spells because the check was against `item.system.isSpell` which wasn't set on Scrolls or Wands. 