### PR TITLE
Add ride-along & extinguish options for lights

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -750,6 +750,8 @@ SHADOWDARK.settings.track_light_sources.pause_with_game.hint: If checked the Rea
 SHADOWDARK.settings.track_light_sources.pause_with_game.name: Pause Light Tracking
 SHADOWDARK.settings.track_light_sources.realtime_tracking.hint: If checked the Light Tracking will follow real time. Disable if an external time/calendar module is used.
 SHADOWDARK.settings.track_light_sources.realtime_tracking.name: Realtime Light Tracking
+SHADOWDARK.settings.track_light_sources.ride_along.hint: Any newly lit light sources will ride along on the current light timer.
+SHADOWDARK.settings.track_light_sources.ride_along.name: Realtime Light Ride-Along
 SHADOWDARK.settings.track_light_sources.show_remaining.hint: Controls if players can see remaining time left on light sources.
 SHADOWDARK.settings.track_light_sources.show_remaining.name: "Show Players Light Remaining"
 SHADOWDARK.settings.track_light_sources.show_remaining.option0: None

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -36,12 +36,12 @@ SHADOWDARK.app.item_properties.save: Save
 SHADOWDARK.app.item_properties.talent.effects.title: Talent Effect Types
 SHADOWDARK.app.item_properties.title: Properties
 SHADOWDARK.app.item_properties.weapon.title: Weapon Properties
-SHADOWDARK.app.light_tracker.minute_short: min
-SHADOWDARK.app.light_tracker.minutes_short: mins
-SHADOWDARK.app.light_tracker.title: Light Tracker
 SHADOWDARK.app.light-tracker.douse-light: Douse Light
 SHADOWDARK.app.light-tracker.hide-inactive: Hide Actors Without Lights
+SHADOWDARK.app.light_tracker.minute_short: min
+SHADOWDARK.app.light_tracker.minutes_short: mins
 SHADOWDARK.app.light-tracker.show-all-actors: Show All Actors
+SHADOWDARK.app.light_tracker.title: Light Tracker
 SHADOWDARK.app.light-tracker.turn-out-the-lights: Turn Out the Lights
 SHADOWDARK.app.loading.body: Searching Distant Lands...
 SHADOWDARK.app.loading.title: Loading
@@ -79,6 +79,8 @@ SHADOWDARK.apps.effect_panel.duration_label.x_hours: "{hours} Hours Remaining"
 SHADOWDARK.apps.effect_panel.duration_label.x_minutes: "{minutes} Minutes Remaining"
 SHADOWDARK.apps.effect_panel.duration_label.x_rounds: "{rounds} Rounds Remaining"
 SHADOWDARK.apps.effect_panel.duration_label.x_seconds: "{seconds} Seconds Remaining"
+SHADOWDARK.apps.light_source.behaviour.prompt: Should this new light ride along on the current timer, or extinguish other lights?
+SHADOWDARK.apps.light_source.behaviour.title: How should this light behave?
 SHADOWDARK.apps.effect_panel.duration_label.x_weeks: "{weeks} Weeks Remaining"
 SHADOWDARK.apps.effect_panel.duration_label.x_years: "{years} Years Remaining"
 SHADOWDARK.apps.effect_panel.right_click_to_remove: "[Right click] Remove effect"
@@ -744,10 +746,18 @@ SHADOWDARK.settings.track_light_sources.inactive_user.name: Track Inactive User 
 SHADOWDARK.settings.track_light_sources.interval.hint: How frequently tracked light sources will be updated, in seconds.
 SHADOWDARK.settings.track_light_sources.interval.name: Light Tracking Interval
 SHADOWDARK.settings.track_light_sources.name: Track Light Sources
+SHADOWDARK.settings.track_light_sources.only_one.hint: Any newly lit light extinguishes other lights
+SHADOWDARK.settings.track_light_sources.only_one.name: One light at a time
 SHADOWDARK.settings.track_light_sources.open_on_start.hint: If checked the Light Tracking interface will open on startup (GM only).
 SHADOWDARK.settings.track_light_sources.open_on_start.name: Open Light Tracking UI on Startup
 SHADOWDARK.settings.track_light_sources.pause_with_game.hint: If checked the Realtime Light Tracking will pause whenever Foundry is paused.
 SHADOWDARK.settings.track_light_sources.pause_with_game.name: Pause Light Tracking
+SHADOWDARK.settings.track_light_sources.behaviour.name: Light Tracking Behaviour
+SHADOWDARK.settings.track_light_sources.behaviour.separate: Track Separately
+SHADOWDARK.settings.track_light_sources.behaviour.ride_along: Ride-Along on Current Timer
+SHADOWDARK.settings.track_light_sources.behaviour.extinguish_others: Extinguish Other Light Sources
+SHADOWDARK.settings.track_light_sources.behaviour.ride_along_or_extinguish: Ride-Along or Extinguish (Prompt)
+SHADOWDARK.settings.track_light_sources.behaviour.hint: How new real-time light sources should behave.
 SHADOWDARK.settings.track_light_sources.realtime_tracking.hint: If checked the Light Tracking will follow real time. Disable if an external time/calendar module is used.
 SHADOWDARK.settings.track_light_sources.realtime_tracking.name: Realtime Light Tracking
 SHADOWDARK.settings.track_light_sources.ride_along.hint: Any newly lit light sources will ride along on the current light timer.

--- a/system/src/apps/LightSourceTrackerSD.mjs
+++ b/system/src/apps/LightSourceTrackerSD.mjs
@@ -65,32 +65,7 @@ export default class LightSourceTrackerSD extends foundry.appv1.api.Application 
 		html.find(".disable-all-lights").click(
 			async event => {
 				event.preventDefault();
-
-				shadowdark.debug("Turning out all the lights");
-
-				if (this.monitoredLightSources.length <= 0) return;
-
-				for (const actorData of this.monitoredLightSources) {
-					if (actorData.lightSources.length <= 0) continue;
-
-					const actor = game.actors.get(actorData._id);
-
-					await actor.turnLightOff();
-
-					for (const itemData of actorData.lightSources) {
-						shadowdark.debug(`Turning off ${actor.name}'s ${itemData.name} light source`);
-
-						if (itemData.type === "Effect") {
-							await actor.deleteEmbeddedDocuments("Item", [itemData._id]);
-						}
-						else {
-							await actor.updateEmbeddedDocuments("Item", [{
-								"_id": itemData._id,
-								"system.light.active": false,
-							}]);
-						}
-					}
-				}
+				await this._turnOutAllLights();
 
 				const cardData = {
 					img: "icons/magic/perception/shadow-stealth-eyes-purple.webp",
@@ -154,6 +129,34 @@ export default class LightSourceTrackerSD extends foundry.appv1.api.Application 
 				this.render(false);
 			}
 		);
+	}
+
+	async _turnOutAllLights() {
+		shadowdark.debug("Turning out all the lights");
+
+		if (this.monitoredLightSources.length <= 0) return;
+
+		for (const actorData of this.monitoredLightSources) {
+			if (actorData.lightSources.length <= 0) continue;
+
+			const actor = game.actors.get(actorData._id);
+
+			await actor.turnLightOff();
+
+			for (const itemData of actorData.lightSources) {
+				shadowdark.debug(`Turning off ${actor.name}'s ${itemData.name} light source`);
+
+				if (itemData.type === "Effect") {
+					await actor.deleteEmbeddedDocuments("Item", [itemData._id]);
+				}
+				else {
+					await actor.updateEmbeddedDocuments("Item", [{
+						"_id": itemData._id,
+						"system.light.active": false,
+					}]);
+				}
+			}
+		}
 	}
 
 	/**
@@ -335,7 +338,13 @@ export default class LightSourceTrackerSD extends foundry.appv1.api.Application 
 		}
 	}
 
-	async toggleLightSource(actor, item) {
+	/**
+	 * toggle a light source
+	 * @param actor
+	 * @param item
+	 * @param {"SEPARATE"|"RIDEALONG"|"EXTINGUISH"} behaviour
+	 */
+	async toggleLightSource(actor, item, behaviour) {
 		if (this._isDisabled()) return;
 
 		if (!game.user.isGM) {
@@ -346,23 +355,17 @@ export default class LightSourceTrackerSD extends foundry.appv1.api.Application 
 					data: {
 						actor,
 						item,
+						behaviour,
 					},
 				}
 			);
 			return;
 		}
+		const activeLightSources = this.monitoredLightSources
+			.map(source => source.lightSources)
+			.flat();
 
-		const rideAlongEnabled = game.settings.get(
-			"shadowdark",
-			"realtimeLightSourceRideAlong"
-		);
-
-		if (rideAlongEnabled) {
-			const activeLightSources =
-				this.monitoredLightSources
-					.map(source => source.lightSources)
-					.flat();
-
+		if (behaviour === "RIDEALONG") {
 			// if there are no active light sources already, then behave like normal
 			if (activeLightSources.length > 0) {
 				const lightOwner = game.actors.find(actor => actor.items.get(item._id));
@@ -378,6 +381,9 @@ export default class LightSourceTrackerSD extends foundry.appv1.api.Application 
 					},
 				]);
 			}
+		}
+		else if (behaviour === "EXTINGUISH") {
+			this._turnOutAllLights();
 		}
 
 		const status = item.system.light.active ? "on" : "off";

--- a/system/src/apps/LightSourceTrackerSD.mjs
+++ b/system/src/apps/LightSourceTrackerSD.mjs
@@ -352,6 +352,34 @@ export default class LightSourceTrackerSD extends foundry.appv1.api.Application 
 			return;
 		}
 
+		const rideAlongEnabled = game.settings.get(
+			"shadowdark",
+			"realtimeLightSourceRideAlong"
+		);
+
+		if (rideAlongEnabled) {
+			const activeLightSources =
+				this.monitoredLightSources
+					.map(source => source.lightSources)
+					.flat();
+
+			// if there are no active light sources already, then behave like normal
+			if (activeLightSources.length > 0) {
+				const lightOwner = game.actors.find(actor => actor.items.get(item._id));
+				const minRemainingSecs = activeLightSources.reduce(
+					(a, b) =>
+						a < b.system.light.remainingSecs ? a : b.system.light.remainingSecs,
+					Number.MAX_SAFE_INTEGER
+				);
+				await lightOwner.updateEmbeddedDocuments("Item", [
+					{
+						"_id": item._id,
+						"system.light.remainingSecs": minRemainingSecs,
+					},
+				]);
+			}
+		}
+
 		const status = item.system.light.active ? "on" : "off";
 
 		shadowdark.debug(`Turning ${status} ${actor.name}'s ${item.name} light source`);

--- a/system/src/settings.mjs
+++ b/system/src/settings.mjs
@@ -4,7 +4,6 @@ import SourceFilterSettings from "./apps/SourceFilterSettings.mjs";
  * Register all of the system"s settings.
  */
 export default function registerSystemSettings() {
-
 	// -----------------
 	//  Content Sources
 	// -----------------
@@ -118,6 +117,16 @@ export default function registerSystemSettings() {
 		scope: "world",
 		config: true,
 		default: true,
+		type: Boolean,
+		onChange: () => game.shadowdark.lightSourceTracker._settingsChanged(),
+	});
+
+	game.settings.register("shadowdark", "realtimeLightSourceRideAlong", {
+		name: "SHADOWDARK.settings.track_light_sources.ride_along.name",
+		hint: "SHADOWDARK.settings.track_light_sources.ride_along.hint",
+		scope: "world",
+		config: true,
+		default: false,
 		type: Boolean,
 		onChange: () => game.shadowdark.lightSourceTracker._settingsChanged(),
 	});
@@ -266,5 +275,4 @@ export default function registerSystemSettings() {
 		default: false,
 		requiresReload: true,
 	});
-
 }

--- a/system/src/settings.mjs
+++ b/system/src/settings.mjs
@@ -121,14 +121,19 @@ export default function registerSystemSettings() {
 		onChange: () => game.shadowdark.lightSourceTracker._settingsChanged(),
 	});
 
-	game.settings.register("shadowdark", "realtimeLightSourceRideAlong", {
-		name: "SHADOWDARK.settings.track_light_sources.ride_along.name",
-		hint: "SHADOWDARK.settings.track_light_sources.ride_along.hint",
+	game.settings.register("shadowdark", "realtimeLightBehaviour", {
+		name: "SHADOWDARK.settings.track_light_sources.behaviour.name",
+		hint: "SHADOWDARK.settings.track_light_sources.behaviour.hint",
 		scope: "world",
 		config: true,
-		default: false,
-		type: Boolean,
-		onChange: () => game.shadowdark.lightSourceTracker._settingsChanged(),
+		default: 0,
+		type: Number,
+		choices: {
+			0: "SHADOWDARK.settings.track_light_sources.behaviour.separate",
+			1: "SHADOWDARK.settings.track_light_sources.behaviour.ride_along",
+			2: "SHADOWDARK.settings.track_light_sources.behaviour.extinguish_others",
+			3: "SHADOWDARK.settings.track_light_sources.behaviour.ride_along_or_extinguish",
+		},
 	});
 
 	game.settings.register("shadowdark", "pauseLightTrackingWithGame", {

--- a/system/src/sheets/PlayerSheetSD.mjs
+++ b/system/src/sheets/PlayerSheetSD.mjs
@@ -769,6 +769,57 @@ export default class PlayerSheetSD extends ActorSheetSD {
 	async _toggleLightSource(item, options = {}) {
 		const active = !item.system.light.active;
 
+		const realtimeLightBehaviour = game.settings.get("shadowdark",  "realtimeLightBehaviour");
+
+		let behaviour;
+
+		if (!active || realtimeLightBehaviour === 0) {
+			// If we are extinguishing a light, then it should just behave like a
+			// separately tracked light
+			behaviour = "SEPARATE";
+		}
+		else if (realtimeLightBehaviour === 1) { // ride-along
+			behaviour = "RIDEALONG";
+		}
+		else if (realtimeLightBehaviour === 2) { // extinguish others
+			behaviour = "EXTINGUISH";
+		}
+		else if (realtimeLightBehaviour === 3) { // a choice of ride-along or extinguish
+			behaviour = await foundry.applications.api.DialogV2.wait({
+				window: {
+					title: game.i18n.localize(
+						"SHADOWDARK.apps.light_source.behaviour.title"
+					),
+				},
+				content: `<p>${game.i18n.localize(
+					"SHADOWDARK.apps.light_source.behaviour.prompt"
+				)}</p>`,
+				buttons: [
+					{
+						action: "rideAlong",
+						icon: "fa-solid fa-clock",
+						label: game.i18n.localize(
+							"SHADOWDARK.settings.track_light_sources.behaviour.ride_along"
+						),
+						callback: () => "RIDEALONG",
+						default: true,
+					},
+					{
+						action: "extinguish",
+						icon: "fa-solid fa-fire-extinguisher",
+						label: game.i18n.localize(
+							"SHADOWDARK.settings.track_light_sources.behaviour.extinguish_others"
+						),
+						callback: () => "EXTINGUISH",
+					},
+				],
+				rejectClose: false,
+			});
+		}
+
+		// If no behaviour is selected, cancel the lighting
+		if (!behaviour) return;
+
 		if (active) {
 			// Find any currently active lights and turn them off
 			const activeLightSources = await this.actor.getActiveLightSources();
@@ -781,6 +832,7 @@ export default class PlayerSheetSD extends ActorSheetSD {
 				);
 			}
 		}
+
 
 		const dataUpdate = {
 			"_id": item.id,
@@ -804,7 +856,8 @@ export default class PlayerSheetSD extends ActorSheetSD {
 			this._sendToggledLightSourceToChat(active, item, options);
 			game.shadowdark.lightSourceTracker.toggleLightSource(
 				this.actor,
-				updatedLight
+				updatedLight,
+				behaviour
 			);
 		}
 	}

--- a/system/src/socket.mjs
+++ b/system/src/socket.mjs
@@ -46,7 +46,8 @@ export default function listenOnSocket() {
 		if (event.type === "toggleLightSource" && game.user.isGM) {
 			game.shadowdark.lightSourceTracker.toggleLightSource(
 				event.data.actor,
-				event.data.item
+				event.data.item,
+				event.data.behaviour
 			);
 		}
 	});


### PR DESCRIPTION
This PR adds a few configuration options to the way lights work, to allow GMs to have their games run more closely to RAW if they'd like. This was [requested a while ago](https://discord.com/channels/558029475837902851/1119133303514071090/1508776531659325540) and I felt like doing it. The default behaviour is to track torches separately still, so there is no change to the way the module works by default. 

## New Configuration Option: "Light Tracking Behaviour"

<img width="514" height="70" alt="image" src="https://github.com/user-attachments/assets/e2f10d93-69b6-44da-a35b-f95dc23f372e" />

There are 4 options for this configuration option:

1. Track Separately: Track each light source timer separately
2. Ride-Along on Current Timer: All new lights are set to the same value as the current light timer
3. Extinguish other Light Sources: All new lights cause all other light sources to be extinguished
4. Ride-Along or Extinguish (Prompt): When a player lights a torch, they are prompted about whether they want to follow the Ride-Along behaviour or the Extinguish others behaviour. This is exactly how the game works Rules-As-Written on Core pg. 84. 

## Ride-Along

When you light a new light, it's "current time" is set to the same time as the other tracked lights (technically the minimum, but the situation where there's a difference between the minimum and the maximum is an edge-case where I think the minimum is a reasonable choice). 

## Extinguish

This literally just extinguishes all actively tracked lights, it uses the same logic as the "Turn out the lights" button, but without sending a message to chat. 

## Prompt

<img width="520" height="174" alt="image" src="https://github.com/user-attachments/assets/4844b4b5-9625-4235-905b-ea7820f60599" />
