### PR TITLE
fix spell check logic and typo

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -103,6 +103,7 @@ SHADOWDARK.apps.level-up.or_boons: or Boons
 SHADOWDARK.apps.level-up.prompt: Not all required selections have been made. Continue with level up anyways?
 SHADOWDARK.apps.level-up.roll_boon: Roll Boon
 SHADOWDARK.apps.level-up.roll_talent: Roll Talent
+SHADOWDARK.apps.level-up.spell_tier_out_of_range: Spell tier out of range
 SHADOWDARK.apps.level-up.title: Leveling Up
 SHADOWDARK.apps.monster-importer.header: Monster Importer
 SHADOWDARK.apps.monster-importer.import_button: Import Monster

--- a/system/src/apps/LevelUpSD.mjs
+++ b/system/src/apps/LevelUpSD.mjs
@@ -298,14 +298,17 @@ export default class LevelUpSD extends foundry.appv1.api.FormApplication {
 
 	_onDropSpell(spellObj) {
 		let spellTier = spellObj.system.tier;
-		// Check to see if the spell is out of bounds
-		if (1 > spellTier > 5) {
-			ui.notifictions.error("Spell tier out of range");
-			return;
-		}
-		// add spell if there is room in that tier
-		if (this.data.spells[spellTier].objects.length < this.data.spells[spellTier].max) {
+		// Add spell if there is room in tier and tier is between 1 and 5
+		if ((spellTier >= 1 && spellTier <= 5)
+				&& (this.data.spells[spellTier].objects.length < this.data.spells[spellTier].max)
+		) {
 			this.data.spells[spellTier].objects.push(spellObj);
+		}
+		else {
+			ui.notifications.error(
+				game.i18n.localize("SHADOWDARK.apps.level-up.spell_tier_out_of_range")
+			);
+			return;
 		}
 		this.render();
 	}


### PR DESCRIPTION
I noticed `(1 > spellTier > 5)` scrolling this file and was curious if it was some eldritch JS syntax, since I'd never seen it before. When I looked it up, the explanation said it was flawed, and the debugger confirmed. (Turns out to be valid in Python.) The original intention was to check for spell tiers less than 1 and greater than 5, but it never hit, so the notification never displayed. 

A notification would also be helpful to show if the user selected a tier that existed but was out of bounds for the current selection, but this silently returned.

So I:
1. Fixed the one check and moved the second up.
2. Moved the notification into an `else` block.
3. Corrected the `notifications` property typo.
4. Added the lang string.