### PR TITLE
#effect-change-value input box handler not looking for `effectUuid` on <li>

### DIFF
--- a/system/src/sheets/ItemSheetSD.mjs
+++ b/system/src/sheets/ItemSheetSD.mjs
@@ -761,10 +761,10 @@ export default class ItemSheetSD extends foundry.appv1.sheets.ItemSheet {
 
 	async _onEffectChangeValue(event) {
 		const li = event.target.closest("li");
-		const effectId = li.dataset.effectId;
-		const effect = this.item.effects.get(effectId);
+		const effectUuid = li.dataset.effectUuid;
+		const effect = this.item.effects.get(foundry.utils.parseUuid(effectUuid).id);
 
-		console.log(`Modifying talent ${event.target.name} (${effectId}) with value ${event.target.value}`);
+		console.log(`Modifying talent ${event.target.name} (${effectUuid}) with value ${event.target.value}`);
 		const updates = {};
 
 		const value = (isNaN(parseInt(event.target.value, 10)))


### PR DESCRIPTION
`_onEffectChangeValue` currently looks for `effectId` on the nearest `<li>`, should be `effectUuid`. Prevents syncing of this:

<img width="650" height="271" alt="input" src="https://github.com/user-attachments/assets/cbad6218-138d-469d-8849-cd8917ec31c2" />

with this:

<img width="528" height="214" alt="effect-sheet" src="https://github.com/user-attachments/assets/ada044aa-0b20-4f4d-9104-a6afb510134e" />
