### PR TITLE
Fix: Support Babele translated item properties (Finesse, Thrown, etc.)

### DIFF
--- a/system/src/models/items/_BaseItemSD.mjs
+++ b/system/src/models/items/_BaseItemSD.mjs
@@ -28,9 +28,15 @@ export class BaseItemSD extends foundry.abstract.TypeDataModel {
 		for (const uuid of this.properties ?? []) {
 			propertyItems.push(fromUuidSync(uuid));
 		}
-		const propertyItem = propertyItems.find(
-			p => p.name.slugify() === property.slugify()
-		);
+		
+		const propSlug = (property || "").slugify();
+		
+		const propertyItem = propertyItems.find(p => {
+			if (!p) return false;
+			const engName = p.originalName || p.flags?.babele?.originalName || p.name || "";
+			return engName.slugify() === propSlug || (p.name || "").slugify() === propSlug;
+		});
+		
 		return propertyItem ? true : false;
 	}
 


### PR DESCRIPTION
### What does this PR do?
This PR updates the `hasProperty` method in `_BaseItemSD.mjs` to natively support non-English communities using translation modules like **Babele**.

### Why is it needed?
Currently, mechanics relying on property items (like Finesse, Thrown, and Versatile) break when Babele translates the compendium index (e.g., changing "Finesse" to "Acuidade" in PT-BR). Because `fromUuidSync()` retrieves the translated index, `p.name.slugify() === property.slugify()` fails, causing Finesse weapons to default to Strength.

### How does it work?
When Babele translates a compendium, it injects the original English name into the index as `originalName` (or under `flags.babele.originalName`). This PR simply adds a fallback to check for that original English name. 
If no translation module is active, it defaults to checking `p.name` as usual.

ps: I vibecoded it, I hope you can help me if I made any mistakes. Thanks!