### PR TITLE
Update strings to Active Effect where applicable

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -25,6 +25,8 @@ SHADOWDARK.ancestry.nametable.tooltip.weight: Affects the chance of rolling when
 SHADOWDARK.ancestry.talents.label: Ancestry Talents
 SHADOWDARK.ancestry.talents.prompt: Select Talent...
 SHADOWDARK.app.active_effects.title: Active Effects
+SHADOWDARK.app.active_effects.singular: Active Effect
+SHADOWDARK.app.active_effects.new_active_effect: New Active Effect
 SHADOWDARK.app.gem_bag.sell_all: Sell All Gems
 SHADOWDARK.app.gem_bag.title: Gem Bag
 SHADOWDARK.app.gem_bag.tooltip.sell_gem: Sell Gem
@@ -447,7 +449,7 @@ SHADOWDARK.item.effect.lightSource.lightSpellNear: Light
 SHADOWDARK.item.effect.lightSource.lightSuppression: Light Suppression
 SHADOWDARK.item.effect.lightSource.purpleGlow: Purple Glow
 SHADOWDARK.item.effect.lightSource.torch: Torch
-SHADOWDARK.item.effect.pre-defined.title: Pre-defined Effects
+SHADOWDARK.item.effect.pre-defined.title: Pre-defined Active Effects
 SHADOWDARK.item.effect.predefined_effect.abilityImprovement: Ability Score Improvement
 SHADOWDARK.item.effect.predefined_effect.abilityImprovementCha: Ability Score Improvement (Cha)
 SHADOWDARK.item.effect.predefined_effect.abilityImprovementCon: Ability Score Improvement (Con)
@@ -756,11 +758,11 @@ SHADOWDARK.sheet.class.item: Shadowdark Item Sheet
 SHADOWDARK.sheet.class.npc: Shadowdark NPC Sheet
 SHADOWDARK.sheet.class.player: Shadowdark Player Sheet
 SHADOWDARK.sheet.general.active_effects.create_effect.title: Create Effect
-SHADOWDARK.sheet.general.active_effects.delete_effect.tooltip: Delete Effect
+SHADOWDARK.sheet.general.active_effects.delete_effect.tooltip: Delete Active Effect
 SHADOWDARK.sheet.general.active_effects.duration.title: Duration
-SHADOWDARK.sheet.general.active_effects.edit_effect.tooltip: Edit Effect
+SHADOWDARK.sheet.general.active_effects.edit_effect.tooltip: Edit Active Effect
 SHADOWDARK.sheet.general.active_effects.source.title: Source
-SHADOWDARK.sheet.general.active_effects.toggle_effect.tooltip: Toggle Effect
+SHADOWDARK.sheet.general.active_effects.toggle_effect.tooltip: Toggle Active Effect
 SHADOWDARK.sheet.general.active_effects.toggle_situational.tooltip: Toggle Situational
 SHADOWDARK.sheet.general.add: Add
 SHADOWDARK.sheet.general.effects_and_conditions.title: Effects and Conditions

--- a/system/src/system/ActiveEffectsSD.mjs
+++ b/system/src/system/ActiveEffectsSD.mjs
@@ -307,8 +307,8 @@ export default class ActiveEffectsSD {
 				const docs = await owner.createEmbeddedDocuments("ActiveEffect", [{
 					disabled: li.dataset.effectType === "inactive",
 					img: "icons/commodities/tech/cog-steel-grey.webp",
-					label: "New Effect",
-					name: "New Effect",
+					label: game.i18n.localize("SHADOWDARK.app.active_effects.new_active_effect"),
+					name: game.i18n.localize("SHADOWDARK.app.active_effects.new_active_effect"),
 					origin: owner.uuid,
 				}]);
 

--- a/system/templates/actors/_partials/effects-tab/active-effect.hbs
+++ b/system/templates/actors/_partials/effects-tab/active-effect.hbs
@@ -26,7 +26,7 @@
 		<a
 			class="effect-control"
 			data-action="toggle"
-			title="{{localize 'SHADOWDARK.sheet.general.active_effects.toggle_effect.tooltip'}}"
+			data-tooltip="{{localize 'SHADOWDARK.sheet.general.active_effects.toggle_effect.tooltip'}}"
 		>
 			<i
 				{{#if effect.disabled}}

--- a/system/templates/actors/_partials/effects-tab/active-effects.hbs
+++ b/system/templates/actors/_partials/effects-tab/active-effects.hbs
@@ -15,7 +15,7 @@
 			</a>
 
 			<h3 class="effect-name">
-				{{localize "SHADOWDARK.item.effect.category.effect"}}
+				{{localize "SHADOWDARK.app.active_effects.singular"}}
 			</h3>
 
 			<h3 class="effect-name">

--- a/system/templates/items/_partials/effects/active-effects-list.hbs
+++ b/system/templates/items/_partials/effects/active-effects-list.hbs
@@ -1,5 +1,5 @@
 <div class="SD-banner">
-	{{localize "SHADOWDARK.sheet.item.tab.effects"}}
+	{{localize "SHADOWDARK.app.active_effects.title"}}
 </div>
 
 <ol class="SD-list">
@@ -12,7 +12,7 @@
 			<i class="fa-solid fa-square-plus"></i>
 		</a>
 		<div class="item-name">
-			{{localize "SHADOWDARK.item.effect.category.effect"}}
+			{{localize "SHADOWDARK.app.active_effects.singular"}}
 		</div>
 		<div class="item-name" style="flex:2;">
 			{{localize "SHADOWDARK.effect.header.changes"}}


### PR DESCRIPTION
This PR updates all strings in the Active Effects panel to include the word _Active_ in order to clearly distinguish them from the Effect _Item_. 

It also adds a `data-tooltip` to the Toggle Active Effect icon to make it consistent with the other icons.

<img width="553" height="170" alt="ae-ui" src="https://github.com/user-attachments/assets/00884667-7251-484f-a78b-37048c8db8b6" />
<img width="663" height="344" alt="effect-item" src="https://github.com/user-attachments/assets/b4c2bd44-49b5-46f0-a7d5-d05d8b372132" />
<img width="625" height="461" alt="character-sheet" src="https://github.com/user-attachments/assets/e5cbe952-5e52-40dc-ad2c-f57877d0831f" />
