### PR TITLE
Apply Active Effects to items when importing

### DIFF
--- a/system/src/apps/ItemImporterSD.mjs
+++ b/system/src/apps/ItemImporterSD.mjs
@@ -27,6 +27,50 @@ export default class ItemImporterSD extends ImporterSD {
 	static TRAIT_KEYWORDS = ["Bonus", "Benefit", "Curse", "Personality"];
 
 	/**
+	 * Patterns that map trait text to predefined Active Effects.
+	 * Each entry has a regex pattern, a predefined effect key, and
+	 * optionally a fixed value (otherwise extracted from capture group 1).
+	 */
+	static BENEFIT_EFFECT_PATTERNS = [
+		{
+			pattern: /\+(\d+)\s+bonus\s+to\s+(?:your\s+)?armor\s+class/i,
+			effect: "acBonus",
+		},
+		{
+			pattern: /\+(\d+)\s+damage\s+with\s+ranged/i,
+			effect: "rangedDamageBonus",
+		},
+		{
+			pattern: /deal\s+\+(\d+)\s+damage.*melee|melee.*\+(\d+)\s+damage/i,
+			effect: "meleeDamageBonus",
+		},
+		{
+			pattern: /Strength\s+stat\s+becomes\s+18/i,
+			effect: "permanentAbilityStr", value: 18,
+		},
+		{
+			pattern: /Dexterity\s+stat\s+becomes\s+18/i,
+			effect: "permanentAbilityDex", value: 18,
+		},
+		{
+			pattern: /Constitution\s+stat\s+becomes\s+18/i,
+			effect: "permanentAbilityCon", value: 18,
+		},
+		{
+			pattern: /Intelligence\s+stat\s+becomes\s+18/i,
+			effect: "permanentAbilityInt", value: 18,
+		},
+		{
+			pattern: /Wisdom\s+stat\s+becomes\s+18/i,
+			effect: "permanentAbilityWis", value: 18,
+		},
+		{
+			pattern: /Charisma\s+stat\s+becomes\s+18/i,
+			effect: "permanentAbilityCha", value: 18,
+		},
+	];
+
+	/**
 	 * Tests if a line starts a trait section (case-insensitive).
 	 * @param {string} line
 	 * @returns {boolean}
@@ -136,6 +180,27 @@ export default class ItemImporterSD extends ImporterSD {
 	}
 
 	/**
+	 * Scans trait text against BENEFIT_EFFECT_PATTERNS and returns
+	 * matched predefined effects with their values.
+	 * @param {{ type: string, text: string }[]} traits
+	 * @returns {{ effect: string, value: number }[]}
+	 */
+	_matchBenefitEffects(traits) {
+		const matched = [];
+		for (const trait of traits) {
+			for (const entry of ItemImporterSD.BENEFIT_EFFECT_PATTERNS) {
+				const match = trait.text.match(entry.pattern);
+				if (match) {
+					const value = entry.value
+						?? parseInt(match[1] ?? match[2], 10);
+					matched.push({ effect: entry.effect, value });
+				}
+			}
+		}
+		return matched;
+	}
+
+	/**
 	 * Builds HTML description from flavor text and traits.
 	 * @param {string} flavorText
 	 * @param {{ type: string, text: string }[]} traits
@@ -156,7 +221,7 @@ export default class ItemImporterSD extends ImporterSD {
 	 * Parses item text into structured data without creating any documents.
 	 * Collects errors from all parsing stages and throws once with the full list.
 	 * @param {string} itemText - Raw pasted item text
-	 * @returns {object} { name, flavorText, traits, bonusHint, description }
+	 * @returns {object} { name, flavorText, traits, bonusHint, benefitEffects, description }
 	 * @throws {Error} With .details array listing all parse failures
 	 */
 	_parseItem(itemText) {
@@ -182,6 +247,7 @@ export default class ItemImporterSD extends ImporterSD {
 		const flavorText = this._parseFlavorText(lines);
 		const traits = this._parseTraits(lines);
 		const bonusHint = this._parseBonusHint(traits);
+		const benefitEffects = this._matchBenefitEffects(traits);
 		const description = this._buildDescription(flavorText, traits);
 
 		if (errors.length > 0) {
@@ -190,7 +256,7 @@ export default class ItemImporterSD extends ImporterSD {
 			throw error;
 		}
 
-		return { name, flavorText, traits, bonusHint, description };
+		return { name, flavorText, traits, bonusHint, benefitEffects, description };
 	}
 
 	/** @override */
@@ -283,7 +349,7 @@ export default class ItemImporterSD extends ImporterSD {
 	 * @returns {object} { itemObj, effects }
 	 */
 	async _resolveItemType(parsed) {
-		const { name, description, bonusHint } = parsed;
+		const { name, description, bonusHint, benefitEffects } = parsed;
 		const effects = [];
 
 		// Bonus trait with +N: check compendium weapons, then armor
@@ -303,6 +369,12 @@ export default class ItemImporterSD extends ImporterSD {
 						"weaponDamageBonus", bonusHint.value
 					)
 				);
+				// Weapon may also have benefit effects (e.g. Armor of the Oni)
+				for (const be of benefitEffects) {
+					effects.push(
+						this._buildPredefinedEffect(be.effect, be.value)
+					);
+				}
 				return {
 					itemObj: this._buildWeaponObj(
 						name, description, bonusHint, matchedWeapon
@@ -318,6 +390,11 @@ export default class ItemImporterSD extends ImporterSD {
 					.includes(piece.name.toLowerCase())
 			);
 			if (matchedArmor) {
+				for (const be of benefitEffects) {
+					effects.push(
+						this._buildPredefinedEffect(be.effect, be.value)
+					);
+				}
 				return {
 					itemObj: this._buildArmorObj(
 						name, description, bonusHint, matchedArmor
@@ -333,6 +410,39 @@ export default class ItemImporterSD extends ImporterSD {
 				+ " or armor was found in the compendium.",
 			];
 			throw error;
+		}
+
+		// Benefit-based AC bonus: create as Armor with base 0
+		const acEffect = benefitEffects.find(
+			be => be.effect === "acBonus"
+		);
+		if (acEffect) {
+			for (const be of benefitEffects) {
+				effects.push(
+					this._buildPredefinedEffect(be.effect, be.value)
+				);
+			}
+			return {
+				itemObj: {
+					name,
+					type: "Armor",
+					system: {
+						ac: { attribute: "dex", base: 0, modifier: acEffect.value },
+						baseArmor: "",
+						properties: [],
+						description,
+						magicItem: true,
+					},
+				},
+				effects,
+			};
+		}
+
+		// Build benefit effects for Basic items too
+		for (const be of benefitEffects) {
+			effects.push(
+				this._buildPredefinedEffect(be.effect, be.value)
+			);
 		}
 
 		// Default: Basic magic item

--- a/system/src/apps/ItemImporterSD.mjs
+++ b/system/src/apps/ItemImporterSD.mjs
@@ -33,40 +33,32 @@ export default class ItemImporterSD extends ImporterSD {
 	 */
 	static BENEFIT_EFFECT_PATTERNS = [
 		{
-			pattern: /\+(\d+)\s+bonus\s+to\s+(?:your\s+)?armor\s+class/i,
+			pattern: /\+(?<value>\d+)\s+bonus\s+to\s+(?:your\s+)?armor\s+class/i,
 			effect: "acBonus",
 		},
 		{
-			pattern: /\+(\d+)\s+damage\s+with\s+ranged/i,
-			effect: "rangedDamageBonus",
+			pattern: /Strength\s+stat\s+becomes\s+(?<value>\d+)/i,
+			effect: "permanentAbilityStr",
 		},
 		{
-			pattern: /deal\s+\+(\d+)\s+damage.*melee|melee.*\+(\d+)\s+damage/i,
-			effect: "meleeDamageBonus",
+			pattern: /Dexterity\s+stat\s+becomes\s+(?<value>\d+)/i,
+			effect: "permanentAbilityDex",
 		},
 		{
-			pattern: /Strength\s+stat\s+becomes\s+18/i,
-			effect: "permanentAbilityStr", value: 18,
+			pattern: /Constitution\s+stat\s+becomes\s+(?<value>\d+)/i,
+			effect: "permanentAbilityCon",
 		},
 		{
-			pattern: /Dexterity\s+stat\s+becomes\s+18/i,
-			effect: "permanentAbilityDex", value: 18,
+			pattern: /Intelligence\s+stat\s+becomes\s+(?<value>\d+)/i,
+			effect: "permanentAbilityInt",
 		},
 		{
-			pattern: /Constitution\s+stat\s+becomes\s+18/i,
-			effect: "permanentAbilityCon", value: 18,
+			pattern: /Wisdom\s+stat\s+becomes\s+(?<value>\d+)/i,
+			effect: "permanentAbilityWis",
 		},
 		{
-			pattern: /Intelligence\s+stat\s+becomes\s+18/i,
-			effect: "permanentAbilityInt", value: 18,
-		},
-		{
-			pattern: /Wisdom\s+stat\s+becomes\s+18/i,
-			effect: "permanentAbilityWis", value: 18,
-		},
-		{
-			pattern: /Charisma\s+stat\s+becomes\s+18/i,
-			effect: "permanentAbilityCha", value: 18,
+			pattern: /Charisma\s+stat\s+becomes\s+(?<value>\d+)/i,
+			effect: "permanentAbilityCha",
 		},
 	];
 
@@ -175,7 +167,6 @@ export default class ItemImporterSD extends ImporterSD {
 		return {
 			value: parseInt(match[1], 10),
 			text: bonus.text,
-			isMithral: /mithral/i.test(bonus.text),
 		};
 	}
 
@@ -191,8 +182,7 @@ export default class ItemImporterSD extends ImporterSD {
 			for (const entry of ItemImporterSD.BENEFIT_EFFECT_PATTERNS) {
 				const match = trait.text.match(entry.pattern);
 				if (match) {
-					const value = entry.value
-						?? parseInt(match[1] ?? match[2], 10);
+					const value = parseInt(match.groups.value, 10);
 					matched.push({ effect: entry.effect, value });
 				}
 			}
@@ -316,13 +306,15 @@ export default class ItemImporterSD extends ImporterSD {
 
 	/**
 	 * Builds a Foundry Armor item object from parsed data and a base armor.
+	 * Mithral items have their armor properties stripped.
 	 * @param {string} name - Item name
 	 * @param {string} description - HTML description
-	 * @param {object} bonusHint - { value, text, isMithral }
+	 * @param {object} bonusHint - { value, text }
 	 * @param {object} baseArmor - Base armor from compendium
 	 * @returns {object}
 	 */
 	_buildArmorObj(name, description, bonusHint, baseArmor) {
+		const isMithral = /mithral/i.test(bonusHint.text);
 		return {
 			...baseArmor,
 			name,
@@ -333,7 +325,7 @@ export default class ItemImporterSD extends ImporterSD {
 					...baseArmor.system.ac,
 					modifier: bonusHint.value,
 				},
-				properties: bonusHint.isMithral
+				properties: isMithral
 					? [] : baseArmor.system.properties,
 				description,
 				magicItem: true,

--- a/system/src/apps/ItemImporterSD.mjs
+++ b/system/src/apps/ItemImporterSD.mjs
@@ -404,12 +404,15 @@ export default class ItemImporterSD extends ImporterSD {
 			throw error;
 		}
 
-		// Benefit-based AC bonus: create as Armor with base 0
+		// Benefit-based AC bonus: create as Armor with base 0.
+		// Use modifier field only for static bonuses — no AE, to avoid doubling.
+		// No ability attribute: bonus armor items don't add an ability mod.
 		const acEffect = benefitEffects.find(
 			be => be.effect === "acBonus"
 		);
 		if (acEffect) {
 			for (const be of benefitEffects) {
+				if (be.effect === "acBonus") continue;
 				effects.push(
 					this._buildPredefinedEffect(be.effect, be.value)
 				);
@@ -419,7 +422,7 @@ export default class ItemImporterSD extends ImporterSD {
 					name,
 					type: "Armor",
 					system: {
-						ac: { attribute: "dex", base: 0, modifier: acEffect.value },
+						ac: { attribute: "", base: 0, modifier: acEffect.value },
 						baseArmor: "",
 						properties: [],
 						description,

--- a/system/src/apps/ItemImporterSD.mjs
+++ b/system/src/apps/ItemImporterSD.mjs
@@ -208,8 +208,19 @@ export default class ItemImporterSD extends ImporterSD {
 	}
 
 	/**
+	 * Normalises OpenShadowdark format by uppercasing the first line so the
+	 * CRB parser can detect it as an all-caps name.
+	 * @param {string[]} lines - Mutated in place
+	 */
+	_normalizeOpenShadowdark(lines) {
+		lines[0] = lines[0].toUpperCase();
+	}
+
+	/**
 	 * Parses item text into structured data without creating any documents.
-	 * Collects errors from all parsing stages and throws once with the full list.
+	 * Supports CRB format (all-caps name, no blank lines) and OpenShadowdark
+	 * format (title-case name, blank line after title). Collects errors from
+	 * all parsing stages and throws once with the full list.
 	 * @param {string} itemText - Raw pasted item text
 	 * @returns {object} { name, flavorText, traits, bonusHint, benefitEffects, description }
 	 * @throws {Error} With .details array listing all parse failures
@@ -225,6 +236,15 @@ export default class ItemImporterSD extends ImporterSD {
 			const error = new Error("Import validation failed");
 			error.details = ["Input is empty"];
 			throw error;
+		}
+
+		// OpenShadowdark format: title-case first line followed by a blank line.
+		// Normalise by uppercasing the first line so the CRB parser handles the rest.
+		const isOpenShadowdark = /[a-z]/.test(lines[0])
+			&& /^[^\n]*\n\s*\n/.test(dehyphenated.trimStart());
+
+		if (isOpenShadowdark) {
+			this._normalizeOpenShadowdark(lines);
 		}
 
 		const errors = [];


### PR DESCRIPTION
I implemented the Active Effects parsing on top of #1288, so this PR needs to go in after that one is merged.

While this PR adds support for magic weapons, I decided not to implement to hit and damage bonuses from otherwise basic items like Bracers of Archery. The wording is finicky, and there is only one example for melee weapons (Armor of the Oni) and ranged attacks (said bracers). I expect third party sources to be very liberal with their wording in these. I think it would be better to offer a better Effects dialogue.

I've learned some things about the importers while coding this. I think the MonsterImporter can be improved. This importer has a nice parse -> resolve type -> import flow. That can be applied to the MonsterImporter as well. Currently that one conflates a lot of things.

## Supported items from Core

*33 out of 94 items* get enriched import (type, effects, or both). The rest import cleanly as Basic with full description.

| Category | Count | Items |
  |---|---|---|
  | Weapon (Bonus +N weapon) | 17 | Blade of Vengeance, Dagger of the Goblin Hero, Greataxe of the Horde, Longbow of the Elven Kings, Memnon's Blazing Javelin, Memnon's Discordant Blade, Necrotic Mace of Withering, Obsidian Witchknife, Scimitar of the Ash Moon, Shortsword of the Thief, Silver Mace of Wrath, Staff of Healing, Staff of Ord, Staff of the Cobra, Sword of the Ancients, Trident of the Seas, Warhammer of the Dwarf Lords |
  | Armor (Bonus +N armor) | 8 | Armor of Saint Terragnis, Armor of the Oni, Moonwrought Chainmail, Nightcloak Armor, Ophidian Armor, Shield of the Crusader, Shield of the Lion, Wraith Chain |
  | AC bonus (Benefit) | 2 | Bracers of Defense, Horned Helm of Ramlaat |
  | Stat becomes 18 (Benefit) | 6 | Amulet of Vitality, Circlet of Wisdom, Gauntlets of Might, Gloves of Agility, Hat of Intellect, Necklace of Charm |
  | Basic (narrative only) | 61 | Everything else |

