### PR TITLE
Fixes #1374: disable level-up arrow when no class selected

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -773,6 +773,7 @@ SHADOWDARK.sheet.actor.character_notes: Character Notes
 SHADOWDARK.sheet.actor.hp_max: Max
 SHADOWDARK.sheet.actor.hp: HP
 SHADOWDARK.sheet.actor.level: Level
+SHADOWDARK.sheet.player.choose_class_to_level_up: Choose a class first
 SHADOWDARK.sheet.actor.placeholder.name: New Actor Name
 SHADOWDARK.sheet.class.item: Shadowdark Item Sheet
 SHADOWDARK.sheet.class.npc: Shadowdark NPC Sheet

--- a/system/src/sheets/PlayerSheetSD.mjs
+++ b/system/src/sheets/PlayerSheetSD.mjs
@@ -194,7 +194,7 @@ export default class PlayerSheetSD extends ActorSheetSD {
 		context.gearSlots = this.actor.system.slots;
 
 		context.xpNextLevel = this.actor.system.level.value * 10;
-		context.levelUp = (this.actor.system.level.xp >= context.xpNextLevel);
+		const hasEnoughXp = this.actor.system.level.xp >= context.xpNextLevel;
 
 		context.isSpellCaster = this.actor.system.isSpellCaster;
 		context.canUseMagicItems = this.actor.system.canUseMagicItems;
@@ -210,6 +210,8 @@ export default class PlayerSheetSD extends ActorSheetSD {
 		await this._prepareItems(context);
 
 		context.characterClass = await this.actor.system.getClass();
+		context.levelUp = hasEnoughXp && !!context.characterClass;
+		context.levelUpNoClass = hasEnoughXp && !context.characterClass;
 		context.classHasPatron = context.characterClass?.system?.patron?.required ?? false;
 		context.classTitle = await this.actor.system.getTitle();
 

--- a/system/templates/actors/player/details/level.hbs
+++ b/system/templates/actors/player/details/level.hbs
@@ -5,11 +5,14 @@
 		<span></span>
 	</div>
 	<div class="content centered">
-		{{#unless levelUp}}
+		{{#unless levelUp}}{{#unless levelUpNoClass}}
 			{{system.level.value}}
-		{{/unless}}
+		{{/unless}}{{/unless}}
 		{{#if levelUp}}
 			<a class="fa-solid fa-arrow-up fa-beat" data-action="level-up"></a>
+		{{/if}}
+		{{#if levelUpNoClass}}
+			<span class="fa-solid fa-arrow-up" style="opacity: 0.35; cursor: default;" title="{{localize 'SHADOWDARK.sheet.player.choose_class_to_level_up'}}"></span>
 		{{/if}}
 	</div>
 </div>


### PR DESCRIPTION
Show a dimmed non-clickable arrow when XP threshold is met but no class is set, preventing the null-dereference crash in _onlevelUp.

Here is the new look with hover text.

<img width="628" height="742" alt="afbeelding" src="https://github.com/user-attachments/assets/65ee2f6f-643d-47c0-9af3-e414949d1106" />


