### PR TITLE
Localize damage/healing apply tooltips

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+# v4.0.5
+
+## Bugfixes
+- [#1333] Fix apply to token/target tooltips
+
+---
+
 # v4.0.4
 
 ## Bugfixes

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -172,6 +172,7 @@ SHADOWDARK.chat_card.button.use_scroll: Use Scroll
 SHADOWDARK.chat_card.button.use_wand: Use Wand
 SHADOWDARK.chat_card.context.apply_damage_secondary: Apply Secondary Damage
 SHADOWDARK.chat_card.context.apply_damage: Apply Damage
+SHADOWDARK.chat_card.context.apply_damageType_to_selectedType: Apply {damageType} to selected {selectedType}
 SHADOWDARK.chat_card.context.apply_healing_secondary: Apply Secondary Healing
 SHADOWDARK.chat_card.context.apply_healing: Apply Healing
 SHADOWDARK.chat_card.dialog.reapply_damage.content: Damage has already been applied from this roll. Apply it again?

--- a/system/src/documents/ChatMessageSD.mjs
+++ b/system/src/documents/ChatMessageSD.mjs
@@ -56,10 +56,16 @@ export default class ChatMessageSD extends ChatMessage {
 			html.querySelectorAll('[data-action="reroll"]').forEach(btn => btn.remove());
 		}
 		if (game.user.isGM) {
+			const damageType = this.rollConfig?.cast?.damageType === "healing" ? "healing" : "damage";
 			html.querySelectorAll(".apply-damage").forEach(async a => {
 				const context = {};
 				context.healing = (this.rollConfig?.cast?.damageType === "healing");
 				context.target = a.dataset.target === "target";
+				const selectedType = context.target ? "targets" : "tokens";
+				a.dataset.tooltip = game.i18n.format(
+					"SHADOWDARK.chat_card.context.apply_damageType_to_selectedType",
+					{ damageType, selectedType }
+				);
 				const selectorhtml = await foundry.applications.handlebars.renderTemplate(
 					"systems/shadowdark/templates/dice/_partials/damage-selectors.hbs",
 					context

--- a/system/templates/chat/roll-card.hbs
+++ b/system/templates/chat/roll-card.hbs
@@ -63,7 +63,7 @@
 				</a>
 			</div>
 			{{#if damageRoll.html}}
-				<a class="apply-damage" data-action="apply-damage" data-target="target" data-tooltip="Apply damage to selected Targets"></a>
+				<a class="apply-damage" data-action="apply-damage" data-target="target"></a>
 			{{/if}}
 		</div>
 	{{/if}}

--- a/system/templates/dice/roll.hbs
+++ b/system/templates/dice/roll.hbs
@@ -8,7 +8,7 @@
 				{{formula}} {{#if options.modified}}<i class="fas fa-asterisk"></i>{{/if}}
 			</div>
 			{{#if damage}}
-			<a class="apply-damage" data-action="apply-damage" data-target="selected" data-tooltip="Apply damage to selected tokens"></a>
+			<a class="apply-damage" data-action="apply-damage" data-target="selected"></a>
 			{{/if}}
 		</div>
     </div>


### PR DESCRIPTION
Check `this.rollConfig` in `_applyVisibilityRules` for healing/damage and mutate chat card HTML.

~1. Set up `damageType` to be read easily downstream.~
~2. Added i18n entries.~
~3. Updated both template contexts.~

