### PR TITLE
docs: Add release note for #1402 drag & drop fix

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,9 @@
 # Enhancements
 - [#1376] Update the Monster Importer to handle various publisher quirks
 
+## Bugfixes
+- [#1389] Fixed dropping Language, Ancestry, Background, Class, Deity or Patron items onto a character sheet *(Ashley Towner)*
+
 # Chores
 - [#1369] Merge Spanish translation updates from Crowdin
 - [#1384] Merge Spanish translation updates from Crowdin


### PR DESCRIPTION
The release note for the drag & drop fix (PR #1402 / issue #1389) was missing from `develop`. 