### PR TITLE
Update .this items to transfer:true

### DIFF
--- a/data/packs/magic-items.db/attack_damage_bonus__78SoFRRmEjEMdPIT.json
+++ b/data/packs/magic-items.db/attack_damage_bonus__78SoFRRmEjEMdPIT.json
@@ -30,6 +30,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/attack_damage_bonus__FqtIDxjhOFDvkQFn.json
+++ b/data/packs/magic-items.db/attack_damage_bonus__FqtIDxjhOFDvkQFn.json
@@ -30,6 +30,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/attack_damage_bonus__JAfTcoh8jcncSGJM.json
+++ b/data/packs/magic-items.db/attack_damage_bonus__JAfTcoh8jcncSGJM.json
@@ -30,6 +30,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/attack_roll_bonus__4QneUXW9pG2CMpKS.json
+++ b/data/packs/magic-items.db/attack_roll_bonus__4QneUXW9pG2CMpKS.json
@@ -30,6 +30,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/attack_roll_bonus__9qMTrleWtCMKO3Xl.json
+++ b/data/packs/magic-items.db/attack_roll_bonus__9qMTrleWtCMKO3Xl.json
@@ -30,6 +30,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/attack_roll_bonus__HhILvM8lD0Nby5gq.json
+++ b/data/packs/magic-items.db/attack_roll_bonus__HhILvM8lD0Nby5gq.json
@@ -30,6 +30,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/critical_multiplier__2NdFJHTHy28UaTCh.json
+++ b/data/packs/magic-items.db/critical_multiplier__2NdFJHTHy28UaTCh.json
@@ -30,6 +30,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__5k96o8ZHd5spUP9K.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__5k96o8ZHd5spUP9K.json
@@ -24,6 +24,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__97RtiQtpwhaO7qNb.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__97RtiQtpwhaO7qNb.json
@@ -24,6 +24,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__OZskI153kjpkFy09.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__OZskI153kjpkFy09.json
@@ -30,6 +30,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__OlbaGSPCczzedFMQ.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__OlbaGSPCczzedFMQ.json
@@ -24,6 +24,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__dbXv9ddp6TR15AFk.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__dbXv9ddp6TR15AFk.json
@@ -26,6 +26,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__doAgFd0Q4WixkRrC.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__doAgFd0Q4WixkRrC.json
@@ -26,6 +26,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__8DPxbb4aUGGtrGlG.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__8DPxbb4aUGGtrGlG.json
@@ -26,6 +26,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__CFbdBIST0hT7qCyu.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__CFbdBIST0hT7qCyu.json
@@ -30,6 +30,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__Z4UACwRTky38K63x.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__Z4UACwRTky38K63x.json
@@ -26,6 +26,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__nYIEUngawHOWjKLV.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__nYIEUngawHOWjKLV.json
@@ -24,6 +24,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__pOdV4x1mBsF4ZJmg.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__pOdV4x1mBsF4ZJmg.json
@@ -24,6 +24,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__yMBdo0WUxtzRzji9.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__yMBdo0WUxtzRzji9.json
@@ -24,6 +24,6 @@
 	"system": {
 	},
 	"tint": "#ffffff",
-	"transfer": false,
+	"transfer": true,
 	"type": "base"
 }


### PR DESCRIPTION
Addresses #1262.

# Magic Items with Updated Active Effects

The following magic items had Active Effects updated from `transfer: false` to `transfer: true`
as part of the v4 `.this` key migration fix.

| Item | Effect Files Updated |
|------|----------------------|
| Asterion | `weapon_attack_roll_bonus__Z4UACwRTky38K63x.json`, `weapon_attack_damage_bonus__OZskI153kjpkFy09.json` |
| Bloodlust | `weapon_attack_roll_bonus__nYIEUngawHOWjKLV.json`, `weapon_attack_damage_bonus__97RtiQtpwhaO7qNb.json`, `critical_multiplier__2NdFJHTHy28UaTCh.json` |
| Memnon's Blazing Javelin (Completed Set) | `weapon_attack_roll_bonus__8DPxbb4aUGGtrGlG.json`, `weapon_attack_damage_bonus__doAgFd0Q4WixkRrC.json` |
| Memnon's Discordant Blade (Completed Set) | `weapon_attack_roll_bonus__Z4UACwRTky38K63x.json`, `weapon_attack_damage_bonus__dbXv9ddp6TR15AFk.json` |
| Shortsword of the Thief | `attack_roll_bonus__4QneUXW9pG2CMpKS.json`, `attack_damage_bonus__JAfTcoh8jcncSGJM.json` |
| Staff of Healing | `attack_roll_bonus__HhILvM8lD0Nby5gq.json`, `attack_damage_bonus__FqtIDxjhOFDvkQFn.json` |
| Sword of the Ancients | `attack_roll_bonus__9qMTrleWtCMKO3Xl.json`, `attack_damage_bonus__78SoFRRmEjEMdPIT.json` |
| Vigilant | `weapon_attack_roll_bonus__yMBdo0WUxtzRzji9.json`, `weapon_attack_damage_bonus__OlbaGSPCczzedFMQ.json` |
| Warhammer of the Dwarf Lords | `weapon_attack_roll_bonus__pOdV4x1mBsF4ZJmg.json`, `weapon_attack_damage_bonus__5k96o8ZHd5spUP9K.json` |
| Warhammer of the Dwarf Lords (CFbdBIST0hT7qCyu) | `weapon_attack_roll_bonus__CFbdBIST0hT7qCyu.json` |
