### PR TITLE
Add cursed scroll (1–3) magic items

### DIFF
--- a/data/packs/conditions.db/blind__xE08WjX14HjHwSJC.json
+++ b/data/packs/conditions.db/blind__xE08WjX14HjHwSJC.json
@@ -1,27 +1,27 @@
 {
 	"_id": "xE08WjX14HjHwSJC",
 	"_key": "!items.effects!Grd46xo0lgHLtfVe.xE08WjX14HjHwSJC",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/creatures/eyes/humanoid-single-blind.webp",
 	"name": "Blind",
 	"origin": "Item.Grd46xo0lgHLtfVe",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/charmed__g02s1plvTDRI6Ido.json
+++ b/data/packs/conditions.db/charmed__g02s1plvTDRI6Ido.json
@@ -1,27 +1,27 @@
 {
 	"_id": "g02s1plvTDRI6Ido",
 	"_key": "!items.effects!fDUPAItc64pmW5zM.g02s1plvTDRI6Ido",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/life/heart-shadow-red.webp",
 	"name": "Charmed",
 	"origin": "Item.fDUPAItc64pmW5zM",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__afraid__CyZNMVHNjIMTM0g7.json
+++ b/data/packs/conditions.db/condition__afraid__CyZNMVHNjIMTM0g7.json
@@ -1,27 +1,27 @@
 {
 	"_id": "CyZNMVHNjIMTM0g7",
 	"_key": "!items.effects!6Hd5Dzf2TnXL9Gxs.CyZNMVHNjIMTM0g7",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/control/fear-fright-white.webp",
 	"name": "Condition: Afraid",
 	"origin": "Item.6Hd5Dzf2TnXL9Gxs",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__asleep__9LKEdqM5gksbj8xV.json
+++ b/data/packs/conditions.db/condition__asleep__9LKEdqM5gksbj8xV.json
@@ -1,27 +1,27 @@
 {
 	"_id": "9LKEdqM5gksbj8xV",
 	"_key": "!items.effects!FoXNI5CfBkJOvJ9c.9LKEdqM5gksbj8xV",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/control/sleep-bubble-purple.webp",
 	"name": "Condition: Asleep",
 	"origin": "Item.FoXNI5CfBkJOvJ9c",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__beguiled__qSuLDWBjPNH2wizr.json
+++ b/data/packs/conditions.db/condition__beguiled__qSuLDWBjPNH2wizr.json
@@ -1,27 +1,27 @@
 {
 	"_id": "qSuLDWBjPNH2wizr",
 	"_key": "!items.effects!4OcLCPW1pxzTua7d.qSuLDWBjPNH2wizr",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/control/hypnosis-mesmerism-pendulum.webp",
 	"name": "Condition: Beguiled",
 	"origin": "Item.4OcLCPW1pxzTua7d",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__bug_brain__YPYxo5WhLBPCnkRd.json
+++ b/data/packs/conditions.db/condition__bug_brain__YPYxo5WhLBPCnkRd.json
@@ -1,33 +1,33 @@
 {
 	"_id": "YPYxo5WhLBPCnkRd",
 	"_key": "!items.effects!rbOmeG3R2mmiiIMT.YPYxo5WhLBPCnkRd",
-	"changes": [
-		{
-			"key": "system.abilities.int.value",
-			"mode": 5,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/creatures/invertebrates/centipede-brown.webp",
 	"name": "Condition: Bug Brain",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.int.value",
+				"priority": null,
+				"type": "override",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__compelled__jtCuGSncFiHgfNgZ.json
+++ b/data/packs/conditions.db/condition__compelled__jtCuGSncFiHgfNgZ.json
@@ -1,27 +1,27 @@
 {
 	"_id": "jtCuGSncFiHgfNgZ",
 	"_key": "!items.effects!7DNtQwX31lpChHZH.jtCuGSncFiHgfNgZ",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/control/energy-stream-link-spiral-white.webp",
 	"name": "Condition: Compelled",
 	"origin": "Item.7DNtQwX31lpChHZH",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__cursed__h8IoE9DUt8lyCAgQ.json
+++ b/data/packs/conditions.db/condition__cursed__h8IoE9DUt8lyCAgQ.json
@@ -1,27 +1,27 @@
 {
 	"_id": "h8IoE9DUt8lyCAgQ",
 	"_key": "!items.effects!T7PD6qqfanwAMEzo.h8IoE9DUt8lyCAgQ",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/unholy/strike-body-explode-disintegrate.webp",
 	"name": "Condition: Cursed",
 	"origin": "Item.T7PD6qqfanwAMEzo",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__disease__1___PAkmxzlF6cIsPNkt.json
+++ b/data/packs/conditions.db/condition__disease__1___PAkmxzlF6cIsPNkt.json
@@ -1,33 +1,33 @@
 {
 	"_id": "PAkmxzlF6cIsPNkt",
 	"_key": "!items.effects!WRFmdFxvPhVKXQB2.PAkmxzlF6cIsPNkt",
-	"changes": [
-		{
-			"key": "system.abilities.con.value",
-			"mode": 2,
-			"priority": null,
-			"value": "-1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/death/skull-poison-green.webp",
 	"name": "Condition: Disease (1)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.con.value",
+				"priority": null,
+				"type": "add",
+				"value": -1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__disease__2___PAkmxzlF6cIsPNkt.json
+++ b/data/packs/conditions.db/condition__disease__2___PAkmxzlF6cIsPNkt.json
@@ -1,33 +1,33 @@
 {
 	"_id": "PAkmxzlF6cIsPNkt",
 	"_key": "!items.effects!fMXSo5UqQD0fedRc.PAkmxzlF6cIsPNkt",
-	"changes": [
-		{
-			"key": "system.abilities.con.value",
-			"mode": 2,
-			"priority": null,
-			"value": "-2"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/death/skull-poison-green.webp",
 	"name": "Condition: Disease (2)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.con.value",
+				"priority": null,
+				"type": "add",
+				"value": -2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__disease__3___PAkmxzlF6cIsPNkt.json
+++ b/data/packs/conditions.db/condition__disease__3___PAkmxzlF6cIsPNkt.json
@@ -1,33 +1,33 @@
 {
 	"_id": "PAkmxzlF6cIsPNkt",
 	"_key": "!items.effects!wDCrj4X7ccqB2jA8.PAkmxzlF6cIsPNkt",
-	"changes": [
-		{
-			"key": "system.abilities.con.value",
-			"mode": 2,
-			"priority": null,
-			"value": "-3"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/death/skull-poison-green.webp",
 	"name": "Condition: Disease (3)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.con.value",
+				"priority": null,
+				"type": "add",
+				"value": -3
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__disease__4___PAkmxzlF6cIsPNkt.json
+++ b/data/packs/conditions.db/condition__disease__4___PAkmxzlF6cIsPNkt.json
@@ -1,33 +1,33 @@
 {
 	"_id": "PAkmxzlF6cIsPNkt",
 	"_key": "!items.effects!PY16IzWMkbYbGAWJ.PAkmxzlF6cIsPNkt",
-	"changes": [
-		{
-			"key": "system.abilities.con.value",
-			"mode": 2,
-			"priority": null,
-			"value": "-4"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/death/skull-poison-green.webp",
 	"name": "Condition: Disease (4)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.con.value",
+				"priority": null,
+				"type": "add",
+				"value": -4
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__drained__1___iatMWq8uzO8KPaxd.json
+++ b/data/packs/conditions.db/condition__drained__1___iatMWq8uzO8KPaxd.json
@@ -1,33 +1,33 @@
 {
 	"_id": "iatMWq8uzO8KPaxd",
 	"_key": "!items.effects!fHiOjFwljNOeJ2aX.iatMWq8uzO8KPaxd",
-	"changes": [
-		{
-			"key": "system.abilities.wis.value",
-			"mode": 2,
-			"priority": null,
-			"value": "-1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/unholy/strike-body-life-soul-green.webp",
 	"name": "Condition: Drained (1)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.wis.value",
+				"priority": null,
+				"type": "add",
+				"value": -1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__drained__2___iatMWq8uzO8KPaxd.json
+++ b/data/packs/conditions.db/condition__drained__2___iatMWq8uzO8KPaxd.json
@@ -1,33 +1,33 @@
 {
 	"_id": "iatMWq8uzO8KPaxd",
 	"_key": "!items.effects!mqOVlejHMZAvqnn4.iatMWq8uzO8KPaxd",
-	"changes": [
-		{
-			"key": "system.abilities.wis.value",
-			"mode": 2,
-			"priority": null,
-			"value": "-2"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/unholy/strike-body-life-soul-green.webp",
 	"name": "Condition: Drained (2)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.wis.value",
+				"priority": null,
+				"type": "add",
+				"value": -2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__drained__3___iatMWq8uzO8KPaxd.json
+++ b/data/packs/conditions.db/condition__drained__3___iatMWq8uzO8KPaxd.json
@@ -1,33 +1,33 @@
 {
 	"_id": "iatMWq8uzO8KPaxd",
 	"_key": "!items.effects!jT3yIGZpBlEYa2va.iatMWq8uzO8KPaxd",
-	"changes": [
-		{
-			"key": "system.abilities.wis.value",
-			"mode": 2,
-			"priority": null,
-			"value": "-3"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/unholy/strike-body-life-soul-green.webp",
 	"name": "Condition: Drained (3)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.wis.value",
+				"priority": null,
+				"type": "add",
+				"value": -3
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__drained__4___iatMWq8uzO8KPaxd.json
+++ b/data/packs/conditions.db/condition__drained__4___iatMWq8uzO8KPaxd.json
@@ -1,33 +1,33 @@
 {
 	"_id": "iatMWq8uzO8KPaxd",
 	"_key": "!items.effects!GQDiR0cXfb86m83P.iatMWq8uzO8KPaxd",
-	"changes": [
-		{
-			"key": "system.abilities.wis.value",
-			"mode": 2,
-			"priority": null,
-			"value": "-4"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/unholy/strike-body-life-soul-green.webp",
 	"name": "Condition: Drained (4)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.wis.value",
+				"priority": null,
+				"type": "add",
+				"value": -4
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__drained__5___iatMWq8uzO8KPaxd.json
+++ b/data/packs/conditions.db/condition__drained__5___iatMWq8uzO8KPaxd.json
@@ -1,33 +1,33 @@
 {
 	"_id": "iatMWq8uzO8KPaxd",
 	"_key": "!items.effects!BcWf0hoWC2DZyaFH.iatMWq8uzO8KPaxd",
-	"changes": [
-		{
-			"key": "system.abilities.wis.value",
-			"mode": 2,
-			"priority": null,
-			"value": "-5"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/unholy/strike-body-life-soul-green.webp",
 	"name": "Condition: Drained (5)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.wis.value",
+				"priority": null,
+				"type": "add",
+				"value": -5
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__drained__6___iatMWq8uzO8KPaxd.json
+++ b/data/packs/conditions.db/condition__drained__6___iatMWq8uzO8KPaxd.json
@@ -1,33 +1,33 @@
 {
 	"_id": "iatMWq8uzO8KPaxd",
 	"_key": "!items.effects!5S5y0GWE2akNYJiq.iatMWq8uzO8KPaxd",
-	"changes": [
-		{
-			"key": "system.abilities.wis.value",
-			"mode": 2,
-			"priority": null,
-			"value": "-6"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/unholy/strike-body-life-soul-green.webp",
 	"name": "Condition: Drained (6)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.wis.value",
+				"priority": null,
+				"type": "add",
+				"value": -6
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__fragile__XGGzrINaGvRwwXPC.json
+++ b/data/packs/conditions.db/condition__fragile__XGGzrINaGvRwwXPC.json
@@ -1,27 +1,27 @@
 {
 	"_id": "XGGzrINaGvRwwXPC",
 	"_key": "!items.effects!pcBuNszkAjGRJ0XX.XGGzrINaGvRwwXPC",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/commodities/bones/bone-broken-grey.webp",
 	"name": "Condition: Fragile",
 	"origin": "Item.pcBuNszkAjGRJ0XX",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__gibbering__7mCWjMOGoEUpJlGc.json
+++ b/data/packs/conditions.db/condition__gibbering__7mCWjMOGoEUpJlGc.json
@@ -1,27 +1,27 @@
 {
 	"_id": "7mCWjMOGoEUpJlGc",
 	"_key": "!items.effects!iU2qaminUz77BQ0L.7mCWjMOGoEUpJlGc",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/creatures/abilities/mouth-teeth-human.webp",
 	"name": "Condition: Gibbering",
 	"origin": "Item.iU2qaminUz77BQ0L",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__invisible__LmXXpHviIuB684gX.json
+++ b/data/packs/conditions.db/condition__invisible__LmXXpHviIuB684gX.json
@@ -1,27 +1,27 @@
 {
 	"_id": "LmXXpHviIuB684gX",
 	"_key": "!items.effects!piycdXLudXTFLG0k.LmXXpHviIuB684gX",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 3,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 3
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/light/explosion-star-glow-silhouette.webp",
 	"name": "Condition: Invisible",
 	"origin": "Item.SMXbMbXcj5hLvTjY",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__laughing__8N8VrjrYr7pGris5.json
+++ b/data/packs/conditions.db/condition__laughing__8N8VrjrYr7pGris5.json
@@ -1,27 +1,27 @@
 {
 	"_id": "8N8VrjrYr7pGris5",
 	"_key": "!items.effects!7yyr32LQtbwxDTAF.8N8VrjrYr7pGris5",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/sonic/scream-wail-shout-teal.webp",
 	"name": "Condition: Laughing",
 	"origin": "Item.7yyr32LQtbwxDTAF",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__life_drain__1___PAkmxzlF6cIsPNkt.json
+++ b/data/packs/conditions.db/condition__life_drain__1___PAkmxzlF6cIsPNkt.json
@@ -1,33 +1,33 @@
 {
 	"_id": "PAkmxzlF6cIsPNkt",
 	"_key": "!items.effects!eAWhmC9ZXzjhIa1H.PAkmxzlF6cIsPNkt",
-	"changes": [
-		{
-			"key": "system.abilities.con.value",
-			"mode": 2,
-			"priority": null,
-			"value": "-1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/unholy/hand-light-pink.webp",
 	"name": "Condition: Life Drain (1)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.con.value",
+				"priority": null,
+				"type": "add",
+				"value": -1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__life_drain__2___PAkmxzlF6cIsPNkt.json
+++ b/data/packs/conditions.db/condition__life_drain__2___PAkmxzlF6cIsPNkt.json
@@ -1,33 +1,33 @@
 {
 	"_id": "PAkmxzlF6cIsPNkt",
 	"_key": "!items.effects!HBDRaw3YhM22PJK2.PAkmxzlF6cIsPNkt",
-	"changes": [
-		{
-			"key": "system.abilities.con.value",
-			"mode": 2,
-			"priority": null,
-			"value": "-2"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/unholy/hand-light-pink.webp",
 	"name": "Condition: Life Drain (2)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.con.value",
+				"priority": null,
+				"type": "add",
+				"value": -2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__life_drain__3___PAkmxzlF6cIsPNkt.json
+++ b/data/packs/conditions.db/condition__life_drain__3___PAkmxzlF6cIsPNkt.json
@@ -1,33 +1,33 @@
 {
 	"_id": "PAkmxzlF6cIsPNkt",
 	"_key": "!items.effects!74xpXmPIMUYnyt1M.PAkmxzlF6cIsPNkt",
-	"changes": [
-		{
-			"key": "system.abilities.con.value",
-			"mode": 2,
-			"priority": null,
-			"value": "-3"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/unholy/hand-light-pink.webp",
 	"name": "Condition: Life Drain (3)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.con.value",
+				"priority": null,
+				"type": "add",
+				"value": -3
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__life_drain__4___PAkmxzlF6cIsPNkt.json
+++ b/data/packs/conditions.db/condition__life_drain__4___PAkmxzlF6cIsPNkt.json
@@ -1,33 +1,33 @@
 {
 	"_id": "PAkmxzlF6cIsPNkt",
 	"_key": "!items.effects!pkvfOgSt7c86e1dw.PAkmxzlF6cIsPNkt",
-	"changes": [
-		{
-			"key": "system.abilities.con.value",
-			"mode": 2,
-			"priority": null,
-			"value": "-4"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/unholy/hand-light-pink.webp",
 	"name": "Condition: Life Drain (4)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.con.value",
+				"priority": null,
+				"type": "add",
+				"value": -4
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__mesmerized__3XkiakzqwT78EG4j.json
+++ b/data/packs/conditions.db/condition__mesmerized__3XkiakzqwT78EG4j.json
@@ -1,27 +1,27 @@
 {
 	"_id": "3XkiakzqwT78EG4j",
 	"_key": "!items.effects!vmcHEQWOyX933G1R.3XkiakzqwT78EG4j",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/control/hypnosis-mesmerism-pendulum.webp",
 	"name": "Condition: Mesmerized",
 	"origin": "Item.vmcHEQWOyX933G1R",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__paralyzed__5Q6foTiBhvvLG7y3.json
+++ b/data/packs/conditions.db/condition__paralyzed__5Q6foTiBhvvLG7y3.json
@@ -1,27 +1,27 @@
 {
 	"_id": "5Q6foTiBhvvLG7y3",
 	"_key": "!items.effects!ROTpAUAHx5s4AZZh.5Q6foTiBhvvLG7y3",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/water/barrier-ice-crystal-wall-faceted-blue.webp",
 	"name": "Condition: Paralyzed",
 	"origin": "Item.ROTpAUAHx5s4AZZh",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__petrified__Ck88Wezyv7vfvNGV.json
+++ b/data/packs/conditions.db/condition__petrified__Ck88Wezyv7vfvNGV.json
@@ -1,27 +1,27 @@
 {
 	"_id": "Ck88Wezyv7vfvNGV",
 	"_key": "!items.effects!DihIx1S94zeXV3oM.Ck88Wezyv7vfvNGV",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/creatures/magical/construct-stone-earth-gray.webp",
 	"name": "Condition: Petrified",
 	"origin": "Item.XbrayNCUis3pV0XU",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__polymorphed__xyhx2skwDPYWZ20G.json
+++ b/data/packs/conditions.db/condition__polymorphed__xyhx2skwDPYWZ20G.json
@@ -1,27 +1,27 @@
 {
 	"_id": "xyhx2skwDPYWZ20G",
 	"_key": "!items.effects!rW7oltlWDmteEpV7.xyhx2skwDPYWZ20G",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/creatures/mammals/rodent-rat-diseaed-gray.webp",
 	"name": "Condition: Polymorphed",
 	"origin": "Item.rW7oltlWDmteEpV7",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__possessed__rEjr6iPhgVuFTCWl.json
+++ b/data/packs/conditions.db/condition__possessed__rEjr6iPhgVuFTCWl.json
@@ -1,27 +1,27 @@
 {
 	"_id": "rEjr6iPhgVuFTCWl",
 	"_key": "!items.effects!OL2kOP05K96L9JV9.rEjr6iPhgVuFTCWl",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/perception/hand-eye-pink.webp",
 	"name": "Condition: Possessed",
 	"origin": "Item.OL2kOP05K96L9JV9",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__stuck__Pw5zyo8apyAphCG2.json
+++ b/data/packs/conditions.db/condition__stuck__Pw5zyo8apyAphCG2.json
@@ -1,27 +1,27 @@
 {
 	"_id": "Pw5zyo8apyAphCG2",
 	"_key": "!items.effects!0McK66FvDi42pjiu.Pw5zyo8apyAphCG2",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/environment/traps/trap-jaw-steel.webp",
 	"name": "Condition: Stuck",
 	"origin": "Item.0McK66FvDi42pjiu",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__stupified__gbK3h5sv3mNm3v3R.json
+++ b/data/packs/conditions.db/condition__stupified__gbK3h5sv3mNm3v3R.json
@@ -1,27 +1,27 @@
 {
 	"_id": "gbK3h5sv3mNm3v3R",
 	"_key": "!items.effects!SQzniFDNODQRLoNi.gbK3h5sv3mNm3v3R",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/water/barrier-ice-water-cube.webp",
 	"name": "Condition: Stupified",
 	"origin": "Item.SQzniFDNODQRLoNi",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/condition__unconscious__iTrME6gdEDXnxloZ.json
+++ b/data/packs/conditions.db/condition__unconscious__iTrME6gdEDXnxloZ.json
@@ -1,27 +1,27 @@
 {
 	"_id": "iTrME6gdEDXnxloZ",
 	"_key": "!items.effects!2UFWFSeffj7vrSSR.iTrME6gdEDXnxloZ",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/unholy/strike-body-life-soul-purple.webp",
 	"name": "Condition: Unconscious",
 	"origin": "Item.2UFWFSeffj7vrSSR",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/perceiving_advantage__M044441XNDJq00mV.json
+++ b/data/packs/conditions.db/perceiving_advantage__M044441XNDJq00mV.json
@@ -1,27 +1,27 @@
 {
 	"_id": "M044441XNDJq00mV",
 	"_key": "!items.effects!MUNwczWej0Bo8x4S.M044441XNDJq00mV",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 10,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 10
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/perception/eye-tendrils-web-purple.webp",
 	"name": "Perceiving Advantage",
 	"origin": "Item.E9GhofNgwIJ7N2A4",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/permanent_ability__cha___F7lcubzHfIM4jQDu.json
+++ b/data/packs/conditions.db/permanent_ability__cha___F7lcubzHfIM4jQDu.json
@@ -1,33 +1,33 @@
 {
 	"_id": "F7lcubzHfIM4jQDu",
 	"_key": "!items.effects!XPk44UuWpkKBxyf3.F7lcubzHfIM4jQDu",
-	"changes": [
-		{
-			"key": "system.abilities.cha.value",
-			"mode": 5,
-			"priority": null,
-			"value": "3"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/unholy/strike-hand-glow-pink.webp",
 	"name": "Permanent Ability (Cha)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.cha.value",
+				"priority": null,
+				"type": "override",
+				"value": 3
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/permanent_ability__con___uBrDknMQigqBcbl0.json
+++ b/data/packs/conditions.db/permanent_ability__con___uBrDknMQigqBcbl0.json
@@ -1,33 +1,33 @@
 {
 	"_id": "uBrDknMQigqBcbl0",
 	"_key": "!items.effects!fkb9HwrPEq9mlZbb.uBrDknMQigqBcbl0",
-	"changes": [
-		{
-			"key": "system.abilities.con.value",
-			"mode": 5,
-			"priority": null,
-			"value": "3"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/unholy/strike-hand-glow-pink.webp",
 	"name": "Permanent Ability (Con)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.con.value",
+				"priority": null,
+				"type": "override",
+				"value": 3
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/permanent_ability__dex___O8bVaWHv6gSA7mPq.json
+++ b/data/packs/conditions.db/permanent_ability__dex___O8bVaWHv6gSA7mPq.json
@@ -1,33 +1,33 @@
 {
 	"_id": "O8bVaWHv6gSA7mPq",
 	"_key": "!items.effects!lsVOr4eduzSNGkVY.O8bVaWHv6gSA7mPq",
-	"changes": [
-		{
-			"key": "system.abilities.dex.value",
-			"mode": 5,
-			"priority": null,
-			"value": "3"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/unholy/strike-hand-glow-pink.webp",
 	"name": "Permanent Ability (Dex)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.dex.value",
+				"priority": null,
+				"type": "override",
+				"value": 3
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/permanent_ability__int___niI5k5QCYV7npdse.json
+++ b/data/packs/conditions.db/permanent_ability__int___niI5k5QCYV7npdse.json
@@ -1,33 +1,33 @@
 {
 	"_id": "niI5k5QCYV7npdse",
 	"_key": "!items.effects!dmEiJzqy55xVYfD2.niI5k5QCYV7npdse",
-	"changes": [
-		{
-			"key": "system.abilities.int.value",
-			"mode": 5,
-			"priority": null,
-			"value": "3"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/unholy/strike-hand-glow-pink.webp",
 	"name": "Permanent Ability (Int)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.int.value",
+				"priority": null,
+				"type": "override",
+				"value": 3
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/permanent_ability__str___O8bVaWHv6gSA7mPq.json
+++ b/data/packs/conditions.db/permanent_ability__str___O8bVaWHv6gSA7mPq.json
@@ -1,33 +1,33 @@
 {
 	"_id": "O8bVaWHv6gSA7mPq",
 	"_key": "!items.effects!ov1K3L3kuKj8hCUG.O8bVaWHv6gSA7mPq",
-	"changes": [
-		{
-			"key": "system.abilities.str.value",
-			"mode": 5,
-			"priority": null,
-			"value": "3"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/unholy/strike-hand-glow-pink.webp",
 	"name": "Permanent Ability (Str)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.str.value",
+				"priority": null,
+				"type": "override",
+				"value": 3
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/conditions.db/permanent_ability__wis___38EONK96mLJWmtGS.json
+++ b/data/packs/conditions.db/permanent_ability__wis___38EONK96mLJWmtGS.json
@@ -1,33 +1,33 @@
 {
 	"_id": "38EONK96mLJWmtGS",
 	"_key": "!items.effects!OvpXs6E4W6Ta6LJZ.38EONK96mLJWmtGS",
-	"changes": [
-		{
-			"key": "system.abilities.wis.value",
-			"mode": 5,
-			"priority": null,
-			"value": "3"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 1,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/unholy/strike-hand-glow-pink.webp",
 	"name": "Permanent Ability (Wis)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.wis.value",
+				"priority": null,
+				"type": "override",
+				"value": 3
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/ability_score_improvement__cha___oHRtAdI8eDjSMzju.json
+++ b/data/packs/magic-items.db/ability_score_improvement__cha___oHRtAdI8eDjSMzju.json
@@ -1,0 +1,36 @@
+{
+	"_id": "oHRtAdI8eDjSMzju",
+	"_key": "!items.effects!EKLviLxm9xcL9iWc.oHRtAdI8eDjSMzju",
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
+	},
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/skills/melee/hand-grip-staff-yellow-brown.webp",
+	"name": "Ability Score Improvement (Cha)",
+	"origin": "Compendium.shadowdark.magic-items.Item.EKLviLxm9xcL9iWc",
+	"showIcon": 1,
+	"start": null,
+	"statuses": [
+	],
+	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.cha.value",
+				"phase": "initial",
+				"priority": 20,
+				"type": "add",
+				"value": 2
+			}
+		]
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/ability_score_improvement__str___ax8eSknJxKU2pBKJ.json
+++ b/data/packs/magic-items.db/ability_score_improvement__str___ax8eSknJxKU2pBKJ.json
@@ -1,0 +1,36 @@
+{
+	"_id": "ax8eSknJxKU2pBKJ",
+	"_key": "!items.effects!EKLviLxm9xcL9iWc.ax8eSknJxKU2pBKJ",
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
+	},
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/skills/melee/hand-grip-staff-yellow-brown.webp",
+	"name": "Ability Score Improvement (Str)",
+	"origin": "Compendium.shadowdark.magic-items.Item.EKLviLxm9xcL9iWc",
+	"showIcon": 1,
+	"start": null,
+	"statuses": [
+	],
+	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.str.value",
+				"phase": "initial",
+				"priority": 20,
+				"type": "add",
+				"value": 2
+			}
+		]
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/ac_bonus__SRuuhmxcNFfK8yUo.json
+++ b/data/packs/magic-items.db/ac_bonus__SRuuhmxcNFfK8yUo.json
@@ -1,27 +1,32 @@
 {
 	"_id": "SRuuhmxcNFfK8yUo",
 	"_key": "!items.effects!fntDmrpNulld7y2r.SRuuhmxcNFfK8yUo",
-	"changes": [
-		{
-			"key": "system.attributes.ac.value",
-			"mode": 2,
-			"value": "1"
-		}
-	],
 	"description": "AC Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/shield-block-gray-orange.webp",
 	"name": "AC Bonus",
 	"origin": "Item.a9GWLEEGCKGrtN6D",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.attributes.ac.value",
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/ac_bonus__UmHdci1cvynol7xU.json
+++ b/data/packs/magic-items.db/ac_bonus__UmHdci1cvynol7xU.json
@@ -1,29 +1,32 @@
 {
 	"_id": "UmHdci1cvynol7xU",
 	"_key": "!items.effects!LhREsz1KVI5yuEwM.UmHdci1cvynol7xU",
-	"changes": [
-		{
-			"key": "system.attributes.ac.value",
-			"mode": 2,
-			"value": "2"
-		}
-	],
 	"description": "AC Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/shield-block-gray-orange.webp",
 	"name": "AC Bonus",
 	"origin": "Item.hIWLvLNP6JWumyrw",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.attributes.ac.value",
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/ac_bonus__naxiMCPRWIxWceVj.json
+++ b/data/packs/magic-items.db/ac_bonus__naxiMCPRWIxWceVj.json
@@ -1,27 +1,32 @@
 {
 	"_id": "naxiMCPRWIxWceVj",
 	"_key": "!items.effects!8RyBRclanxBD4pMx.naxiMCPRWIxWceVj",
-	"changes": [
-		{
-			"key": "system.attributes.ac.value",
-			"mode": 2,
-			"value": "1"
-		}
-	],
 	"description": "AC Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/shield-block-gray-orange.webp",
 	"name": "AC Bonus",
 	"origin": "Item.lIQyD40OcRKVneot",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.attributes.ac.value",
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/additional_gear_slots__MquW5uUJ7QQO7eFk.json
+++ b/data/packs/magic-items.db/additional_gear_slots__MquW5uUJ7QQO7eFk.json
@@ -1,33 +1,33 @@
 {
 	"_id": "MquW5uUJ7QQO7eFk",
 	"_key": "!items.effects!vHwzxeO0sX9GlRbj.MquW5uUJ7QQO7eFk",
-	"changes": [
-		{
-			"key": "system.slots",
-			"mode": 2,
-			"priority": null,
-			"value": "10"
-		}
-	],
 	"description": "Additional Gear Slots",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/defensive/shield-barrier-deflect-teal.webp",
 	"name": "Additional Gear Slots",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.slots",
+				"priority": null,
+				"type": "add",
+				"value": 10
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/advantage_on_attacks_vs_undead__CcqfuguaihVg3TY3.json
+++ b/data/packs/magic-items.db/advantage_on_attacks_vs_undead__CcqfuguaihVg3TY3.json
@@ -1,36 +1,36 @@
 {
 	"_id": "CcqfuguaihVg3TY3",
 	"_key": "!items.effects!SuPwL1LQKe8DdaRq.CcqfuguaihVg3TY3",
-	"changes": [
-		{
-			"key": "system.roll.melee.advantage.this",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "Advantage on attacks vs Undead",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 		"shadowdark": {
 			"situational": true
 		}
 	},
+	"folder": null,
 	"img": "icons/commodities/tech/cog-steel-grey.webp",
 	"name": "Advantage on attacks vs Undead",
 	"origin": "Compendium.shadowdark.magic-items.Item.SuPwL1LQKe8DdaRq",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.melee.advantage.this",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/advantage_vs_poison__Jezaa6jJyGQpprzu.json
+++ b/data/packs/magic-items.db/advantage_vs_poison__Jezaa6jJyGQpprzu.json
@@ -1,36 +1,36 @@
 {
 	"_id": "Jezaa6jJyGQpprzu",
 	"_key": "!items.effects!MyHXrPewu36OmWB6.Jezaa6jJyGQpprzu",
-	"changes": [
-		{
-			"key": "system.roll.stat.advantage.con",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "Advantage vs Poison",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 		"shadowdark": {
 			"situational": true
 		}
 	},
+	"folder": null,
 	"img": "icons/commodities/tech/cog-steel-grey.webp",
 	"name": "Advantage vs Poison",
 	"origin": "Compendium.shadowdark.magic-items.Item.MyHXrPewu36OmWB6",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.stat.advantage.con",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/advantage_vs_unnatural_creatures___outsiders__6mClhm9ShmrgbUEL.json
+++ b/data/packs/magic-items.db/advantage_vs_unnatural_creatures___outsiders__6mClhm9ShmrgbUEL.json
@@ -1,36 +1,36 @@
 {
 	"_id": "6mClhm9ShmrgbUEL",
 	"_key": "!items.effects!DtswEluGPMrFpzW1.6mClhm9ShmrgbUEL",
-	"changes": [
-		{
-			"key": "system.roll.ranged.advantage.this",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "Advantage on attacks vs unnatural creatures and outsiders",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 		"shadowdark": {
 			"situational": true
 		}
 	},
+	"folder": null,
 	"img": "icons/commodities/tech/cog-steel-grey.webp",
 	"name": "Advantage vs Unnatural Creatures & Outsiders",
 	"origin": "Compendium.shadowdark.magic-items.Item.DtswEluGPMrFpzW1",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.ranged.advantage.this",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/attack_damage_bonus__78SoFRRmEjEMdPIT.json
+++ b/data/packs/magic-items.db/attack_damage_bonus__78SoFRRmEjEMdPIT.json
@@ -1,33 +1,33 @@
 {
 	"_id": "78SoFRRmEjEMdPIT",
 	"_key": "!items.effects!ZamB6OED5J1EeU81.78SoFRRmEjEMdPIT",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 2,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Attack Damage Bonus",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/attack_damage_bonus__FqtIDxjhOFDvkQFn.json
+++ b/data/packs/magic-items.db/attack_damage_bonus__FqtIDxjhOFDvkQFn.json
@@ -1,33 +1,33 @@
 {
 	"_id": "FqtIDxjhOFDvkQFn",
 	"_key": "!items.effects!jEeDexWHYy7wKsfa.FqtIDxjhOFDvkQFn",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Attack Damage Bonus",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/attack_damage_bonus__JAfTcoh8jcncSGJM.json
+++ b/data/packs/magic-items.db/attack_damage_bonus__JAfTcoh8jcncSGJM.json
@@ -1,33 +1,33 @@
 {
 	"_id": "JAfTcoh8jcncSGJM",
 	"_key": "!items.effects!98cxnRdtTLv0Onka.JAfTcoh8jcncSGJM",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Attack Damage Bonus",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/attack_roll_bonus__4QneUXW9pG2CMpKS.json
+++ b/data/packs/magic-items.db/attack_roll_bonus__4QneUXW9pG2CMpKS.json
@@ -1,33 +1,33 @@
 {
 	"_id": "4QneUXW9pG2CMpKS",
 	"_key": "!items.effects!98cxnRdtTLv0Onka.4QneUXW9pG2CMpKS",
-	"changes": [
-		{
-			"key": "system.roll.attack.bonus.this",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Attack Roll Bonus",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.this",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/attack_roll_bonus__9qMTrleWtCMKO3Xl.json
+++ b/data/packs/magic-items.db/attack_roll_bonus__9qMTrleWtCMKO3Xl.json
@@ -1,33 +1,33 @@
 {
 	"_id": "9qMTrleWtCMKO3Xl",
 	"_key": "!items.effects!ZamB6OED5J1EeU81.9qMTrleWtCMKO3Xl",
-	"changes": [
-		{
-			"key": "system.roll.attack.bonus.this",
-			"mode": 2,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Attack Roll Bonus",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.this",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/attack_roll_bonus__HhILvM8lD0Nby5gq.json
+++ b/data/packs/magic-items.db/attack_roll_bonus__HhILvM8lD0Nby5gq.json
@@ -1,33 +1,33 @@
 {
 	"_id": "HhILvM8lD0Nby5gq",
 	"_key": "!items.effects!jEeDexWHYy7wKsfa.HhILvM8lD0Nby5gq",
-	"changes": [
-		{
-			"key": "system.roll.attack.bonus.this",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Attack Roll Bonus",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.this",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/axe_of_nine_eyes__qk4oabtNkR319n90.json
+++ b/data/packs/magic-items.db/axe_of_nine_eyes__qk4oabtNkR319n90.json
@@ -1,0 +1,53 @@
+{
+	"_id": "qk4oabtNkR319n90",
+	"_key": "!items!qk4oabtNkR319n90",
+	"effects": [
+		"JJyBMwRca7dp4Ou7",
+		"NT3qgLk6YxG8dQuv"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/axes/axe-battle-worn-eye.webp",
+	"name": "Axe of Nine Eyes",
+	"system": {
+		"ammoClass": "",
+		"baseWeapon": "greataxe",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"damage": {
+			"oneHanded": "d8",
+			"twoHanded": "d10"
+		},
+		"description": "<p><em>A silvery, +1 greataxe with nine open eyes engraved on its blade. Its wielder can learn the </em>@UUID[Compendium.shadowdark.magic-items.Item.gNah418e2ykhDWDE]{True Name} <em>of up to 9 creatures total. An eye closes each time this is used.</em></p>",
+		"equipped": false,
+		"handedness": "",
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": ""
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.qEIYaQ9j2EUmSrx6"
+		],
+		"quantity": 1,
+		"range": "close",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 2
+		},
+		"source": {
+			"title": "cursed-scroll-3"
+		},
+		"stashed": false,
+		"type": "melee"
+	},
+	"type": "Weapon"
+}

--- a/data/packs/magic-items.db/bonus_to_control_water__0SIRUg3EWmVGZkBZ.json
+++ b/data/packs/magic-items.db/bonus_to_control_water__0SIRUg3EWmVGZkBZ.json
@@ -1,36 +1,36 @@
 {
 	"_id": "0SIRUg3EWmVGZkBZ",
 	"_key": "!items.effects!REKbDm3ShTNQouM2.0SIRUg3EWmVGZkBZ",
-	"changes": [
-		{
-			"key": "system.roll.spell.bonus.control-water",
-			"mode": 2,
-			"priority": null,
-			"value": "4"
-		}
-	],
 	"description": "+4 to control water spellcasting checks (1/day)",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 		"shadowdark": {
 			"situational": true
 		}
 	},
+	"folder": null,
 	"img": "icons/commodities/tech/cog-steel-grey.webp",
 	"name": "Bonus to Control Water",
 	"origin": "Compendium.shadowdark.magic-items.Item.REKbDm3ShTNQouM2",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.spell.bonus.control-water",
+				"priority": null,
+				"type": "add",
+				"value": 4
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/cloven_heart__EKLviLxm9xcL9iWc.json
+++ b/data/packs/magic-items.db/cloven_heart__EKLviLxm9xcL9iWc.json
@@ -1,0 +1,53 @@
+{
+	"_id": "EKLviLxm9xcL9iWc",
+	"_key": "!items!EKLviLxm9xcL9iWc",
+	"effects": [
+		"ax8eSknJxKU2pBKJ",
+		"oHRtAdI8eDjSMzju"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/commodities/gems/gem-rough-can-red.webp",
+	"name": "Cloven Heart",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p><em>Heart-shaped, glittering ruby with crack down center.</em></p><p><strong>Benefit. </strong>Grants owner immunity to fire, +2 STR, +2 CHA, and the enmity of the dralech, Tzakoru, who wants it back.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": ""
+		},
+		"isAmmunition": false,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "cursed-scroll-1"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/critical_failure_threshold__UojiuFQ7ufucHAMl.json
+++ b/data/packs/magic-items.db/critical_failure_threshold__UojiuFQ7ufucHAMl.json
@@ -1,33 +1,33 @@
 {
 	"_id": "UojiuFQ7ufucHAMl",
 	"_key": "!items.effects!w3UsdCcYKnwcAgbH.UojiuFQ7ufucHAMl",
-	"changes": [
-		{
-			"key": "system.roll.attack.critical-failure.all",
-			"mode": 5,
-			"priority": null,
-			"value": "3"
-		}
-	],
 	"description": "Critical Failure Threshold",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/life/cross-area-circle-green-white.webp",
 	"name": "Critical Failure Threshold",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.critical-failure.all",
+				"priority": null,
+				"type": "override",
+				"value": 3
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/critical_multiplier__2NdFJHTHy28UaTCh.json
+++ b/data/packs/magic-items.db/critical_multiplier__2NdFJHTHy28UaTCh.json
@@ -1,33 +1,33 @@
 {
 	"_id": "2NdFJHTHy28UaTCh",
 	"_key": "!items.effects!Mb7OBENXa5XnClS9.2NdFJHTHy28UaTCh",
-	"changes": [
-		{
-			"key": "system.roll.attack.critical-multiplier.this",
-			"mode": 5,
-			"priority": null,
-			"value": "4"
-		}
-	],
 	"description": "Critical Multiplier",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/hand-grip-staff-yellow-brown.webp",
 	"name": "Critical Multiplier",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.critical-multiplier.this",
+				"priority": null,
+				"type": "override",
+				"value": 4
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/critical_success_threshold__b7lXcLAavPlpMhqp.json
+++ b/data/packs/magic-items.db/critical_success_threshold__b7lXcLAavPlpMhqp.json
@@ -1,33 +1,33 @@
 {
 	"_id": "b7lXcLAavPlpMhqp",
 	"_key": "!items.effects!w3UsdCcYKnwcAgbH.b7lXcLAavPlpMhqp",
-	"changes": [
-		{
-			"key": "system.roll.attack.critical-success.all",
-			"mode": 5,
-			"priority": null,
-			"value": "18"
-		}
-	],
 	"description": "Critical Success Threshold",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/fire/flame-burning-fist-strike.webp",
 	"name": "Critical Success Threshold",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.critical-success.all",
+				"priority": null,
+				"type": "override",
+				"value": 18
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/disadvantage_on_attacks___spellcasting_vs_demons__phVQo5ikKtoR4emZ.json
+++ b/data/packs/magic-items.db/disadvantage_on_attacks___spellcasting_vs_demons__phVQo5ikKtoR4emZ.json
@@ -1,48 +1,48 @@
 {
 	"_id": "phVQo5ikKtoR4emZ",
 	"_key": "!items.effects!hcC1kuGgQ2VdnHmj.phVQo5ikKtoR4emZ",
-	"changes": [
-		{
-			"key": "system.roll.melee.advantage.all",
-			"mode": 2,
-			"priority": null,
-			"value": "-1"
-		},
-		{
-			"key": "system.roll.ranged.advantage.all",
-			"mode": 2,
-			"priority": null,
-			"value": "-1"
-		},
-		{
-			"key": "system.roll.spell.advantage.all",
-			"mode": 2,
-			"priority": null,
-			"value": "-1"
-		}
-	],
 	"description": "Disadvantage on Attacks &amp; Spellcasting vs Demons",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 		"shadowdark": {
 			"situational": true
 		}
 	},
+	"folder": null,
 	"img": "icons/commodities/tech/cog-steel-grey.webp",
 	"name": "Disadvantage on Attacks & Spellcasting vs Demons",
 	"origin": "Compendium.shadowdark.magic-items.Item.hcC1kuGgQ2VdnHmj",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.melee.advantage.all",
+				"priority": null,
+				"type": "add",
+				"value": -1
+			},
+			{
+				"key": "system.roll.ranged.advantage.all",
+				"priority": null,
+				"type": "add",
+				"value": -1
+			},
+			{
+				"key": "system.roll.spell.advantage.all",
+				"priority": null,
+				"type": "add",
+				"value": -1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/disadvantage_on_attacks___spells_vs_snakes__gKzyPrgEBI8O9NXr.json
+++ b/data/packs/magic-items.db/disadvantage_on_attacks___spells_vs_snakes__gKzyPrgEBI8O9NXr.json
@@ -1,48 +1,48 @@
 {
 	"_id": "gKzyPrgEBI8O9NXr",
 	"_key": "!items.effects!EiyxS6MOvGlZgG65.gKzyPrgEBI8O9NXr",
-	"changes": [
-		{
-			"key": "system.roll.melee.advantage.all",
-			"mode": 2,
-			"priority": null,
-			"value": "-1"
-		},
-		{
-			"key": "system.roll.ranged.advantage.all",
-			"mode": 2,
-			"priority": null,
-			"value": "-1"
-		},
-		{
-			"key": "system.roll.spell.advantage.all",
-			"mode": 2,
-			"priority": null,
-			"value": "-1"
-		}
-	],
 	"description": "Disadvantage on attacks and hostile spells targeting snakes",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 		"shadowdark": {
 			"situational": true
 		}
 	},
+	"folder": null,
 	"img": "icons/commodities/tech/cog-steel-grey.webp",
 	"name": "Disadvantage on Attacks & Spells vs Snakes",
 	"origin": "Compendium.shadowdark.magic-items.Item.EiyxS6MOvGlZgG65",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.melee.advantage.all",
+				"priority": null,
+				"type": "add",
+				"value": -1
+			},
+			{
+				"key": "system.roll.ranged.advantage.all",
+				"priority": null,
+				"type": "add",
+				"value": -1
+			},
+			{
+				"key": "system.roll.spell.advantage.all",
+				"priority": null,
+				"type": "add",
+				"value": -1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/double_damage_vs_demons__devils____undead__us7NkXHO8GnlNAiE.json
+++ b/data/packs/magic-items.db/double_damage_vs_demons__devils____undead__us7NkXHO8GnlNAiE.json
@@ -1,36 +1,36 @@
 {
 	"_id": "us7NkXHO8GnlNAiE",
 	"_key": "!items.effects!MgWPwzNTzC7cPi7H.us7NkXHO8GnlNAiE",
-	"changes": [
-		{
-			"key": "system.roll.spell.advantage.all",
-			"mode": 2,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "Double Damage vs Demons, Devils &amp;  Undead",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 		"shadowdark": {
 			"situational": true
 		}
 	},
+	"folder": null,
 	"img": "icons/commodities/tech/cog-steel-grey.webp",
 	"name": "Double Damage vs Demons, Devils &  Undead",
 	"origin": "Compendium.shadowdark.magic-items.Item.MgWPwzNTzC7cPi7H",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.spell.advantage.all",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/double_damage_vs_giants__12wqYPS5nYdD0srs.json
+++ b/data/packs/magic-items.db/double_damage_vs_giants__12wqYPS5nYdD0srs.json
@@ -1,36 +1,36 @@
 {
 	"_id": "12wqYPS5nYdD0srs",
 	"_key": "!items.effects!EBfBPArPRSyLXFPM.12wqYPS5nYdD0srs",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 1,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "Double Damage vs Giants",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 		"shadowdark": {
 			"situational": true
 		}
 	},
+	"folder": null,
 	"img": "icons/commodities/tech/cog-steel-grey.webp",
 	"name": "Double Damage vs Giants",
 	"origin": "Compendium.shadowdark.magic-items.Item.EBfBPArPRSyLXFPM",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"priority": null,
+				"type": "multiply",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/double_damage_vs_giants__GH1P7tijaj5st9hm.json
+++ b/data/packs/magic-items.db/double_damage_vs_giants__GH1P7tijaj5st9hm.json
@@ -1,33 +1,33 @@
 {
 	"_id": "GH1P7tijaj5st9hm",
 	"_key": "!items.effects!FqhEJHkaKd0emTzn.GH1P7tijaj5st9hm",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 1,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "Double Damage vs Giants",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/commodities/tech/cog-steel-grey.webp",
 	"name": "Double Damage vs Giants",
 	"origin": "Compendium.shadowdark.magic-items.Item.FqhEJHkaKd0emTzn",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"priority": null,
+				"type": "multiply",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/double_damage_vs_lycanthropes__G7VI8iNu9to3a2iz.json
+++ b/data/packs/magic-items.db/double_damage_vs_lycanthropes__G7VI8iNu9to3a2iz.json
@@ -1,36 +1,36 @@
 {
 	"_id": "G7VI8iNu9to3a2iz",
 	"_key": "!items.effects!bpJlJ3vnZVmvOEJV.G7VI8iNu9to3a2iz",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 1,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "Double Damage vs Lycanthropes",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 		"shadowdark": {
 			"situational": true
 		}
 	},
+	"folder": null,
 	"img": "icons/commodities/tech/cog-steel-grey.webp",
 	"name": "Double Damage vs Lycanthropes",
 	"origin": "Compendium.shadowdark.magic-items.Item.bpJlJ3vnZVmvOEJV",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"priority": null,
+				"type": "multiply",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/emerald_blade__tVMll4MiliOXbg0i.json
+++ b/data/packs/magic-items.db/emerald_blade__tVMll4MiliOXbg0i.json
@@ -1,0 +1,53 @@
+{
+	"_id": "tVMll4MiliOXbg0i",
+	"_key": "!items!tVMll4MiliOXbg0i",
+	"effects": [
+		"A9BPMWmWpSXDGqYI",
+		"XxQ6F27a8mmAtDxN"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/swords/sword-guard-serrated.webp",
+	"name": "Emerald Blade",
+	"system": {
+		"ammoClass": "",
+		"baseWeapon": "bastard-sword",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"damage": {
+			"oneHanded": "d8",
+			"twoHanded": "d10"
+		},
+		"description": "<p><em>A +2 bastard sword that allows its wielder to speak to wild animals.</em></p><p><strong>Bonus. </strong>+2 bastard sword.</p><p><strong>Benefit. </strong>Allows its wielder to speak to wild animals</p>",
+		"equipped": false,
+		"handedness": "",
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": ""
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.qEIYaQ9j2EUmSrx6"
+		],
+		"quantity": 1,
+		"range": "close",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 2
+		},
+		"source": {
+			"title": "cursed-scroll-1"
+		},
+		"stashed": false,
+		"type": "melee"
+	},
+	"type": "Weapon"
+}

--- a/data/packs/magic-items.db/holy_prayer_ac_bonus__G5THNKdzVuAqhJ5Q.json
+++ b/data/packs/magic-items.db/holy_prayer_ac_bonus__G5THNKdzVuAqhJ5Q.json
@@ -1,36 +1,36 @@
 {
 	"_id": "G5THNKdzVuAqhJ5Q",
 	"_key": "!items.effects!8RyBRclanxBD4pMx.G5THNKdzVuAqhJ5Q",
-	"changes": [
-		{
-			"key": "system.attributes.ac.value",
-			"mode": 2,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "+2 AC for 3 rounds after speaking a holy prayer (1/day)",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 		"shadowdark": {
 			"situational": true
 		}
 	},
+	"folder": null,
 	"img": "icons/commodities/tech/cog-steel-grey.webp",
 	"name": "Holy Prayer AC Bonus",
 	"origin": "Compendium.shadowdark.magic-items.Item.8RyBRclanxBD4pMx",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.attributes.ac.value",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/jelly_orb__ooRnPCC8FCCVgvJN.json
+++ b/data/packs/magic-items.db/jelly_orb__ooRnPCC8FCCVgvJN.json
@@ -1,0 +1,51 @@
+{
+	"_id": "ooRnPCC8FCCVgvJN",
+	"_key": "!items!ooRnPCC8FCCVgvJN",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/commodities/materials/slime-thick-blue.webp",
+	"name": "Jelly Orb",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p>Edible slime ball, breathe underwater for 1 hour</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": ""
+		},
+		"isAmmunition": false,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "cursed-scroll-3"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/jotunblad__eqUuf9OGupuGPsBM.json
+++ b/data/packs/magic-items.db/jotunblad__eqUuf9OGupuGPsBM.json
@@ -1,0 +1,53 @@
+{
+	"_id": "eqUuf9OGupuGPsBM",
+	"_key": "!items!eqUuf9OGupuGPsBM",
+	"effects": [
+		"zQd4dPnp6pqJ28Kc",
+		"L8qZFZFh4n57A3BT"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/swords/greatsword-crossguard-curved.webp",
+	"name": "Jotunblad",
+	"system": {
+		"ammoClass": "",
+		"baseWeapon": "greatsword",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 12,
+			"sp": 0
+		},
+		"damage": {
+			"oneHanded": "",
+			"twoHanded": "d12"
+		},
+		"description": "<p>A green-hued +2 greatsword.</p>",
+		"equipped": false,
+		"handedness": "",
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": ""
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.b6Gm2ULKj2qyy2xJ"
+		],
+		"quantity": 1,
+		"range": "close",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 2
+		},
+		"source": {
+			"title": "cursed-scroll-3"
+		},
+		"stashed": false,
+		"type": "melee"
+	},
+	"type": "Weapon"
+}

--- a/data/packs/magic-items.db/melee_attack_roll_bonus__HcunJo9lsdxtj8p8.json
+++ b/data/packs/magic-items.db/melee_attack_roll_bonus__HcunJo9lsdxtj8p8.json
@@ -1,0 +1,35 @@
+{
+	"_id": "HcunJo9lsdxtj8p8",
+	"_key": "!items.effects!NN8q2aJgmedMfrnm.HcunJo9lsdxtj8p8",
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
+	},
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Melee Attack Roll Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.NN8q2aJgmedMfrnm",
+	"showIcon": 1,
+	"start": null,
+	"statuses": [
+	],
+	"system": {
+		"changes": [
+			{
+				"key": "system.roll.melee.bonus.all",
+				"phase": "initial",
+				"type": "add",
+				"value": 1
+			}
+		]
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/melee_attack_roll_bonus__JJyBMwRca7dp4Ou7.json
+++ b/data/packs/magic-items.db/melee_attack_roll_bonus__JJyBMwRca7dp4Ou7.json
@@ -1,0 +1,35 @@
+{
+	"_id": "JJyBMwRca7dp4Ou7",
+	"_key": "!items.effects!qk4oabtNkR319n90.JJyBMwRca7dp4Ou7",
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
+	},
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Melee Attack Roll Bonus",
+	"origin": "Item.qk4oabtNkR319n90",
+	"showIcon": 1,
+	"start": null,
+	"statuses": [
+	],
+	"system": {
+		"changes": [
+			{
+				"key": "system.roll.melee.bonus.all",
+				"phase": "initial",
+				"type": "add",
+				"value": 1
+			}
+		]
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/melee_attack_roll_bonus__xwiRD5vkzpmFn4Sd.json
+++ b/data/packs/magic-items.db/melee_attack_roll_bonus__xwiRD5vkzpmFn4Sd.json
@@ -1,0 +1,35 @@
+{
+	"_id": "xwiRD5vkzpmFn4Sd",
+	"_key": "!items.effects!XaQsvwnvOk3TAZnN.xwiRD5vkzpmFn4Sd",
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
+	},
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Melee Attack Roll Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.XaQsvwnvOk3TAZnN",
+	"showIcon": 1,
+	"start": null,
+	"statuses": [
+	],
+	"system": {
+		"changes": [
+			{
+				"key": "system.roll.melee.bonus.all",
+				"phase": "initial",
+				"type": "add",
+				"value": 1
+			}
+		]
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/melee_attack_roll_bonus__zQd4dPnp6pqJ28Kc.json
+++ b/data/packs/magic-items.db/melee_attack_roll_bonus__zQd4dPnp6pqJ28Kc.json
@@ -1,0 +1,36 @@
+{
+	"_id": "zQd4dPnp6pqJ28Kc",
+	"_key": "!items.effects!eqUuf9OGupuGPsBM.zQd4dPnp6pqJ28Kc",
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
+	},
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Melee Attack Roll Bonus",
+	"origin": "Item.eqUuf9OGupuGPsBM",
+	"showIcon": 1,
+	"start": null,
+	"statuses": [
+	],
+	"system": {
+		"changes": [
+			{
+				"key": "system.roll.melee.bonus.all",
+				"phase": "initial",
+				"priority": 20,
+				"type": "add",
+				"value": 2
+			}
+		]
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/melee_damage_bonus__5iAPSMbm5EclVkse.json
+++ b/data/packs/magic-items.db/melee_damage_bonus__5iAPSMbm5EclVkse.json
@@ -1,0 +1,35 @@
+{
+	"_id": "5iAPSMbm5EclVkse",
+	"_key": "!items.effects!NN8q2aJgmedMfrnm.5iAPSMbm5EclVkse",
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
+	},
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/skills/melee/strike-axe-blood-red.webp",
+	"name": "Melee Damage Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.NN8q2aJgmedMfrnm",
+	"showIcon": 1,
+	"start": null,
+	"statuses": [
+	],
+	"system": {
+		"changes": [
+			{
+				"key": "system.roll.melee.damage.all",
+				"phase": "initial",
+				"type": "add",
+				"value": 1
+			}
+		]
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/melee_damage_bonus__L8qZFZFh4n57A3BT.json
+++ b/data/packs/magic-items.db/melee_damage_bonus__L8qZFZFh4n57A3BT.json
@@ -1,0 +1,36 @@
+{
+	"_id": "L8qZFZFh4n57A3BT",
+	"_key": "!items.effects!eqUuf9OGupuGPsBM.L8qZFZFh4n57A3BT",
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
+	},
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/skills/melee/strike-axe-blood-red.webp",
+	"name": "Melee Damage Bonus",
+	"origin": "Item.eqUuf9OGupuGPsBM",
+	"showIcon": 1,
+	"start": null,
+	"statuses": [
+	],
+	"system": {
+		"changes": [
+			{
+				"key": "system.roll.melee.damage.all",
+				"phase": "initial",
+				"priority": 20,
+				"type": "add",
+				"value": 2
+			}
+		]
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/melee_damage_bonus__NT3qgLk6YxG8dQuv.json
+++ b/data/packs/magic-items.db/melee_damage_bonus__NT3qgLk6YxG8dQuv.json
@@ -1,0 +1,35 @@
+{
+	"_id": "NT3qgLk6YxG8dQuv",
+	"_key": "!items.effects!qk4oabtNkR319n90.NT3qgLk6YxG8dQuv",
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
+	},
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/skills/melee/strike-axe-blood-red.webp",
+	"name": "Melee Damage Bonus",
+	"origin": "Item.qk4oabtNkR319n90",
+	"showIcon": 1,
+	"start": null,
+	"statuses": [
+	],
+	"system": {
+		"changes": [
+			{
+				"key": "system.roll.melee.damage.all",
+				"phase": "initial",
+				"type": "add",
+				"value": 1
+			}
+		]
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/melee_damage_bonus__SzyJeSkWrWDD64zP.json
+++ b/data/packs/magic-items.db/melee_damage_bonus__SzyJeSkWrWDD64zP.json
@@ -1,27 +1,32 @@
 {
 	"_id": "SzyJeSkWrWDD64zP",
 	"_key": "!items.effects!hcC1kuGgQ2VdnHmj.SzyJeSkWrWDD64zP",
-	"changes": [
-		{
-			"key": "system.roll.melee.damage.all",
-			"mode": 2,
-			"value": "1"
-		}
-	],
 	"description": "Melee Damage Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-axe-blood-red.webp",
 	"name": "Melee Damage Bonus",
 	"origin": "Compendium.shadowdark.magic-items.Item.hcC1kuGgQ2VdnHmj",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.melee.damage.all",
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/melee_damage_bonus__u9KcTSUxAz4Tz9zg.json
+++ b/data/packs/magic-items.db/melee_damage_bonus__u9KcTSUxAz4Tz9zg.json
@@ -1,0 +1,35 @@
+{
+	"_id": "u9KcTSUxAz4Tz9zg",
+	"_key": "!items.effects!XaQsvwnvOk3TAZnN.u9KcTSUxAz4Tz9zg",
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
+	},
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/skills/melee/strike-axe-blood-red.webp",
+	"name": "Melee Damage Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.XaQsvwnvOk3TAZnN",
+	"showIcon": 1,
+	"start": null,
+	"statuses": [
+	],
+	"system": {
+		"changes": [
+			{
+				"key": "system.roll.melee.damage.all",
+				"phase": "initial",
+				"type": "add",
+				"value": 1
+			}
+		]
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/permanent_ability__cha___07RIJ800mgt95fNl.json
+++ b/data/packs/magic-items.db/permanent_ability__cha___07RIJ800mgt95fNl.json
@@ -1,33 +1,33 @@
 {
 	"_id": "07RIJ800mgt95fNl",
 	"_key": "!items.effects!ZypO4jCOurSK2aOB.07RIJ800mgt95fNl",
-	"changes": [
-		{
-			"key": "system.abilities.cha.value",
-			"mode": 5,
-			"priority": null,
-			"value": "18"
-		}
-	],
 	"description": "Permanent Ability (Cha)",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-axe-blood-red.webp",
 	"name": "Permanent Ability (Cha)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.cha.value",
+				"priority": null,
+				"type": "override",
+				"value": 18
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/permanent_ability__cha___MN2vxYiGWgfQSbpi.json
+++ b/data/packs/magic-items.db/permanent_ability__cha___MN2vxYiGWgfQSbpi.json
@@ -1,27 +1,32 @@
 {
 	"_id": "MN2vxYiGWgfQSbpi",
 	"_key": "!items.effects!Bm8NbNaVH1pUerSh.MN2vxYiGWgfQSbpi",
-	"changes": [
-		{
-			"key": "system.abilities.cha.value",
-			"mode": 5,
-			"value": "18"
-		}
-	],
 	"description": "Permanent Ability (Cha)",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-axe-blood-red.webp",
 	"name": "Permanent Ability (Cha)",
 	"origin": "Compendium.shadowdark.magic-items.Item.Bm8NbNaVH1pUerSh",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.cha.value",
+				"type": "override",
+				"value": 18
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/permanent_ability__con___s6ifDUJHIkwx5wvx.json
+++ b/data/packs/magic-items.db/permanent_ability__con___s6ifDUJHIkwx5wvx.json
@@ -1,27 +1,32 @@
 {
 	"_id": "s6ifDUJHIkwx5wvx",
 	"_key": "!items.effects!qHyL2dlqQaxwMzKX.s6ifDUJHIkwx5wvx",
-	"changes": [
-		{
-			"key": "system.abilities.con.value",
-			"mode": 5,
-			"value": "18"
-		}
-	],
 	"description": "Permanent Ability (Con)",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-axe-blood-red.webp",
 	"name": "Permanent Ability (Con)",
 	"origin": "Compendium.shadowdark.magic-items.Item.qHyL2dlqQaxwMzKX",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.con.value",
+				"type": "override",
+				"value": 18
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/permanent_ability__con___zrPgEyvt0Qpp6rca.json
+++ b/data/packs/magic-items.db/permanent_ability__con___zrPgEyvt0Qpp6rca.json
@@ -1,33 +1,33 @@
 {
 	"_id": "zrPgEyvt0Qpp6rca",
 	"_key": "!items.effects!7pECwim9a2CVzFLy.zrPgEyvt0Qpp6rca",
-	"changes": [
-		{
-			"key": "system.abilities.con.value",
-			"mode": 5,
-			"priority": null,
-			"value": "18"
-		}
-	],
 	"description": "Permanent Ability (Con)",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-axe-blood-red.webp",
 	"name": "Permanent Ability (Con)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.con.value",
+				"priority": null,
+				"type": "override",
+				"value": 18
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/permanent_ability__dex___2iAdf3ZD4FdzPonT.json
+++ b/data/packs/magic-items.db/permanent_ability__dex___2iAdf3ZD4FdzPonT.json
@@ -1,33 +1,33 @@
 {
 	"_id": "2iAdf3ZD4FdzPonT",
 	"_key": "!items.effects!lUuyDaiDHJbDg82j.2iAdf3ZD4FdzPonT",
-	"changes": [
-		{
-			"key": "system.abilities.dex.value",
-			"mode": 5,
-			"priority": null,
-			"value": "18"
-		}
-	],
 	"description": "Permanent Ability (Dex)",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-axe-blood-red.webp",
 	"name": "Permanent Ability (Dex)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.dex.value",
+				"priority": null,
+				"type": "override",
+				"value": 18
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/permanent_ability__dex___I9RcaNvoUpSqiWUz.json
+++ b/data/packs/magic-items.db/permanent_ability__dex___I9RcaNvoUpSqiWUz.json
@@ -1,27 +1,32 @@
 {
 	"_id": "I9RcaNvoUpSqiWUz",
 	"_key": "!items.effects!Ka1NPr6edk9cwrzo.I9RcaNvoUpSqiWUz",
-	"changes": [
-		{
-			"key": "system.abilities.dex.value",
-			"mode": 5,
-			"value": "18"
-		}
-	],
 	"description": "Permanent Ability (Dex)",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-axe-blood-red.webp",
 	"name": "Permanent Ability (Dex)",
 	"origin": "Compendium.shadowdark.magic-items.Item.Ka1NPr6edk9cwrzo",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.dex.value",
+				"type": "override",
+				"value": 18
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/permanent_ability__int___94JaF8oYeiAAWASd.json
+++ b/data/packs/magic-items.db/permanent_ability__int___94JaF8oYeiAAWASd.json
@@ -1,33 +1,33 @@
 {
 	"_id": "94JaF8oYeiAAWASd",
 	"_key": "!items.effects!K7PJLC0GUhtQ7aX2.94JaF8oYeiAAWASd",
-	"changes": [
-		{
-			"key": "system.abilities.int.value",
-			"mode": 5,
-			"priority": null,
-			"value": "18"
-		}
-	],
 	"description": "Permanent Ability (Int)",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-axe-blood-red.webp",
 	"name": "Permanent Ability (Int)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.int.value",
+				"priority": null,
+				"type": "override",
+				"value": 18
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/permanent_ability__int___fEHEHVFcLflsUsCv.json
+++ b/data/packs/magic-items.db/permanent_ability__int___fEHEHVFcLflsUsCv.json
@@ -1,27 +1,32 @@
 {
 	"_id": "fEHEHVFcLflsUsCv",
 	"_key": "!items.effects!BJ59d0lCvvMKSbu7.fEHEHVFcLflsUsCv",
-	"changes": [
-		{
-			"key": "system.abilities.int.value",
-			"mode": 5,
-			"value": "18"
-		}
-	],
 	"description": "Permanent Ability (Int)",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-axe-blood-red.webp",
 	"name": "Permanent Ability (Int)",
 	"origin": "Compendium.shadowdark.magic-items.Item.BJ59d0lCvvMKSbu7",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.int.value",
+				"type": "override",
+				"value": 18
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/permanent_ability__str___N3a7CEwOlseizR4z.json
+++ b/data/packs/magic-items.db/permanent_ability__str___N3a7CEwOlseizR4z.json
@@ -1,33 +1,33 @@
 {
 	"_id": "N3a7CEwOlseizR4z",
 	"_key": "!items.effects!ZhykyK0shgnyC4Fh.N3a7CEwOlseizR4z",
-	"changes": [
-		{
-			"key": "system.abilities.str.value",
-			"mode": 5,
-			"priority": null,
-			"value": "18"
-		}
-	],
 	"description": "Permanent Ability (Str)",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-axe-blood-red.webp",
 	"name": "Permanent Ability (Str)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.str.value",
+				"priority": null,
+				"type": "override",
+				"value": 18
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/permanent_ability__str___mEwSq29I1Sr8gG2t.json
+++ b/data/packs/magic-items.db/permanent_ability__str___mEwSq29I1Sr8gG2t.json
@@ -1,33 +1,33 @@
 {
 	"_id": "mEwSq29I1Sr8gG2t",
 	"_key": "!items.effects!FWQK9qFGagcEXCq5.mEwSq29I1Sr8gG2t",
-	"changes": [
-		{
-			"key": "system.abilities.str.value",
-			"mode": 5,
-			"priority": null,
-			"value": "18"
-		}
-	],
 	"description": "Permanent Ability (Str)",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-axe-blood-red.webp",
 	"name": "Permanent Ability (Str)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.str.value",
+				"priority": null,
+				"type": "override",
+				"value": 18
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/permanent_ability__wis___FKzhrPnFt0njaDh8.json
+++ b/data/packs/magic-items.db/permanent_ability__wis___FKzhrPnFt0njaDh8.json
@@ -1,27 +1,32 @@
 {
 	"_id": "FKzhrPnFt0njaDh8",
 	"_key": "!items.effects!yE6fl9FlZldHBupD.FKzhrPnFt0njaDh8",
-	"changes": [
-		{
-			"key": "system.abilities.wis.value",
-			"mode": 5,
-			"value": "18"
-		}
-	],
 	"description": "Permanent Ability (Wis)",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-axe-blood-red.webp",
 	"name": "Permanent Ability (Wis)",
 	"origin": "Compendium.shadowdark.magic-items.Item.yE6fl9FlZldHBupD",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.wis.value",
+				"type": "override",
+				"value": 18
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/permanent_ability__wis___cUIGFlc2YR57pzXl.json
+++ b/data/packs/magic-items.db/permanent_ability__wis___cUIGFlc2YR57pzXl.json
@@ -1,33 +1,33 @@
 {
 	"_id": "cUIGFlc2YR57pzXl",
 	"_key": "!items.effects!wrtcUfAY6yXwSqLY.cUIGFlc2YR57pzXl",
-	"changes": [
-		{
-			"key": "system.abilities.wis.value",
-			"mode": 5,
-			"priority": null,
-			"value": "18"
-		}
-	],
 	"description": "Permanent Ability (Wis)",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-axe-blood-red.webp",
 	"name": "Permanent Ability (Wis)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.wis.value",
+				"priority": null,
+				"type": "override",
+				"value": 18
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/permanentability__1sKZFEAOhR1t3W5D.json
+++ b/data/packs/magic-items.db/permanentability__1sKZFEAOhR1t3W5D.json
@@ -1,33 +1,33 @@
 {
 	"_id": "1sKZFEAOhR1t3W5D",
 	"_key": "!items.effects!0Ws5acsixawAITFi.1sKZFEAOhR1t3W5D",
-	"changes": [
-		{
-			"key": "system.abilities.cha.value",
-			"mode": 5,
-			"priority": null,
-			"value": "18"
-		}
-	],
 	"description": "permanentAbility",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-axe-blood-red.webp",
 	"name": "permanentAbility",
 	"origin": "Item.B3iC2SrJAnnNifTE",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.cha.value",
+				"priority": null,
+				"type": "override",
+				"value": 18
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/ranged_attack_roll_bonus__VU4MlhbeYOgPlEke.json
+++ b/data/packs/magic-items.db/ranged_attack_roll_bonus__VU4MlhbeYOgPlEke.json
@@ -1,0 +1,35 @@
+{
+	"_id": "VU4MlhbeYOgPlEke",
+	"_key": "!items.effects!XaQsvwnvOk3TAZnN.VU4MlhbeYOgPlEke",
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
+	},
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
+	"name": "Ranged Attack Roll Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.XaQsvwnvOk3TAZnN",
+	"showIcon": 1,
+	"start": null,
+	"statuses": [
+	],
+	"system": {
+		"changes": [
+			{
+				"key": "system.roll.ranged.bonus.all",
+				"phase": "initial",
+				"type": "add",
+				"value": 1
+			}
+		]
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/ranged_damage_bonus__JUfuu0JhYDQE9QMi.json
+++ b/data/packs/magic-items.db/ranged_damage_bonus__JUfuu0JhYDQE9QMi.json
@@ -1,0 +1,35 @@
+{
+	"_id": "JUfuu0JhYDQE9QMi",
+	"_key": "!items.effects!XaQsvwnvOk3TAZnN.JUfuu0JhYDQE9QMi",
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
+	},
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/skills/melee/strike-axe-blood-red.webp",
+	"name": "Ranged Damage Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.XaQsvwnvOk3TAZnN",
+	"showIcon": 1,
+	"start": null,
+	"statuses": [
+	],
+	"system": {
+		"changes": [
+			{
+				"key": "system.roll.ranged.damage.all",
+				"phase": "initial",
+				"type": "add",
+				"value": 1
+			}
+		]
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/ranged_damage_bonus__yQZ0cvsfdvrSTM4o.json
+++ b/data/packs/magic-items.db/ranged_damage_bonus__yQZ0cvsfdvrSTM4o.json
@@ -1,27 +1,32 @@
 {
 	"_id": "yQZ0cvsfdvrSTM4o",
 	"_key": "!items.effects!j0WXRAkFtjg9LYKS.yQZ0cvsfdvrSTM4o",
-	"changes": [
-		{
-			"key": "system.roll.ranged.damage.all",
-			"mode": 2,
-			"value": "1"
-		}
-	],
 	"description": "Ranged Damage Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-axe-blood-red.webp",
 	"name": "Ranged Damage Bonus",
 	"origin": "Compendium.shadowdark.magic-items.Item.j0WXRAkFtjg9LYKS",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.ranged.damage.all",
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/scroll_of_charm_person__HNh1iCX94vS6JZv2.json
+++ b/data/packs/magic-items.db/scroll_of_charm_person__HNh1iCX94vS6JZv2.json
@@ -1,0 +1,42 @@
+{
+	"_id": "HNh1iCX94vS6JZv2",
+	"_key": "!items!HNh1iCX94vS6JZv2",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/sundries/scrolls/scroll-runed-brown-purple.webp",
+	"name": "Scroll of Charm Person",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p></p><p>@UUID[Compendium.shadowdark.spells.Item.0VCMisYBNpLkx28M]{Charm Person}</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": ""
+		},
+		"isAmmunition": false,
+		"magicItem": false,
+		"properties": [
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "cursed-scroll-1"
+		},
+		"spellUuid": "Compendium.shadowdark.spells.Item.0VCMisYBNpLkx28M",
+		"stashed": false
+	},
+	"type": "Scroll"
+}

--- a/data/packs/magic-items.db/scroll_of_light__i4gJv0503i9kshYC.json
+++ b/data/packs/magic-items.db/scroll_of_light__i4gJv0503i9kshYC.json
@@ -1,0 +1,42 @@
+{
+	"_id": "i4gJv0503i9kshYC",
+	"_key": "!items!i4gJv0503i9kshYC",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/sundries/scrolls/scroll-runed-brown-purple.webp",
+	"name": "Scroll of Light",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p>@UUID[Actor.Xd7wGmvi2Mf7c7z0.Item.QJy9vKkW5A4EdXs2]{Light}</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": ""
+		},
+		"isAmmunition": false,
+		"magicItem": false,
+		"properties": [
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "cursed-scroll-3"
+		},
+		"spellUuid": "Compendium.shadowdark.spells.Item.N4v17mtxJlVBbgpn",
+		"stashed": false
+	},
+	"type": "Scroll"
+}

--- a/data/packs/magic-items.db/scroll_of_protection_from_evil__f8VaY9WgmpJxC1ME.json
+++ b/data/packs/magic-items.db/scroll_of_protection_from_evil__f8VaY9WgmpJxC1ME.json
@@ -1,0 +1,42 @@
+{
+	"_id": "f8VaY9WgmpJxC1ME",
+	"_key": "!items!f8VaY9WgmpJxC1ME",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/sundries/scrolls/scroll-runed-brown-purple.webp",
+	"name": "Scroll of Protection from Evil",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p>@UUID[Compendium.shadowdark.spells.Item.CH5fnXxghhGQlr7h]{Protection from Evil}</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": ""
+		},
+		"isAmmunition": false,
+		"magicItem": false,
+		"properties": [
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "cursed-scroll-3"
+		},
+		"spellUuid": "Compendium.shadowdark.spells.Item.CH5fnXxghhGQlr7h",
+		"stashed": false
+	},
+	"type": "Scroll"
+}

--- a/data/packs/magic-items.db/speak___understand_diabolic__n3Z0tBxloczqrb2w.json
+++ b/data/packs/magic-items.db/speak___understand_diabolic__n3Z0tBxloczqrb2w.json
@@ -1,33 +1,33 @@
 {
 	"_id": "n3Z0tBxloczqrb2w",
 	"_key": "!items.effects!hcC1kuGgQ2VdnHmj.n3Z0tBxloczqrb2w",
-	"changes": [
-		{
-			"key": "system.languages",
-			"mode": 2,
-			"priority": null,
-			"value": "Compendium.shadowdark.languages.Item.b5yBrLaRIl7ZEWKu"
-		}
-	],
 	"description": "Speak &amp; Understand Diabolic",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/commodities/tech/cog-steel-grey.webp",
 	"name": "Speak & Understand Diabolic",
 	"origin": "Item.WQAnfvteIZallISc",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.languages",
+				"priority": null,
+				"type": "add",
+				"value": "Compendium.shadowdark.languages.Item.b5yBrLaRIl7ZEWKu"
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/speak_goblin__kUrrVadALCQYuXNm.json
+++ b/data/packs/magic-items.db/speak_goblin__kUrrVadALCQYuXNm.json
@@ -1,33 +1,33 @@
 {
 	"_id": "kUrrVadALCQYuXNm",
 	"_key": "!items.effects!YITrYmzXxk6Yjxfc.kUrrVadALCQYuXNm",
-	"changes": [
-		{
-			"key": "system.languages",
-			"mode": 2,
-			"priority": null,
-			"value": "Compendium.shadowdark.languages.Item.NN9wFGgwk49oOQeN"
-		}
-	],
 	"description": "Speak Goblin",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/commodities/tech/cog-steel-grey.webp",
 	"name": "Speak Goblin",
 	"origin": "Compendium.shadowdark.magic-items.Item.YITrYmzXxk6Yjxfc",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.languages",
+				"priority": null,
+				"type": "add",
+				"value": "Compendium.shadowdark.languages.Item.NN9wFGgwk49oOQeN"
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/spellcasting_advantage_on_spell__2O1rrQbpFSYKLiI8.json
+++ b/data/packs/magic-items.db/spellcasting_advantage_on_spell__2O1rrQbpFSYKLiI8.json
@@ -1,33 +1,33 @@
 {
 	"_id": "2O1rrQbpFSYKLiI8",
 	"_key": "!items.effects!h2i73FkXUZZybLc1.2O1rrQbpFSYKLiI8",
-	"changes": [
-		{
-			"key": "system.roll.spell.advantage.disintegrate",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "Spellcasting Advantage on Spell",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/air/air-smoke-casting.webp",
 	"name": "Spellcasting Advantage on Spell",
 	"origin": "Compendium.shadowdark.magic-items.Item.h2i73FkXUZZybLc1",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.spell.advantage.disintegrate",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/spellcasting_advantage_on_spell__BR7oklaQANiLMTwW.json
+++ b/data/packs/magic-items.db/spellcasting_advantage_on_spell__BR7oklaQANiLMTwW.json
@@ -1,33 +1,33 @@
 {
 	"_id": "BR7oklaQANiLMTwW",
 	"_key": "!items.effects!BMNSa23mVQ2UzDce.BR7oklaQANiLMTwW",
-	"changes": [
-		{
-			"key": "system.roll.spell.advantage.power-word-kill",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "Spellcasting Advantage on Spell",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/air/air-smoke-casting.webp",
 	"name": "Spellcasting Advantage on Spell",
 	"origin": "Compendium.shadowdark.magic-items.Item.BMNSa23mVQ2UzDce",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.spell.advantage.power-word-kill",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/spellcasting_advantage_on_spell__Kf2eneYOrzvxxnWU.json
+++ b/data/packs/magic-items.db/spellcasting_advantage_on_spell__Kf2eneYOrzvxxnWU.json
@@ -1,36 +1,36 @@
 {
 	"_id": "Kf2eneYOrzvxxnWU",
 	"_key": "!items.effects!v2khQSVLOXjdYA4j.Kf2eneYOrzvxxnWU",
-	"changes": [
-		{
-			"key": "system.roll.spell.advantage.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "+1 to your next spellcasting check or ranged attack (1/day)",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 		"shadowdark": {
 			"situational": true
 		}
 	},
+	"folder": null,
 	"img": "icons/magic/air/air-smoke-casting.webp",
 	"name": "Spellcasting Advantage on Spell",
 	"origin": "Compendium.shadowdark.magic-items.Item.v2khQSVLOXjdYA4j",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.spell.advantage.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/spellcasting_advantage_on_spell__OJ3nY3HrPcGtdv4L.json
+++ b/data/packs/magic-items.db/spellcasting_advantage_on_spell__OJ3nY3HrPcGtdv4L.json
@@ -1,33 +1,33 @@
 {
 	"_id": "OJ3nY3HrPcGtdv4L",
 	"_key": "!items.effects!dupIuIdb8hVNC5gh.OJ3nY3HrPcGtdv4L",
-	"changes": [
-		{
-			"key": "system.roll.spell.advantage.shapechanger",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "Spellcasting Advantage on Spell",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/air/air-smoke-casting.webp",
 	"name": "Spellcasting Advantage on Spell",
 	"origin": "Compendium.shadowdark.magic-items.Item.dupIuIdb8hVNC5gh",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.spell.advantage.shapechanger",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/spellcasting_check_bonus__lx4pzHIfjRY8COai.json
+++ b/data/packs/magic-items.db/spellcasting_check_bonus__lx4pzHIfjRY8COai.json
@@ -1,36 +1,36 @@
 {
 	"_id": "lx4pzHIfjRY8COai",
 	"_key": "!items.effects!HxnAZ36Mm2jSDF6p.lx4pzHIfjRY8COai",
-	"changes": [
-		{
-			"key": "system.roll.spell.bonus.detect-thoughts",
-			"mode": 2,
-			"priority": null,
-			"value": "4"
-		}
-	],
 	"description": "+4 to detect thoughts spellcasting checks (3/day)",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 		"shadowdark": {
 			"situational": true
 		}
 	},
+	"folder": null,
 	"img": "icons/magic/fire/flame-burning-fist-strike.webp",
 	"name": "Spellcasting Check Bonus",
 	"origin": "Compendium.shadowdark.magic-items.Item.HxnAZ36Mm2jSDF6p",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.spell.bonus.detect-thoughts",
+				"priority": null,
+				"type": "add",
+				"value": 4
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/wand_of_moonbeam__9zrh3hE78KwKB03Z.json
+++ b/data/packs/magic-items.db/wand_of_moonbeam__9zrh3hE78KwKB03Z.json
@@ -1,0 +1,51 @@
+{
+	"_id": "9zrh3hE78KwKB03Z",
+	"_key": "!items!9zrh3hE78KwKB03Z",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/wands/wand-carved-stone-shard.webp",
+	"name": "Wand of Moonbeam",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p>@UUID[Compendium.shadowdark.spells.Item.EQNDaZJ71fyOYCHb]{Moonbeam}</p><p>Any spellcaster can wield this wand. It begins twitching whenever a lycanthrope is within near distance of it. </p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": ""
+		},
+		"isAmmunition": false,
+		"light": {
+			"active": false,
+			"hasBeenUsed": false,
+			"isSource": false,
+			"longevityMins": 60,
+			"remainingSecs": 3600,
+			"template": "torch"
+		},
+		"magicItem": true,
+		"properties": [
+		],
+		"quantity": 1,
+		"scroll": false,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "cursed-scroll-1"
+		},
+		"stashed": false,
+		"treasure": false
+	},
+	"type": "Basic"
+}

--- a/data/packs/magic-items.db/wand_of_wisdom__SaHAMKARPugwUtEP.json
+++ b/data/packs/magic-items.db/wand_of_wisdom__SaHAMKARPugwUtEP.json
@@ -1,0 +1,47 @@
+{
+	"_id": "SaHAMKARPugwUtEP",
+	"_key": "!items!SaHAMKARPugwUtEP",
+	"effects": [
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/wands/wand-carved-fire.webp",
+	"name": "Wand of Wisdom",
+	"system": {
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"description": "<p>A gnarled stick dipped in gold with the word \"wisdom\" etched on it in runes. Seers can wield it. Contains the seer spell @UUID[Compendium.shadowdark.spells.Item.sFAGFCh8390dnfi2]{trance}.</p>",
+		"equipped": false,
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": ""
+		},
+		"isAmmunition": false,
+		"magicItem": false,
+		"properties": [
+		],
+		"quantity": 1,
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "cursed-scroll-3"
+		},
+		"spells": [
+			{
+				"lost": false,
+				"uuid": "Compendium.shadowdark.spells.Item.sFAGFCh8390dnfi2"
+			}
+		],
+		"stashed": false
+	},
+	"type": "Wand"
+}

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__1WtVBmSCkzVeEdL7.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__1WtVBmSCkzVeEdL7.json
@@ -1,29 +1,32 @@
 {
 	"_id": "1WtVBmSCkzVeEdL7",
 	"_key": "!items.effects!3Wgj18VMKb0KmRHI.1WtVBmSCkzVeEdL7",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 2,
-			"value": "2"
-		}
-	],
 	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Weapon Attack Damage Bonus",
 	"origin": "Item.Jsn81bt8tPxZCdmD",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__2QCEx24N0mtaaRR7.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__2QCEx24N0mtaaRR7.json
@@ -1,27 +1,32 @@
 {
 	"_id": "2QCEx24N0mtaaRR7",
 	"_key": "!items.effects!EiyxS6MOvGlZgG65.2QCEx24N0mtaaRR7",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 2,
-			"value": "1"
-		}
-	],
 	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Weapon Attack Damage Bonus",
 	"origin": "Item.u8JqsRuUaGOch5Se",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__5k96o8ZHd5spUP9K.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__5k96o8ZHd5spUP9K.json
@@ -1,27 +1,32 @@
 {
 	"_id": "5k96o8ZHd5spUP9K",
 	"_key": "!items.effects!EBfBPArPRSyLXFPM.5k96o8ZHd5spUP9K",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 2,
-			"value": "1"
-		}
-	],
 	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Weapon Attack Damage Bonus",
 	"origin": "Compendium.shadowdark.magic-items.Item.EBfBPArPRSyLXFPM",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__97RtiQtpwhaO7qNb.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__97RtiQtpwhaO7qNb.json
@@ -1,27 +1,32 @@
 {
 	"_id": "97RtiQtpwhaO7qNb",
 	"_key": "!items.effects!Mb7OBENXa5XnClS9.97RtiQtpwhaO7qNb",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 2,
-			"value": "1"
-		}
-	],
 	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Weapon Attack Damage Bonus",
 	"origin": "Compendium.shadowdark.magic-items.Item.Mb7OBENXa5XnClS9",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__9ScRP2bW6K4ljUpQ.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__9ScRP2bW6K4ljUpQ.json
@@ -1,33 +1,33 @@
 {
 	"_id": "9ScRP2bW6K4ljUpQ",
 	"_key": "!items.effects!SuPwL1LQKe8DdaRq.9ScRP2bW6K4ljUpQ",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 2,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Weapon Attack Damage Bonus",
 	"origin": "Compendium.shadowdark.magic-items.Item.SuPwL1LQKe8DdaRq",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__CaRqa4l3vE2ZALbE.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__CaRqa4l3vE2ZALbE.json
@@ -1,33 +1,33 @@
 {
 	"_id": "CaRqa4l3vE2ZALbE",
 	"_key": "!items.effects!r4V3eAGkZ1klmFe7.CaRqa4l3vE2ZALbE",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Weapon Attack Damage Bonus",
 	"origin": "Item.QZDYdbLD9VM4i3Mr",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__JeLSOetsunFunEnm.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__JeLSOetsunFunEnm.json
@@ -1,33 +1,33 @@
 {
 	"_id": "JeLSOetsunFunEnm",
 	"_key": "!items.effects!FqhEJHkaKd0emTzn.JeLSOetsunFunEnm",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 2,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Weapon Attack Damage Bonus",
 	"origin": "Item.wCrCGPDGTPns41gH",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__LryuYkHDYOAm4I0g.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__LryuYkHDYOAm4I0g.json
@@ -1,29 +1,32 @@
 {
 	"_id": "LryuYkHDYOAm4I0g",
 	"_key": "!items.effects!Zci7qHVAp0lHEYID.LryuYkHDYOAm4I0g",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 2,
-			"value": "3"
-		}
-	],
 	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Weapon Attack Damage Bonus",
 	"origin": "Item.kUnwNFe9A9PKk4Ri",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"type": "add",
+				"value": 3
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__MYoK22maOIV6Z0VE.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__MYoK22maOIV6Z0VE.json
@@ -1,27 +1,32 @@
 {
 	"_id": "MYoK22maOIV6Z0VE",
 	"_key": "!items.effects!5vaHRsgVMO4v6ePR.MYoK22maOIV6Z0VE",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 2,
-			"value": "1"
-		}
-	],
 	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Weapon Attack Damage Bonus",
 	"origin": "Item.B30rw9qP2aK1r73k",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__OZskI153kjpkFy09.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__OZskI153kjpkFy09.json
@@ -1,33 +1,33 @@
 {
 	"_id": "OZskI153kjpkFy09",
 	"_key": "!items.effects!X5FwZjvgzeSXvNDQ.OZskI153kjpkFy09",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Weapon Attack Damage Bonus",
 	"origin": "Compendium.shadowdark.magic-items.Item.X5FwZjvgzeSXvNDQ",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__OlbaGSPCczzedFMQ.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__OlbaGSPCczzedFMQ.json
@@ -1,27 +1,32 @@
 {
 	"_id": "OlbaGSPCczzedFMQ",
 	"_key": "!items.effects!iEbHLvRPWNXo32qm.OlbaGSPCczzedFMQ",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 2,
-			"value": "1"
-		}
-	],
 	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Weapon Attack Damage Bonus",
 	"origin": "Compendium.shadowdark.magic-items.Item.iEbHLvRPWNXo32qm",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__POfmKSqbE5nitw2s.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__POfmKSqbE5nitw2s.json
@@ -1,27 +1,32 @@
 {
 	"_id": "POfmKSqbE5nitw2s",
 	"_key": "!items.effects!Nz0Wzbzgwa74gEgQ.POfmKSqbE5nitw2s",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 2,
-			"value": "1"
-		}
-	],
 	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Weapon Attack Damage Bonus",
 	"origin": "Compendium.shadowdark.magic-items.Item.Nz0Wzbzgwa74gEgQ",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__UTm25I1vjFzNqZKZ.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__UTm25I1vjFzNqZKZ.json
@@ -1,33 +1,33 @@
 {
 	"_id": "UTm25I1vjFzNqZKZ",
 	"_key": "!items.effects!DtswEluGPMrFpzW1.UTm25I1vjFzNqZKZ",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Weapon Attack Damage Bonus",
 	"origin": "Compendium.shadowdark.magic-items.Item.DtswEluGPMrFpzW1",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__Vn1UKd6iBKvZh0tc.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__Vn1UKd6iBKvZh0tc.json
@@ -1,27 +1,32 @@
 {
 	"_id": "Vn1UKd6iBKvZh0tc",
 	"_key": "!items.effects!bpJlJ3vnZVmvOEJV.Vn1UKd6iBKvZh0tc",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 2,
-			"value": "1"
-		}
-	],
 	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Weapon Attack Damage Bonus",
 	"origin": "Item.nfRD48XCs8SvvptW",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__XxQ6F27a8mmAtDxN.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__XxQ6F27a8mmAtDxN.json
@@ -1,0 +1,36 @@
+{
+	"_id": "XxQ6F27a8mmAtDxN",
+	"_key": "!items.effects!tVMll4MiliOXbg0i.XxQ6F27a8mmAtDxN",
+	"description": "<p>Weapon Attack Damage Bonus</p>",
+	"disabled": false,
+	"duration": {
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
+	},
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
+	"name": "Weapon Attack Damage Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.tVMll4MiliOXbg0i",
+	"showIcon": 1,
+	"start": null,
+	"statuses": [
+	],
+	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"phase": "initial",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__ZDqSlow0fxMp6JOf.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__ZDqSlow0fxMp6JOf.json
@@ -1,33 +1,33 @@
 {
 	"_id": "ZDqSlow0fxMp6JOf",
 	"_key": "!items.effects!RbAtv4hRODYmOoit.ZDqSlow0fxMp6JOf",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 2,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Weapon Attack Damage Bonus",
 	"origin": "Compendium.shadowdark.magic-items.Item.RbAtv4hRODYmOoit",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__dZkdrikRTlcELylW.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__dZkdrikRTlcELylW.json
@@ -1,29 +1,32 @@
 {
 	"_id": "dZkdrikRTlcELylW",
 	"_key": "!items.effects!REKbDm3ShTNQouM2.dZkdrikRTlcELylW",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 2,
-			"value": "2"
-		}
-	],
 	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Weapon Attack Damage Bonus",
 	"origin": "Item.5ayvpKEkkJ70T9Ir",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__dbXv9ddp6TR15AFk.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__dbXv9ddp6TR15AFk.json
@@ -1,29 +1,32 @@
 {
 	"_id": "dbXv9ddp6TR15AFk",
 	"_key": "!items.effects!4BkbHe0cL8Zvsd7a.dbXv9ddp6TR15AFk",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 2,
-			"value": "3"
-		}
-	],
 	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Weapon Attack Damage Bonus",
 	"origin": "Compendium.shadowdark.magic-items.Item.4BkbHe0cL8Zvsd7a",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"type": "add",
+				"value": 3
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__doAgFd0Q4WixkRrC.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__doAgFd0Q4WixkRrC.json
@@ -1,29 +1,32 @@
 {
 	"_id": "doAgFd0Q4WixkRrC",
 	"_key": "!items.effects!5gdNWsFJjgmtZroK.doAgFd0Q4WixkRrC",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 2,
-			"value": "3"
-		}
-	],
 	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Weapon Attack Damage Bonus",
 	"origin": "Compendium.shadowdark.magic-items.Item.5gdNWsFJjgmtZroK",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"type": "add",
+				"value": 3
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__n94S9biW3s0ZHhoR.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__n94S9biW3s0ZHhoR.json
@@ -1,29 +1,32 @@
 {
 	"_id": "n94S9biW3s0ZHhoR",
 	"_key": "!items.effects!ck4lutlGUcVmIE6y.n94S9biW3s0ZHhoR",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 2,
-			"value": "3"
-		}
-	],
 	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Weapon Attack Damage Bonus",
 	"origin": "Item.Hl8FZ5dUga3pYqH8",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"type": "add",
+				"value": 3
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__tOLeg6MI1ii7c98V.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__tOLeg6MI1ii7c98V.json
@@ -1,33 +1,33 @@
 {
 	"_id": "tOLeg6MI1ii7c98V",
 	"_key": "!items.effects!YITrYmzXxk6Yjxfc.tOLeg6MI1ii7c98V",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Weapon Attack Damage Bonus",
 	"origin": "Compendium.shadowdark.magic-items.Item.YITrYmzXxk6Yjxfc",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_damage_bonus__uBVpxbCrrpyNJxZS.json
+++ b/data/packs/magic-items.db/weapon_attack_damage_bonus__uBVpxbCrrpyNJxZS.json
@@ -1,29 +1,32 @@
 {
 	"_id": "uBVpxbCrrpyNJxZS",
 	"_key": "!items.effects!MgWPwzNTzC7cPi7H.uBVpxbCrrpyNJxZS",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.this",
-			"mode": 2,
-			"value": "3"
-		}
-	],
 	"description": "Weapon Attack Damage Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Weapon Attack Damage Bonus",
 	"origin": "Item.IMsCntyKjKOgNteb",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.this",
+				"type": "add",
+				"value": 3
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__3uu1cZFg4jJ9uOBU.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__3uu1cZFg4jJ9uOBU.json
@@ -1,33 +1,33 @@
 {
 	"_id": "3uu1cZFg4jJ9uOBU",
 	"_key": "!items.effects!FqhEJHkaKd0emTzn.3uu1cZFg4jJ9uOBU",
-	"changes": [
-		{
-			"key": "system.roll.attack.bonus.this",
-			"mode": 2,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Weapon Attack Roll Bonus",
 	"origin": "Item.wCrCGPDGTPns41gH",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.this",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__4JjKaawthhmI2NLb.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__4JjKaawthhmI2NLb.json
@@ -1,29 +1,32 @@
 {
 	"_id": "4JjKaawthhmI2NLb",
 	"_key": "!items.effects!Zci7qHVAp0lHEYID.4JjKaawthhmI2NLb",
-	"changes": [
-		{
-			"key": "system.roll.attack.bonus.this",
-			"mode": 2,
-			"value": "3"
-		}
-	],
 	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Weapon Attack Roll Bonus",
 	"origin": "Item.kUnwNFe9A9PKk4Ri",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.this",
+				"type": "add",
+				"value": 3
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__8DPxbb4aUGGtrGlG.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__8DPxbb4aUGGtrGlG.json
@@ -1,29 +1,32 @@
 {
 	"_id": "8DPxbb4aUGGtrGlG",
 	"_key": "!items.effects!5gdNWsFJjgmtZroK.8DPxbb4aUGGtrGlG",
-	"changes": [
-		{
-			"key": "system.roll.attack.bonus.this",
-			"mode": 2,
-			"value": "3"
-		}
-	],
 	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Weapon Attack Roll Bonus",
 	"origin": "Compendium.shadowdark.magic-items.Item.5gdNWsFJjgmtZroK",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.this",
+				"type": "add",
+				"value": 3
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__A9BPMWmWpSXDGqYI.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__A9BPMWmWpSXDGqYI.json
@@ -1,0 +1,36 @@
+{
+	"_id": "A9BPMWmWpSXDGqYI",
+	"_key": "!items.effects!tVMll4MiliOXbg0i.A9BPMWmWpSXDGqYI",
+	"description": "<p>Weapon Attack Roll Bonus</p>",
+	"disabled": false,
+	"duration": {
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
+	},
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
+	"name": "Weapon Attack Roll Bonus",
+	"origin": "Compendium.shadowdark.magic-items.Item.tVMll4MiliOXbg0i",
+	"showIcon": 1,
+	"start": null,
+	"statuses": [
+	],
+	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.this",
+				"phase": "initial",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__CFbdBIST0hT7qCyu.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__CFbdBIST0hT7qCyu.json
@@ -1,33 +1,33 @@
 {
 	"_id": "CFbdBIST0hT7qCyu",
 	"_key": "!items.effects!X5FwZjvgzeSXvNDQ.CFbdBIST0hT7qCyu",
-	"changes": [
-		{
-			"key": "system.roll.attack.bonus.this",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Weapon Attack Roll Bonus",
 	"origin": "Compendium.shadowdark.magic-items.Item.X5FwZjvgzeSXvNDQ",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.this",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__ENAyqljvyYqIr8rK.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__ENAyqljvyYqIr8rK.json
@@ -1,33 +1,33 @@
 {
 	"_id": "ENAyqljvyYqIr8rK",
 	"_key": "!items.effects!RbAtv4hRODYmOoit.ENAyqljvyYqIr8rK",
-	"changes": [
-		{
-			"key": "system.roll.attack.bonus.this",
-			"mode": 2,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Weapon Attack Roll Bonus",
 	"origin": "Compendium.shadowdark.magic-items.Item.RbAtv4hRODYmOoit",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.this",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__HIFDdRlLUKbLS5zK.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__HIFDdRlLUKbLS5zK.json
@@ -1,27 +1,32 @@
 {
 	"_id": "HIFDdRlLUKbLS5zK",
 	"_key": "!items.effects!Nz0Wzbzgwa74gEgQ.HIFDdRlLUKbLS5zK",
-	"changes": [
-		{
-			"key": "system.roll.attack.bonus.this",
-			"mode": 2,
-			"value": "1"
-		}
-	],
 	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Weapon Attack Roll Bonus",
 	"origin": "Compendium.shadowdark.magic-items.Item.Nz0Wzbzgwa74gEgQ",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.this",
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__HOkTvzEf4v5RBLfx.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__HOkTvzEf4v5RBLfx.json
@@ -1,33 +1,33 @@
 {
 	"_id": "HOkTvzEf4v5RBLfx",
 	"_key": "!items.effects!DtswEluGPMrFpzW1.HOkTvzEf4v5RBLfx",
-	"changes": [
-		{
-			"key": "system.roll.attack.bonus.this",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Weapon Attack Roll Bonus",
 	"origin": "Compendium.shadowdark.magic-items.Item.DtswEluGPMrFpzW1",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.this",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__Qt03jfl943CxPGeL.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__Qt03jfl943CxPGeL.json
@@ -1,33 +1,33 @@
 {
 	"_id": "Qt03jfl943CxPGeL",
 	"_key": "!items.effects!r4V3eAGkZ1klmFe7.Qt03jfl943CxPGeL",
-	"changes": [
-		{
-			"key": "system.roll.attack.bonus.this",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Weapon Attack Roll Bonus",
 	"origin": "Item.QZDYdbLD9VM4i3Mr",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.this",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__U8i8NfAsHGKpezHN.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__U8i8NfAsHGKpezHN.json
@@ -1,29 +1,32 @@
 {
 	"_id": "U8i8NfAsHGKpezHN",
 	"_key": "!items.effects!3Wgj18VMKb0KmRHI.U8i8NfAsHGKpezHN",
-	"changes": [
-		{
-			"key": "system.roll.attack.bonus.this",
-			"mode": 2,
-			"value": "2"
-		}
-	],
 	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Weapon Attack Roll Bonus",
 	"origin": "Item.Jsn81bt8tPxZCdmD",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.this",
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__WhT5yrk9W2vCWs6X.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__WhT5yrk9W2vCWs6X.json
@@ -1,33 +1,33 @@
 {
 	"_id": "WhT5yrk9W2vCWs6X",
 	"_key": "!items.effects!SuPwL1LQKe8DdaRq.WhT5yrk9W2vCWs6X",
-	"changes": [
-		{
-			"key": "system.roll.attack.bonus.this",
-			"mode": 2,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Weapon Attack Roll Bonus",
 	"origin": "Compendium.shadowdark.magic-items.Item.SuPwL1LQKe8DdaRq",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.this",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__Z4UACwRTky38K63x.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__Z4UACwRTky38K63x.json
@@ -1,29 +1,32 @@
 {
 	"_id": "Z4UACwRTky38K63x",
 	"_key": "!items.effects!4BkbHe0cL8Zvsd7a.Z4UACwRTky38K63x",
-	"changes": [
-		{
-			"key": "system.roll.attack.bonus.this",
-			"mode": 2,
-			"value": "3"
-		}
-	],
 	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Weapon Attack Roll Bonus",
 	"origin": "Compendium.shadowdark.magic-items.Item.4BkbHe0cL8Zvsd7a",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.this",
+				"type": "add",
+				"value": 3
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__apF91F2anJCrmkSm.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__apF91F2anJCrmkSm.json
@@ -1,27 +1,32 @@
 {
 	"_id": "apF91F2anJCrmkSm",
 	"_key": "!items.effects!EiyxS6MOvGlZgG65.apF91F2anJCrmkSm",
-	"changes": [
-		{
-			"key": "system.roll.attack.bonus.this",
-			"mode": 2,
-			"value": "1"
-		}
-	],
 	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Weapon Attack Roll Bonus",
 	"origin": "Item.u8JqsRuUaGOch5Se",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.this",
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__eXpmyWBLi6CfFuTt.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__eXpmyWBLi6CfFuTt.json
@@ -1,33 +1,33 @@
 {
 	"_id": "eXpmyWBLi6CfFuTt",
 	"_key": "!items.effects!YITrYmzXxk6Yjxfc.eXpmyWBLi6CfFuTt",
-	"changes": [
-		{
-			"key": "system.roll.attack.bonus.this",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Weapon Attack Roll Bonus",
 	"origin": "Compendium.shadowdark.magic-items.Item.YITrYmzXxk6Yjxfc",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.this",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__kjwVuIlPksnF2hR1.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__kjwVuIlPksnF2hR1.json
@@ -1,29 +1,32 @@
 {
 	"_id": "kjwVuIlPksnF2hR1",
 	"_key": "!items.effects!ck4lutlGUcVmIE6y.kjwVuIlPksnF2hR1",
-	"changes": [
-		{
-			"key": "system.roll.attack.bonus.this",
-			"mode": 2,
-			"value": "3"
-		}
-	],
 	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Weapon Attack Roll Bonus",
 	"origin": "Item.Hl8FZ5dUga3pYqH8",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.this",
+				"type": "add",
+				"value": 3
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__l9MlejatmWj0EesQ.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__l9MlejatmWj0EesQ.json
@@ -1,27 +1,32 @@
 {
 	"_id": "l9MlejatmWj0EesQ",
 	"_key": "!items.effects!bpJlJ3vnZVmvOEJV.l9MlejatmWj0EesQ",
-	"changes": [
-		{
-			"key": "system.roll.attack.bonus.this",
-			"mode": 2,
-			"value": "1"
-		}
-	],
 	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Weapon Attack Roll Bonus",
 	"origin": "Item.nfRD48XCs8SvvptW",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.this",
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__nYIEUngawHOWjKLV.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__nYIEUngawHOWjKLV.json
@@ -1,27 +1,32 @@
 {
 	"_id": "nYIEUngawHOWjKLV",
 	"_key": "!items.effects!EBfBPArPRSyLXFPM.nYIEUngawHOWjKLV",
-	"changes": [
-		{
-			"key": "system.roll.attack.bonus.this",
-			"mode": 2,
-			"value": "1"
-		}
-	],
 	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Weapon Attack Roll Bonus",
 	"origin": "Compendium.shadowdark.magic-items.Item.EBfBPArPRSyLXFPM",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.this",
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__nv1kzlTwOcLqpi7w.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__nv1kzlTwOcLqpi7w.json
@@ -1,29 +1,32 @@
 {
 	"_id": "nv1kzlTwOcLqpi7w",
 	"_key": "!items.effects!REKbDm3ShTNQouM2.nv1kzlTwOcLqpi7w",
-	"changes": [
-		{
-			"key": "system.roll.attack.bonus.this",
-			"mode": 2,
-			"value": "2"
-		}
-	],
 	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Weapon Attack Roll Bonus",
 	"origin": "Item.5ayvpKEkkJ70T9Ir",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.this",
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__pOdV4x1mBsF4ZJmg.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__pOdV4x1mBsF4ZJmg.json
@@ -1,27 +1,32 @@
 {
 	"_id": "pOdV4x1mBsF4ZJmg",
 	"_key": "!items.effects!Mb7OBENXa5XnClS9.pOdV4x1mBsF4ZJmg",
-	"changes": [
-		{
-			"key": "system.roll.attack.bonus.this",
-			"mode": 2,
-			"value": "1"
-		}
-	],
 	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Weapon Attack Roll Bonus",
 	"origin": "Compendium.shadowdark.magic-items.Item.Mb7OBENXa5XnClS9",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.this",
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__qx4j9GoWPYmbbu9g.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__qx4j9GoWPYmbbu9g.json
@@ -1,27 +1,32 @@
 {
 	"_id": "qx4j9GoWPYmbbu9g",
 	"_key": "!items.effects!5vaHRsgVMO4v6ePR.qx4j9GoWPYmbbu9g",
-	"changes": [
-		{
-			"key": "system.roll.attack.bonus.this",
-			"mode": 2,
-			"value": "1"
-		}
-	],
 	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Weapon Attack Roll Bonus",
 	"origin": "Item.B30rw9qP2aK1r73k",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.this",
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__un7hIgJAJuzdyLvo.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__un7hIgJAJuzdyLvo.json
@@ -1,29 +1,32 @@
 {
 	"_id": "un7hIgJAJuzdyLvo",
 	"_key": "!items.effects!MgWPwzNTzC7cPi7H.un7hIgJAJuzdyLvo",
-	"changes": [
-		{
-			"key": "system.roll.attack.bonus.this",
-			"mode": 2,
-			"value": "3"
-		}
-	],
 	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Weapon Attack Roll Bonus",
 	"origin": "Item.IMsCntyKjKOgNteb",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.this",
+				"type": "add",
+				"value": 3
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/weapon_attack_roll_bonus__yMBdo0WUxtzRzji9.json
+++ b/data/packs/magic-items.db/weapon_attack_roll_bonus__yMBdo0WUxtzRzji9.json
@@ -1,27 +1,32 @@
 {
 	"_id": "yMBdo0WUxtzRzji9",
 	"_key": "!items.effects!iEbHLvRPWNXo32qm.yMBdo0WUxtzRzji9",
-	"changes": [
-		{
-			"key": "system.roll.attack.bonus.this",
-			"mode": 2,
-			"value": "1"
-		}
-	],
 	"description": "Weapon Attack Roll Bonus",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"startTime": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Weapon Attack Roll Bonus",
 	"origin": "Compendium.shadowdark.magic-items.Item.iEbHLvRPWNXo32qm",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.this",
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/magic-items.db/wrath_bolt__XaQsvwnvOk3TAZnN.json
+++ b/data/packs/magic-items.db/wrath_bolt__XaQsvwnvOk3TAZnN.json
@@ -1,0 +1,56 @@
+{
+	"_id": "XaQsvwnvOk3TAZnN",
+	"_key": "!items!XaQsvwnvOk3TAZnN",
+	"effects": [
+		"xwiRD5vkzpmFn4Sd",
+		"u9KcTSUxAz4Tz9zg",
+		"VU4MlhbeYOgPlEke",
+		"JUfuu0JhYDQE9QMi"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/swords/sword-flamberge.webp",
+	"name": "Wrath Bolt",
+	"system": {
+		"ammoClass": "",
+		"baseWeapon": "dagger",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"damage": {
+			"oneHanded": "d4",
+			"twoHanded": ""
+		},
+		"description": "<p><strong>Curse. </strong>Deals [[/r 1d100]] damage to anyone who tries to take it from previous possessor (dead or alive).</p>",
+		"equipped": false,
+		"handedness": "",
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": ""
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.rqQwpoeWEqi0ZcYK",
+			"Compendium.shadowdark.properties.Item.c35ROL1nXwC840kC"
+		],
+		"quantity": 1,
+		"range": "near",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "cursed-scroll-1"
+		},
+		"stashed": false,
+		"type": "melee"
+	},
+	"type": "Weapon"
+}

--- a/data/packs/magic-items.db/ynnith__NN8q2aJgmedMfrnm.json
+++ b/data/packs/magic-items.db/ynnith__NN8q2aJgmedMfrnm.json
@@ -1,0 +1,53 @@
+{
+	"_id": "NN8q2aJgmedMfrnm",
+	"_key": "!items!NN8q2aJgmedMfrnm",
+	"effects": [
+		"HcunJo9lsdxtj8p8",
+		"5iAPSMbm5EclVkse"
+	],
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/weapons/staves/staff-simple-wrapped.webp",
+	"name": "Ynnith",
+	"system": {
+		"ammoClass": "",
+		"baseWeapon": "staff",
+		"broken": false,
+		"cost": {
+			"cp": 0,
+			"gp": 0,
+			"sp": 0
+		},
+		"damage": {
+			"oneHanded": "d4",
+			"twoHanded": ""
+		},
+		"description": "<p><em>A +1 staff of knotted oak</em></p><p><strong>Bonus. </strong>+1 staff.</p><p><strong>Benefit. </strong>Once a day, the wielder can summon an obedient giant owl for 5 rounds.</p><p><strong>Curse. </strong>Druids who see the staff will try to lay claim to it.</p>",
+		"equipped": false,
+		"handedness": "",
+		"identification": {
+			"description": "",
+			"identified": true,
+			"name": ""
+		},
+		"isAmmunition": false,
+		"magicItem": true,
+		"properties": [
+			"Compendium.shadowdark.properties.Item.b6Gm2ULKj2qyy2xJ"
+		],
+		"quantity": 1,
+		"range": "close",
+		"slots": {
+			"free_carry": 0,
+			"per_slot": 1,
+			"slots_used": 1
+		},
+		"source": {
+			"title": "cursed-scroll-1"
+		},
+		"stashed": false,
+		"type": "melee"
+	},
+	"type": "Weapon"
+}

--- a/data/packs/monsters.db/aboleth__sgVqRuCaadRK1P7R.json
+++ b/data/packs/monsters.db/aboleth__sgVqRuCaadRK1P7R.json
@@ -25,8 +25,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -95,9 +96,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/acolyte__k2YdCMGiq3USE8oE.json
+++ b/data/packs/monsters.db/acolyte__k2YdCMGiq3USE8oE.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/angel__domini__63d5P0opwEQTdDIn.json
+++ b/data/packs/monsters.db/angel__domini__63d5P0opwEQTdDIn.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/angel__principi__X8hc2Uhflvy8F634.json
+++ b/data/packs/monsters.db/angel__principi__X8hc2Uhflvy8F634.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/angel__seraph__9mHBuBhx1RxUdheA.json
+++ b/data/packs/monsters.db/angel__seraph__9mHBuBhx1RxUdheA.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/animated_armor__qSeHWgP59WltutCz.json
+++ b/data/packs/monsters.db/animated_armor__qSeHWgP59WltutCz.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/ankheg__rrI5NuJ8q0Pm4ehs.json
+++ b/data/packs/monsters.db/ankheg__rrI5NuJ8q0Pm4ehs.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/ape__52p2phLsOZiNFTFS.json
+++ b/data/packs/monsters.db/ape__52p2phLsOZiNFTFS.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/ape__snow__z4UPCFgmpXHwzmJu.json
+++ b/data/packs/monsters.db/ape__snow__z4UPCFgmpXHwzmJu.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/apprentice__9R3qr0129OxaXMcy.json
+++ b/data/packs/monsters.db/apprentice__9R3qr0129OxaXMcy.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/archangel__GzjB5DsORxRuX2MV.json
+++ b/data/packs/monsters.db/archangel__GzjB5DsORxRuX2MV.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/archdevil__OkhcwZ7JqJxTgkJo.json
+++ b/data/packs/monsters.db/archdevil__OkhcwZ7JqJxTgkJo.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/archmage__5NUw5FTgSVwAi0nL.json
+++ b/data/packs/monsters.db/archmage__5NUw5FTgSVwAi0nL.json
@@ -26,8 +26,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -96,9 +97,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/assassin__I5y9YDSIg2n0u8CM.json
+++ b/data/packs/monsters.db/assassin__I5y9YDSIg2n0u8CM.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/azer__rEhCGVPPzY0R18oJ.json
+++ b/data/packs/monsters.db/azer__rEhCGVPPzY0R18oJ.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/badger__VM65vWCNjlx5tKTP.json
+++ b/data/packs/monsters.db/badger__VM65vWCNjlx5tKTP.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/bandit__AMSI3MCLvpcZpJPO.json
+++ b/data/packs/monsters.db/bandit__AMSI3MCLvpcZpJPO.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/basilisk__r9PchmCuVg1r9FOA.json
+++ b/data/packs/monsters.db/basilisk__r9PchmCuVg1r9FOA.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/basilisk_hatchling__ubcYvhvDW1WywYcw.json
+++ b/data/packs/monsters.db/basilisk_hatchling__ubcYvhvDW1WywYcw.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/bat__giant__EJ94w4A9mb9ETSGA.json
+++ b/data/packs/monsters.db/bat__giant__EJ94w4A9mb9ETSGA.json
@@ -21,8 +21,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -91,9 +92,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/bat__swarm__CUpk1oMNktqZPdXp.json
+++ b/data/packs/monsters.db/bat__swarm__CUpk1oMNktqZPdXp.json
@@ -21,8 +21,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -91,9 +92,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/bear__brown__RG84tprafQTDEFCa.json
+++ b/data/packs/monsters.db/bear__brown__RG84tprafQTDEFCa.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/bear__polar__A84XNl4aGBeeDDLu.json
+++ b/data/packs/monsters.db/bear__polar__A84XNl4aGBeeDDLu.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/beastman__k8tAgECWIzPIStGU.json
+++ b/data/packs/monsters.db/beastman__k8tAgECWIzPIStGU.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/berserker__dqWmtEZjAMQLmCBn.json
+++ b/data/packs/monsters.db/berserker__dqWmtEZjAMQLmCBn.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/black_pudding__LjwxMX3llNTrJk78.json
+++ b/data/packs/monsters.db/black_pudding__LjwxMX3llNTrJk78.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/boar__bXYsB2bHIdtOsZgV.json
+++ b/data/packs/monsters.db/boar__bXYsB2bHIdtOsZgV.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/brachiosaurus__P3UFDBgbA5kkwcYb.json
+++ b/data/packs/monsters.db/brachiosaurus__P3UFDBgbA5kkwcYb.json
@@ -21,8 +21,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 4,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -91,9 +92,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/brain_eater__MnV9R6AbzWjLreaZ.json
+++ b/data/packs/monsters.db/brain_eater__MnV9R6AbzWjLreaZ.json
@@ -25,8 +25,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -95,9 +96,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/bugbear__qUuNdFtYmo1vXVP5.json
+++ b/data/packs/monsters.db/bugbear__qUuNdFtYmo1vXVP5.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/bulette__ktpbMeq6xDzNbOu3.json
+++ b/data/packs/monsters.db/bulette__ktpbMeq6xDzNbOu3.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/camel__JO2HwD53QhEuV3W9.json
+++ b/data/packs/monsters.db/camel__JO2HwD53QhEuV3W9.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/cave_brute__nhKDBbnOnXXTzfBr.json
+++ b/data/packs/monsters.db/cave_brute__nhKDBbnOnXXTzfBr.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/cave_creeper__j7sQ6Km2jSx5twCC.json
+++ b/data/packs/monsters.db/cave_creeper__j7sQ6Km2jSx5twCC.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/centaur__5AV9DF5BbMu7mvVO.json
+++ b/data/packs/monsters.db/centaur__5AV9DF5BbMu7mvVO.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/centipede__giant__W9n69R2FY4EIgBuQ.json
+++ b/data/packs/monsters.db/centipede__giant__W9n69R2FY4EIgBuQ.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/centipede__swarm__lcqq47H1YVF0ABnp.json
+++ b/data/packs/monsters.db/centipede__swarm__lcqq47H1YVF0ABnp.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/chimera__5SaVYhtOSTOUcHCV.json
+++ b/data/packs/monsters.db/chimera__5SaVYhtOSTOUcHCV.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/chuul__4v8PY6yOUcQOTWWo.json
+++ b/data/packs/monsters.db/chuul__4v8PY6yOUcQOTWWo.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/cloaker__SeY0lvD3U4pr6mXD.json
+++ b/data/packs/monsters.db/cloaker__SeY0lvD3U4pr6mXD.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/cockatrice__xUxKG0CR6Elw1l7h.json
+++ b/data/packs/monsters.db/cockatrice__xUxKG0CR6Elw1l7h.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/couatl__ibQF9DMmu8sTLz4B.json
+++ b/data/packs/monsters.db/couatl__ibQF9DMmu8sTLz4B.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/crab__giant__2KRkhIG0f9YAnUHb.json
+++ b/data/packs/monsters.db/crab__giant__2KRkhIG0f9YAnUHb.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/crocodile__obS0HaAx233uar7B.json
+++ b/data/packs/monsters.db/crocodile__obS0HaAx233uar7B.json
@@ -21,8 +21,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -91,9 +92,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/cultist__CpHttsoemSoZRiDe.json
+++ b/data/packs/monsters.db/cultist__CpHttsoemSoZRiDe.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/cyclops__68wDauouPEUU9oMR.json
+++ b/data/packs/monsters.db/cyclops__68wDauouPEUU9oMR.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/darkmantle__0JAEN5FsKjaXXZaA.json
+++ b/data/packs/monsters.db/darkmantle__0JAEN5FsKjaXXZaA.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/deep_one__5J7IfGiC6Za14VuU.json
+++ b/data/packs/monsters.db/deep_one__5J7IfGiC6Za14VuU.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/demon__balor__ju93VWtuoi9BRX5F.json
+++ b/data/packs/monsters.db/demon__balor__ju93VWtuoi9BRX5F.json
@@ -25,8 +25,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -95,9 +96,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/demon__dretch__UzRHO1MCMmYDSVzo.json
+++ b/data/packs/monsters.db/demon__dretch__UzRHO1MCMmYDSVzo.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/demon__glabrezu__CuwjaziXY6YoAg7O.json
+++ b/data/packs/monsters.db/demon__glabrezu__CuwjaziXY6YoAg7O.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/demon__marilith__P53eJcTVm4axJ2bR.json
+++ b/data/packs/monsters.db/demon__marilith__P53eJcTVm4axJ2bR.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/demon__vrock__0Q9d1621wpUEsuFC.json
+++ b/data/packs/monsters.db/demon__vrock__0Q9d1621wpUEsuFC.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/devil__barbed__n4liAI4qBGY4orA4.json
+++ b/data/packs/monsters.db/devil__barbed__n4liAI4qBGY4orA4.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/devil__cubi__eytIJSxijnY4VZ3U.json
+++ b/data/packs/monsters.db/devil__cubi__eytIJSxijnY4VZ3U.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/devil__erinyes__8Lma2TIrsJc0IJzV.json
+++ b/data/packs/monsters.db/devil__erinyes__8Lma2TIrsJc0IJzV.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/devil__horned__TWzBMX1oWU10HBOW.json
+++ b/data/packs/monsters.db/devil__horned__TWzBMX1oWU10HBOW.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/devil__imp__qhy4sxYqEkl171L5.json
+++ b/data/packs/monsters.db/devil__imp__qhy4sxYqEkl171L5.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 0.5,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/djinni__ytftI0motwEnF29v.json
+++ b/data/packs/monsters.db/djinni__ytftI0motwEnF29v.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/doppelganger__6ldPPlMIMSd4ALoZ.json
+++ b/data/packs/monsters.db/doppelganger__6ldPPlMIMSd4ALoZ.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/dragon__desert__3ao87kQaYih26b9q.json
+++ b/data/packs/monsters.db/dragon__desert__3ao87kQaYih26b9q.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/dragon__fire__8nKQ8hgoWY7vZHb4.json
+++ b/data/packs/monsters.db/dragon__fire__8nKQ8hgoWY7vZHb4.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/dragon__forest__GGiSjGtAWFwFT81z.json
+++ b/data/packs/monsters.db/dragon__forest__GGiSjGtAWFwFT81z.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/dragon__frost__CUMRox407hfN6Ho1.json
+++ b/data/packs/monsters.db/dragon__frost__CUMRox407hfN6Ho1.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/dragon__sea__wGmyKKVD5P4oE4RD.json
+++ b/data/packs/monsters.db/dragon__sea__wGmyKKVD5P4oE4RD.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/dragon__swamp__KKc8fESqPDECz0bL.json
+++ b/data/packs/monsters.db/dragon__swamp__KKc8fESqPDECz0bL.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/drow__OQKt55SQZZUZhlNq.json
+++ b/data/packs/monsters.db/drow__OQKt55SQZZUZhlNq.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/drow__drider__DttbFgMrxQulVKEf.json
+++ b/data/packs/monsters.db/drow__drider__DttbFgMrxQulVKEf.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/drow__priestess__mLujryShxJUk5Jys.json
+++ b/data/packs/monsters.db/drow__priestess__mLujryShxJUk5Jys.json
@@ -26,8 +26,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -96,9 +97,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/druid__xwdLsiejN4nayUR5.json
+++ b/data/packs/monsters.db/druid__xwdLsiejN4nayUR5.json
@@ -26,8 +26,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -96,9 +97,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/dryad__vXaqgfDykZPdXnIm.json
+++ b/data/packs/monsters.db/dryad__vXaqgfDykZPdXnIm.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/duergar__B1B7yApS28xtu8HN.json
+++ b/data/packs/monsters.db/duergar__B1B7yApS28xtu8HN.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/dung_beetle__giant__99s2guSyYKPWp1oy.json
+++ b/data/packs/monsters.db/dung_beetle__giant__99s2guSyYKPWp1oy.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/efreeti__o1aBfxHFxYVHLTRn.json
+++ b/data/packs/monsters.db/efreeti__o1aBfxHFxYVHLTRn.json
@@ -25,8 +25,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -95,9 +96,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/elemental__air__greater___adojju5DJl1iWEg4.json
+++ b/data/packs/monsters.db/elemental__air__greater___adojju5DJl1iWEg4.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/elemental__air__lesser___XEFAKSOcCUd8G89y.json
+++ b/data/packs/monsters.db/elemental__air__lesser___XEFAKSOcCUd8G89y.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/elemental__earth__greater___w14e0EzbGfvjkbes.json
+++ b/data/packs/monsters.db/elemental__earth__greater___w14e0EzbGfvjkbes.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/elemental__earth__lesser___Puc0P5lO6IphdIQP.json
+++ b/data/packs/monsters.db/elemental__earth__lesser___Puc0P5lO6IphdIQP.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/elemental__fire__greater___V1wcRoUEnIbaNjXN.json
+++ b/data/packs/monsters.db/elemental__fire__greater___V1wcRoUEnIbaNjXN.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/elemental__fire__lesser___vylW8UYkC5i9wAS7.json
+++ b/data/packs/monsters.db/elemental__fire__lesser___vylW8UYkC5i9wAS7.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/elemental__water__greater___Fb4nfQoOqplwmGHe.json
+++ b/data/packs/monsters.db/elemental__water__greater___Fb4nfQoOqplwmGHe.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/elemental__water__lesser___ZP1OsAWwqVppLts0.json
+++ b/data/packs/monsters.db/elemental__water__lesser___ZP1OsAWwqVppLts0.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/elephant__Ezs7usvuZdG6zMAL.json
+++ b/data/packs/monsters.db/elephant__Ezs7usvuZdG6zMAL.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/elf__GvxrOdZ1MejJL8DV.json
+++ b/data/packs/monsters.db/elf__GvxrOdZ1MejJL8DV.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/ettercap__fcgq7uwsJEMMdRNx.json
+++ b/data/packs/monsters.db/ettercap__fcgq7uwsJEMMdRNx.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/fairy__RAEbIzHkREYWKvLh.json
+++ b/data/packs/monsters.db/fairy__RAEbIzHkREYWKvLh.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 0.5,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/frog__giant__mpdnvoVyYfvu8yLP.json
+++ b/data/packs/monsters.db/frog__giant__mpdnvoVyYfvu8yLP.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/gargoyle__FeQJTjVbjxIH6uHd.json
+++ b/data/packs/monsters.db/gargoyle__FeQJTjVbjxIH6uHd.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/gelatinous_cube__udRspLiTyURGmLav.json
+++ b/data/packs/monsters.db/gelatinous_cube__udRspLiTyURGmLav.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/ghast__XNiuEhf8QpfOnVCJ.json
+++ b/data/packs/monsters.db/ghast__XNiuEhf8QpfOnVCJ.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/ghost__LV2ZWlK1qUQz5J4K.json
+++ b/data/packs/monsters.db/ghost__LV2ZWlK1qUQz5J4K.json
@@ -25,8 +25,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -95,9 +96,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/ghoul__aJPxeuzZ597SWMES.json
+++ b/data/packs/monsters.db/ghoul__aJPxeuzZ597SWMES.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/giant__cloud__vdCzdpAsjmYTa1ps.json
+++ b/data/packs/monsters.db/giant__cloud__vdCzdpAsjmYTa1ps.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/giant__fire__PzLMBzFtioZhBlTq.json
+++ b/data/packs/monsters.db/giant__fire__PzLMBzFtioZhBlTq.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/giant__frost__Om5RbAEQDbXI8MwN.json
+++ b/data/packs/monsters.db/giant__frost__Om5RbAEQDbXI8MwN.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/giant__goat__KFCqi1XnRQM7kZyj.json
+++ b/data/packs/monsters.db/giant__goat__KFCqi1XnRQM7kZyj.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/giant__hill__sFz8XfLheORSuxxM.json
+++ b/data/packs/monsters.db/giant__hill__sFz8XfLheORSuxxM.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/giant__stone__zIaJgXifG1mIY7FM.json
+++ b/data/packs/monsters.db/giant__stone__zIaJgXifG1mIY7FM.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/giant__storm__owL9cUM2LTVpMarQ.json
+++ b/data/packs/monsters.db/giant__storm__owL9cUM2LTVpMarQ.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/gibbering_mouther__8aDS9mPcNoxNc3Ha.json
+++ b/data/packs/monsters.db/gibbering_mouther__8aDS9mPcNoxNc3Ha.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/gladiator__14gxjungNSpJTf3w.json
+++ b/data/packs/monsters.db/gladiator__14gxjungNSpJTf3w.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/gnoll__d2dPYSjcZhR5psLj.json
+++ b/data/packs/monsters.db/gnoll__d2dPYSjcZhR5psLj.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/gnome__deep__WMw4J1wECaLGf3Am.json
+++ b/data/packs/monsters.db/gnome__deep__WMw4J1wECaLGf3Am.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/goblin__I7CMFbyFmFHVwE5U.json
+++ b/data/packs/monsters.db/goblin__I7CMFbyFmFHVwE5U.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/goblin__boss__R3CMnUkD0AVVkjuZ.json
+++ b/data/packs/monsters.db/goblin__boss__R3CMnUkD0AVVkjuZ.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/goblin__shaman__Ot77aKKqmML8yboF.json
+++ b/data/packs/monsters.db/goblin__shaman__Ot77aKKqmML8yboF.json
@@ -25,8 +25,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -95,9 +96,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/golem__clay__y8O1UJWvVI7fDXpn.json
+++ b/data/packs/monsters.db/golem__clay__y8O1UJWvVI7fDXpn.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/golem__flesh__IDgaXGnSleQcfAwm.json
+++ b/data/packs/monsters.db/golem__flesh__IDgaXGnSleQcfAwm.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/golem__iron__KZNQRwpG4DaN57zB.json
+++ b/data/packs/monsters.db/golem__iron__KZNQRwpG4DaN57zB.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/golem__stone__zLDg6vIYEj4wB0lQ.json
+++ b/data/packs/monsters.db/golem__stone__zLDg6vIYEj4wB0lQ.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/gorgon__c9n0i79sjiUWwkiV.json
+++ b/data/packs/monsters.db/gorgon__c9n0i79sjiUWwkiV.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/gorilla__cfdlaAx4balFmIb4.json
+++ b/data/packs/monsters.db/gorilla__cfdlaAx4balFmIb4.json
@@ -21,8 +21,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -91,9 +92,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/gray_ooze__04acXEvbSpXQ1NjS.json
+++ b/data/packs/monsters.db/gray_ooze__04acXEvbSpXQ1NjS.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/grick__Jn5JjEPCUT86txAg.json
+++ b/data/packs/monsters.db/grick__Jn5JjEPCUT86txAg.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/griffon__72LUt9AEysl22JGv.json
+++ b/data/packs/monsters.db/griffon__72LUt9AEysl22JGv.json
@@ -21,8 +21,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -91,9 +92,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/grimlow__A6QrevZXpJ0SeiIv.json
+++ b/data/packs/monsters.db/grimlow__A6QrevZXpJ0SeiIv.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/guard__unySR92Si932s01C.json
+++ b/data/packs/monsters.db/guard__unySR92Si932s01C.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/hag__night__hi47xC8rfvviBoOO.json
+++ b/data/packs/monsters.db/hag__night__hi47xC8rfvviBoOO.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/hag__sea__vSA5WApOVd99itBh.json
+++ b/data/packs/monsters.db/hag__sea__vSA5WApOVd99itBh.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/hag__weald__9q5O77FFFJ7pTjhL.json
+++ b/data/packs/monsters.db/hag__weald__9q5O77FFFJ7pTjhL.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/harpy__CsQXDNmBDfao8hij.json
+++ b/data/packs/monsters.db/harpy__CsQXDNmBDfao8hij.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/hell_hound__PAb9czULqynbNnKj.json
+++ b/data/packs/monsters.db/hell_hound__PAb9czULqynbNnKj.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/hippogriff__SgSkMF7D9BE69ubm.json
+++ b/data/packs/monsters.db/hippogriff__SgSkMF7D9BE69ubm.json
@@ -21,8 +21,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -91,9 +92,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/hippopotamus__WI7Tq6Vf2vmgBKcN.json
+++ b/data/packs/monsters.db/hippopotamus__WI7Tq6Vf2vmgBKcN.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/hobgoblin__uqHIz56KiBwTnbTJ.json
+++ b/data/packs/monsters.db/hobgoblin__uqHIz56KiBwTnbTJ.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/horse__olqRJQaOKMLkESQN.json
+++ b/data/packs/monsters.db/horse__olqRJQaOKMLkESQN.json
@@ -21,8 +21,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -91,9 +92,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/hydra__hr2wYwBcd0WuJWK8.json
+++ b/data/packs/monsters.db/hydra__hr2wYwBcd0WuJWK8.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/invisible_stalker__3cz1ScEh3YlMU1ql.json
+++ b/data/packs/monsters.db/invisible_stalker__3cz1ScEh3YlMU1ql.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/jellyfish__uNah6fsgfkt4Aiet.json
+++ b/data/packs/monsters.db/jellyfish__uNah6fsgfkt4Aiet.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 0.5,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/knight__BviPIbrJao1ubOX1.json
+++ b/data/packs/monsters.db/knight__BviPIbrJao1ubOX1.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/kobold__BxilUr9Ac6zgekYU.json
+++ b/data/packs/monsters.db/kobold__BxilUr9Ac6zgekYU.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/kobold__sorcerer__j1Uy1uGIUxbtB0iD.json
+++ b/data/packs/monsters.db/kobold__sorcerer__j1Uy1uGIUxbtB0iD.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/kraken__4A7ELy7Oj4YKRqTf.json
+++ b/data/packs/monsters.db/kraken__4A7ELy7Oj4YKRqTf.json
@@ -25,8 +25,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 4,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -95,9 +96,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/leech__giant__UGsq7I9Gyahgd0dG.json
+++ b/data/packs/monsters.db/leech__giant__UGsq7I9Gyahgd0dG.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 0.5,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/leprechaun__dNSmJX2keI0T2Gig.json
+++ b/data/packs/monsters.db/leprechaun__dNSmJX2keI0T2Gig.json
@@ -25,8 +25,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -95,9 +96,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/lich__sncxcSi6ziTStjAh.json
+++ b/data/packs/monsters.db/lich__sncxcSi6ziTStjAh.json
@@ -29,8 +29,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -99,9 +100,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/lion__3InGAUnBJixja6ld.json
+++ b/data/packs/monsters.db/lion__3InGAUnBJixja6ld.json
@@ -21,8 +21,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -91,9 +92,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/lizardfolk__h4e6ntO5vWTShNi9.json
+++ b/data/packs/monsters.db/lizardfolk__h4e6ntO5vWTShNi9.json
@@ -21,8 +21,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -91,9 +92,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/mage__manaoose71vhAWCT.json
+++ b/data/packs/monsters.db/mage__manaoose71vhAWCT.json
@@ -25,8 +25,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -95,9 +96,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/mammoth__0QznxquCW5qW69V6.json
+++ b/data/packs/monsters.db/mammoth__0QznxquCW5qW69V6.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/manta_ray__giant__QhFsevIc23TsTHZE.json
+++ b/data/packs/monsters.db/manta_ray__giant__QhFsevIc23TsTHZE.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/manticore__LBjQecdHrFaX8SPj.json
+++ b/data/packs/monsters.db/manticore__LBjQecdHrFaX8SPj.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/mastiff__lJyH2RWm3t5MB5iG.json
+++ b/data/packs/monsters.db/mastiff__lJyH2RWm3t5MB5iG.json
@@ -21,8 +21,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -91,9 +92,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/medusa__u05UfQ9hKno0bwWj.json
+++ b/data/packs/monsters.db/medusa__u05UfQ9hKno0bwWj.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/merfolk__CXZNV3102oiDkME4.json
+++ b/data/packs/monsters.db/merfolk__CXZNV3102oiDkME4.json
@@ -21,8 +21,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -91,9 +92,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/mimic__LFx9hb8JlEfGxDaI.json
+++ b/data/packs/monsters.db/mimic__LFx9hb8JlEfGxDaI.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/minotaur__c3Nvj86e0Layz3NG.json
+++ b/data/packs/monsters.db/minotaur__c3Nvj86e0Layz3NG.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/moose__tfoTO9pQhnS0RAOH.json
+++ b/data/packs/monsters.db/moose__tfoTO9pQhnS0RAOH.json
@@ -21,8 +21,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -91,9 +92,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/mordanticus_the_flayed__DP8n8iIiU1Qostjv.json
+++ b/data/packs/monsters.db/mordanticus_the_flayed__DP8n8iIiU1Qostjv.json
@@ -31,8 +31,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -101,9 +102,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/mummy__kY87zSryGuQ963Ba.json
+++ b/data/packs/monsters.db/mummy__kY87zSryGuQ963Ba.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/mushroomfolk__K2FMeD45kPEr8RNS.json
+++ b/data/packs/monsters.db/mushroomfolk__K2FMeD45kPEr8RNS.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/naga__UDGXIj9pB0TdWPA6.json
+++ b/data/packs/monsters.db/naga__UDGXIj9pB0TdWPA6.json
@@ -25,8 +25,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -95,9 +96,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/naga__bone__azSFk2v032NJ635x.json
+++ b/data/packs/monsters.db/naga__bone__azSFk2v032NJ635x.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/nightmare__bxcbuzesUqGpEBxw.json
+++ b/data/packs/monsters.db/nightmare__bxcbuzesUqGpEBxw.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/obe_ixx_of_azarumme__6ce2xr1QmjJFMe5P.json
+++ b/data/packs/monsters.db/obe_ixx_of_azarumme__6ce2xr1QmjJFMe5P.json
@@ -28,8 +28,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -98,9 +99,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/ochre_jelly__QErMaMVIbddgk9MX.json
+++ b/data/packs/monsters.db/ochre_jelly__QErMaMVIbddgk9MX.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/octopus__giant__h0NMkJj2DCJiQ9Zw.json
+++ b/data/packs/monsters.db/octopus__giant__h0NMkJj2DCJiQ9Zw.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/ogre__VrYTiPjDOH1LIEBr.json
+++ b/data/packs/monsters.db/ogre__VrYTiPjDOH1LIEBr.json
@@ -21,8 +21,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -91,9 +92,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/oni__yMyZ18conSZhwlpg.json
+++ b/data/packs/monsters.db/oni__yMyZ18conSZhwlpg.json
@@ -25,8 +25,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -95,9 +96,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/orc__Rq4WF5z0ZBFHNLub.json
+++ b/data/packs/monsters.db/orc__Rq4WF5z0ZBFHNLub.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/orc__chieftain__v2Q2R3tGkcvslEbB.json
+++ b/data/packs/monsters.db/orc__chieftain__v2Q2R3tGkcvslEbB.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/otyugh__Crc6mFgLL9vNJuaS.json
+++ b/data/packs/monsters.db/otyugh__Crc6mFgLL9vNJuaS.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/owlbear__jXsS8HEA6XsvOngt.json
+++ b/data/packs/monsters.db/owlbear__jXsS8HEA6XsvOngt.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/panther__dULmhpAV6apvNDPO.json
+++ b/data/packs/monsters.db/panther__dULmhpAV6apvNDPO.json
@@ -21,8 +21,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -91,9 +92,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/peasant__V75YwrR126oziTKk.json
+++ b/data/packs/monsters.db/peasant__V75YwrR126oziTKk.json
@@ -21,8 +21,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -91,9 +92,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/pegasus__5Tp7B3qOMEAdMkJ8.json
+++ b/data/packs/monsters.db/pegasus__5Tp7B3qOMEAdMkJ8.json
@@ -21,8 +21,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -91,9 +92,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/phoenix__o3Yd8P0DavwDp21b.json
+++ b/data/packs/monsters.db/phoenix__o3Yd8P0DavwDp21b.json
@@ -25,8 +25,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -95,9 +96,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/piranha__swarm__LZsDirxnEAlPoOhH.json
+++ b/data/packs/monsters.db/piranha__swarm__LZsDirxnEAlPoOhH.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/pirate__ZFH3OQCziTyacf5e.json
+++ b/data/packs/monsters.db/pirate__ZFH3OQCziTyacf5e.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/plesiosaurus__vVRAwuWbYEtPctOE.json
+++ b/data/packs/monsters.db/plesiosaurus__vVRAwuWbYEtPctOE.json
@@ -21,8 +21,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -91,9 +92,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/priest__vRn6zM7a0nrqSiY5.json
+++ b/data/packs/monsters.db/priest__vRn6zM7a0nrqSiY5.json
@@ -25,8 +25,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -95,9 +96,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/primordial_slime__pB9F8QWYdWzfZMzs.json
+++ b/data/packs/monsters.db/primordial_slime__pB9F8QWYdWzfZMzs.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/pterodactyl__xIitpxW19LP91JA3.json
+++ b/data/packs/monsters.db/pterodactyl__xIitpxW19LP91JA3.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/purple_worm__VxV56gRyhUJfXu83.json
+++ b/data/packs/monsters.db/purple_worm__VxV56gRyhUJfXu83.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 4,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/rakshasa__JAl9s0Rm4b1beFa1.json
+++ b/data/packs/monsters.db/rakshasa__JAl9s0Rm4b1beFa1.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/rat__dire__3jwLk7zEFiHk7kna.json
+++ b/data/packs/monsters.db/rat__dire__3jwLk7zEFiHk7kna.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/rat__giant__OYtg4Ta4PIpvIZxq.json
+++ b/data/packs/monsters.db/rat__giant__OYtg4Ta4PIpvIZxq.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 0.5,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/rat__kRjM8lPIVu1b5b3g.json
+++ b/data/packs/monsters.db/rat__kRjM8lPIVu1b5b3g.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 0.5,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/rat__swarm__UxMr9qvyuIt9ZwM7.json
+++ b/data/packs/monsters.db/rat__swarm__UxMr9qvyuIt9ZwM7.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/rathgamnon__o5xhxniboMbTCMLk.json
+++ b/data/packs/monsters.db/rathgamnon__o5xhxniboMbTCMLk.json
@@ -29,8 +29,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -99,9 +100,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/reaver__HO9aYtRdsjHHAYHj.json
+++ b/data/packs/monsters.db/reaver__HO9aYtRdsjHHAYHj.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/remorhaz__OrFJy0frYF2B8wbh.json
+++ b/data/packs/monsters.db/remorhaz__OrFJy0frYF2B8wbh.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/rhinoceros__SG7K5ZFCguR27Gxm.json
+++ b/data/packs/monsters.db/rhinoceros__SG7K5ZFCguR27Gxm.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/rime_walker__pWIrU2mRsvTe17Nh.json
+++ b/data/packs/monsters.db/rime_walker__pWIrU2mRsvTe17Nh.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/roc__39kt1XjVZ4JZSdEj.json
+++ b/data/packs/monsters.db/roc__39kt1XjVZ4JZSdEj.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/roper__C0CuPZJOFDmuplw8.json
+++ b/data/packs/monsters.db/roper__C0CuPZJOFDmuplw8.json
@@ -26,8 +26,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -96,9 +97,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/rot_flower__pE0tXsYluDmktWNv.json
+++ b/data/packs/monsters.db/rot_flower__pE0tXsYluDmktWNv.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/rust_monster__qISCrzLvHr4uQ9Q8.json
+++ b/data/packs/monsters.db/rust_monster__qISCrzLvHr4uQ9Q8.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/sahuagin__soe49ydTgVbQ0AwZ.json
+++ b/data/packs/monsters.db/sahuagin__soe49ydTgVbQ0AwZ.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/salamander__t3Wr5E8hsOs1xtfK.json
+++ b/data/packs/monsters.db/salamander__t3Wr5E8hsOs1xtfK.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/scarab__swarm__U9moCUg8DnL6C0Sq.json
+++ b/data/packs/monsters.db/scarab__swarm__U9moCUg8DnL6C0Sq.json
@@ -21,8 +21,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -91,9 +92,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/scarecrow__Hdpcnnvyh69C4BnO.json
+++ b/data/packs/monsters.db/scarecrow__Hdpcnnvyh69C4BnO.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/scorpion__giant__TZGzGBYncOs3r9ZF.json
+++ b/data/packs/monsters.db/scorpion__giant__TZGzGBYncOs3r9ZF.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/scorpion__lDXLWTA4FLMpAblB.json
+++ b/data/packs/monsters.db/scorpion__lDXLWTA4FLMpAblB.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 0.5,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/shadow__Fd7VgUIaCK6xQkS2.json
+++ b/data/packs/monsters.db/shadow__Fd7VgUIaCK6xQkS2.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/shambling_mound__uTmirbJfdHFTag2i.json
+++ b/data/packs/monsters.db/shambling_mound__uTmirbJfdHFTag2i.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/shark__MQ6bhM8xiI39ziUU.json
+++ b/data/packs/monsters.db/shark__MQ6bhM8xiI39ziUU.json
@@ -21,8 +21,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -91,9 +92,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/shark__megalodon__uQLXRcMggAhwFVMJ.json
+++ b/data/packs/monsters.db/shark__megalodon__uQLXRcMggAhwFVMJ.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/siren__iaP5JVmGCrkkTAzO.json
+++ b/data/packs/monsters.db/siren__iaP5JVmGCrkkTAzO.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/skeleton__cWzG0yEVgIk8ijk6.json
+++ b/data/packs/monsters.db/skeleton__cWzG0yEVgIk8ijk6.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/smilodon__8tUERo3WvtZe9K8O.json
+++ b/data/packs/monsters.db/smilodon__8tUERo3WvtZe9K8O.json
@@ -21,8 +21,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -91,9 +92,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/snake__cobra__anfsgfN2gFs72MHo.json
+++ b/data/packs/monsters.db/snake__cobra__anfsgfN2gFs72MHo.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 0.5,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/snake__giant__YHdOAuMUdCigLIHR.json
+++ b/data/packs/monsters.db/snake__giant__YHdOAuMUdCigLIHR.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/snake__swarm__cUUnqWyaNDYghKxE.json
+++ b/data/packs/monsters.db/snake__swarm__cUUnqWyaNDYghKxE.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/soldier__Kw5KEyZVy5ugaTTy.json
+++ b/data/packs/monsters.db/soldier__Kw5KEyZVy5ugaTTy.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/sphinx__JjJbKB1yomE7Ma8T.json
+++ b/data/packs/monsters.db/sphinx__JjJbKB1yomE7Ma8T.json
@@ -27,8 +27,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -97,9 +98,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/spider__giant__p9PayU4K9nBZ8JRl.json
+++ b/data/packs/monsters.db/spider__giant__p9PayU4K9nBZ8JRl.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/spider__piZE4vxM1QjLxEt0.json
+++ b/data/packs/monsters.db/spider__piZE4vxM1QjLxEt0.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 0.5,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/spider__swarm__rwE58nsTLAG7pW1u.json
+++ b/data/packs/monsters.db/spider__swarm__rwE58nsTLAG7pW1u.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/stingbat__bILTV7P0d55nACrQ.json
+++ b/data/packs/monsters.db/stingbat__bILTV7P0d55nACrQ.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 0.5,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/strangler__MldOgsKh8tfL0IhT.json
+++ b/data/packs/monsters.db/strangler__MldOgsKh8tfL0IhT.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/the_tarrasque__NTRHmnsw7poR4rZ9.json
+++ b/data/packs/monsters.db/the_tarrasque__NTRHmnsw7poR4rZ9.json
@@ -30,8 +30,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 4,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -100,9 +101,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/the_ten_eyed_oracle__hiZvVJPOJWtOXV4m.json
+++ b/data/packs/monsters.db/the_ten_eyed_oracle__hiZvVJPOJWtOXV4m.json
@@ -32,8 +32,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -102,9 +103,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/the_wandering_merchant__DbkmPt2k9fw5zxJw.json
+++ b/data/packs/monsters.db/the_wandering_merchant__DbkmPt2k9fw5zxJw.json
@@ -28,8 +28,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -98,9 +99,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/thief__Ap1b6HrZLpeRMvGp.json
+++ b/data/packs/monsters.db/thief__Ap1b6HrZLpeRMvGp.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/thug__zQMZlqx02eiQwbhV.json
+++ b/data/packs/monsters.db/thug__zQMZlqx02eiQwbhV.json
@@ -21,8 +21,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -91,9 +92,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/treant__0kzqjwTD3ouYsDZh.json
+++ b/data/packs/monsters.db/treant__0kzqjwTD3ouYsDZh.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/triceratops__ZGILlry1pBhE4iDh.json
+++ b/data/packs/monsters.db/triceratops__ZGILlry1pBhE4iDh.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/troll__eaA0qpZMGIgdIQYn.json
+++ b/data/packs/monsters.db/troll__eaA0qpZMGIgdIQYn.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/troll__frost__5uzilW5qSX7bPzxe.json
+++ b/data/packs/monsters.db/troll__frost__5uzilW5qSX7bPzxe.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/tyrannosaurus__JlQsRP4Gr5VhDYVK.json
+++ b/data/packs/monsters.db/tyrannosaurus__JlQsRP4Gr5VhDYVK.json
@@ -21,8 +21,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 3,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -91,9 +92,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/unicorn__Rh2bzqDRC1JF1FiG.json
+++ b/data/packs/monsters.db/unicorn__Rh2bzqDRC1JF1FiG.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/vampire__ei53dGxj76xmqQty.json
+++ b/data/packs/monsters.db/vampire__ei53dGxj76xmqQty.json
@@ -26,8 +26,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -96,9 +97,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/vampire_spawn__EDaGLKYYCT5rCMhY.json
+++ b/data/packs/monsters.db/vampire_spawn__EDaGLKYYCT5rCMhY.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/velociraptor__SEZS6U1BW8lEznja.json
+++ b/data/packs/monsters.db/velociraptor__SEZS6U1BW8lEznja.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 0.5,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/violet_fungus__NyZfmD9E2ZPD4QdH.json
+++ b/data/packs/monsters.db/violet_fungus__NyZfmD9E2ZPD4QdH.json
@@ -21,8 +21,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -91,9 +92,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/viperian__1lgm8jaBx4YNXmr7.json
+++ b/data/packs/monsters.db/viperian__1lgm8jaBx4YNXmr7.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/viperian__ophid__VRZ60vAEV5ltvs6k.json
+++ b/data/packs/monsters.db/viperian__ophid__VRZ60vAEV5ltvs6k.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/viperian__wizard__wgHzqAqBNsutUALU.json
+++ b/data/packs/monsters.db/viperian__wizard__wgHzqAqBNsutUALU.json
@@ -25,8 +25,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -95,9 +96,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/void_spawn__VvkJkRVLs6l9UaZy.json
+++ b/data/packs/monsters.db/void_spawn__VvkJkRVLs6l9UaZy.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/void_spider__QziiJsawKcGcS0QJ.json
+++ b/data/packs/monsters.db/void_spider__QziiJsawKcGcS0QJ.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/vulture__bzKSq624safyHLbE.json
+++ b/data/packs/monsters.db/vulture__bzKSq624safyHLbE.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/wasp__giant__K9M3BA8PlvYWFADe.json
+++ b/data/packs/monsters.db/wasp__giant__K9M3BA8PlvYWFADe.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/wererat__dSiRSDzrV4AJNnMk.json
+++ b/data/packs/monsters.db/wererat__dSiRSDzrV4AJNnMk.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/werewolf__1Z2r4GggLt8aNrP8.json
+++ b/data/packs/monsters.db/werewolf__1Z2r4GggLt8aNrP8.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/wight__ZCbay6SPPzbbz2bJ.json
+++ b/data/packs/monsters.db/wight__ZCbay6SPPzbbz2bJ.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/will_o__wisp__Fo9DMEiLgAJzsrJM.json
+++ b/data/packs/monsters.db/will_o__wisp__Fo9DMEiLgAJzsrJM.json
@@ -21,8 +21,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 0.5,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 20,
 		"disposition": -1,
@@ -91,9 +92,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/wolf__FzBj2e0DzIjvQ0JE.json
+++ b/data/packs/monsters.db/wolf__FzBj2e0DzIjvQ0JE.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/wolf__dire__fsxmTnmQ6ASZaVJ9.json
+++ b/data/packs/monsters.db/wolf__dire__fsxmTnmQ6ASZaVJ9.json
@@ -22,8 +22,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -92,9 +93,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/wolf__winter__nugxSBkw9LcUDPqF.json
+++ b/data/packs/monsters.db/wolf__winter__nugxSBkw9LcUDPqF.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/worg__D5Tu4i3vYYqTCwUK.json
+++ b/data/packs/monsters.db/worg__D5Tu4i3vYYqTCwUK.json
@@ -21,8 +21,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -91,9 +92,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/wraith__ch1UpQSCVBgUNS2a.json
+++ b/data/packs/monsters.db/wraith__ch1UpQSCVBgUNS2a.json
@@ -24,8 +24,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -94,9 +95,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/wyvern__IUN6KcvNGGJWTQCE.json
+++ b/data/packs/monsters.db/wyvern__IUN6KcvNGGJWTQCE.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 2,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/monsters.db/zombie__Q89EgThYcungYTke.json
+++ b/data/packs/monsters.db/zombie__Q89EgThYcungYTke.json
@@ -23,8 +23,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 0,
 		"disposition": -1,
@@ -93,9 +94,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/tokens/cowled_token.webp",

--- a/data/packs/quickstart-adventures.db/the_lost_citadel_of_the_scarlet_minotaur__0qbqDCsioL4HWVvW.json
+++ b/data/packs/quickstart-adventures.db/the_lost_citadel_of_the_scarlet_minotaur__0qbqDCsioL4HWVvW.json
@@ -6,7 +6,7 @@
 			"_id": "asJ04sNrjrONdPYc",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.monster.V75YwrR126oziTKk",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629679,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -28,10 +28,12 @@
 					"_id": "3DtlC7L1PrMFyn7n",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -91,8 +93,9 @@
 				"bar2": {
 					"attribute": null
 				},
-				"detectionModes": [
-				],
+				"depth": 1,
+				"detectionModes": {
+				},
 				"displayBars": 0,
 				"displayName": 20,
 				"disposition": 0,
@@ -161,9 +164,6 @@
 					"anchorX": 0.5,
 					"anchorY": 0.5,
 					"fit": "contain",
-					"offsetX": 0,
-					"offsetY": 0,
-					"rotation": 0,
 					"scaleX": 1,
 					"scaleY": 1,
 					"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -229,7 +229,7 @@
 			"_id": "XPNU79kJyse04pL3",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.monster.c3Nvj86e0Layz3NG",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629679,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -251,10 +251,12 @@
 					"_id": "bHue9K4fSJkmUWNm",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -283,10 +285,12 @@
 					"_id": "ZOlhmdkqfQyyT6R3",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -335,10 +339,12 @@
 					"_id": "Ag019spAbwwDbhSZ",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -398,8 +404,9 @@
 				"bar2": {
 					"attribute": null
 				},
-				"detectionModes": [
-				],
+				"depth": 1,
+				"detectionModes": {
+				},
 				"displayBars": 0,
 				"displayName": 20,
 				"disposition": -1,
@@ -468,9 +475,6 @@
 					"anchorX": 0.5,
 					"anchorY": 0.5,
 					"fit": "contain",
-					"offsetX": 0,
-					"offsetY": 0,
-					"rotation": 0,
 					"scaleX": 1.5,
 					"scaleY": 1.5,
 					"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -536,7 +540,7 @@
 			"_id": "rh1ZgUTuHcwhlt4F",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.monster.fcgq7uwsJEMMdRNx",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629679,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -558,10 +562,12 @@
 					"_id": "e020Tn4yv7Aj604M",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -590,10 +596,12 @@
 					"_id": "hhkN0EkQbBFGgJfr",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -642,10 +650,12 @@
 					"_id": "xURhvz16GozH0j8f",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -705,8 +715,9 @@
 				"bar2": {
 					"attribute": null
 				},
-				"detectionModes": [
-				],
+				"depth": 1,
+				"detectionModes": {
+				},
 				"displayBars": 0,
 				"displayName": 20,
 				"disposition": -1,
@@ -775,9 +786,6 @@
 					"anchorX": 0.5,
 					"anchorY": 0.5,
 					"fit": "contain",
-					"offsetX": 0,
-					"offsetY": 0,
-					"rotation": 0,
 					"scaleX": 1,
 					"scaleY": 1,
 					"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -843,7 +851,7 @@
 			"_id": "QvVJAySJZMTMnEZp",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.monster.fcgq7uwsJEMMdRNx",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629679,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -865,10 +873,12 @@
 					"_id": "e020Tn4yv7Aj604M",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -897,10 +907,12 @@
 					"_id": "hhkN0EkQbBFGgJfr",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -949,10 +961,12 @@
 					"_id": "xURhvz16GozH0j8f",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -1012,8 +1026,9 @@
 				"bar2": {
 					"attribute": null
 				},
-				"detectionModes": [
-				],
+				"depth": 1,
+				"detectionModes": {
+				},
 				"displayBars": 0,
 				"displayName": 20,
 				"disposition": -1,
@@ -1082,9 +1097,6 @@
 					"anchorX": 0.5,
 					"anchorY": 0.5,
 					"fit": "contain",
-					"offsetX": 0,
-					"offsetY": 0,
-					"rotation": 0,
 					"scaleX": 1,
 					"scaleY": 1,
 					"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -1150,7 +1162,7 @@
 			"_id": "82lFpkXeVpKnPWCQ",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.monster.fcgq7uwsJEMMdRNx",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629679,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -1172,10 +1184,12 @@
 					"_id": "e020Tn4yv7Aj604M",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -1204,10 +1218,12 @@
 					"_id": "hhkN0EkQbBFGgJfr",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -1256,10 +1272,12 @@
 					"_id": "xURhvz16GozH0j8f",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -1319,8 +1337,9 @@
 				"bar2": {
 					"attribute": null
 				},
-				"detectionModes": [
-				],
+				"depth": 1,
+				"detectionModes": {
+				},
 				"displayBars": 0,
 				"displayName": 20,
 				"disposition": -1,
@@ -1389,9 +1408,6 @@
 					"anchorX": 0.5,
 					"anchorY": 0.5,
 					"fit": "contain",
-					"offsetX": 0,
-					"offsetY": 0,
-					"rotation": 0,
 					"scaleX": 1,
 					"scaleY": 1,
 					"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -1457,7 +1473,7 @@
 			"_id": "1WXEDbF6gSa4fQUQ",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.monster.fcgq7uwsJEMMdRNx",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629679,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -1479,10 +1495,12 @@
 					"_id": "e020Tn4yv7Aj604M",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -1511,10 +1529,12 @@
 					"_id": "hhkN0EkQbBFGgJfr",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -1563,10 +1583,12 @@
 					"_id": "xURhvz16GozH0j8f",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -1626,8 +1648,9 @@
 				"bar2": {
 					"attribute": null
 				},
-				"detectionModes": [
-				],
+				"depth": 1,
+				"detectionModes": {
+				},
 				"displayBars": 0,
 				"displayName": 20,
 				"disposition": -1,
@@ -1696,9 +1719,6 @@
 					"anchorX": 0.5,
 					"anchorY": 0.5,
 					"fit": "contain",
-					"offsetX": 0,
-					"offsetY": 0,
-					"rotation": 0,
 					"scaleX": 1,
 					"scaleY": 1,
 					"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -1764,7 +1784,7 @@
 			"_id": "eVuNGaceV93M5whd",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.monster.fcgq7uwsJEMMdRNx",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629679,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -1786,10 +1806,12 @@
 					"_id": "e020Tn4yv7Aj604M",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -1818,10 +1840,12 @@
 					"_id": "hhkN0EkQbBFGgJfr",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -1870,10 +1894,12 @@
 					"_id": "xURhvz16GozH0j8f",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -1933,8 +1959,9 @@
 				"bar2": {
 					"attribute": null
 				},
-				"detectionModes": [
-				],
+				"depth": 1,
+				"detectionModes": {
+				},
 				"displayBars": 0,
 				"displayName": 20,
 				"disposition": -1,
@@ -2003,9 +2030,6 @@
 					"anchorX": 0.5,
 					"anchorY": 0.5,
 					"fit": "contain",
-					"offsetX": 0,
-					"offsetY": 0,
-					"rotation": 0,
 					"scaleX": 1,
 					"scaleY": 1,
 					"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -2071,7 +2095,7 @@
 			"_id": "rok3i6Gy0RjoBgrq",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.monster.fcgq7uwsJEMMdRNx",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629679,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -2093,10 +2117,12 @@
 					"_id": "e020Tn4yv7Aj604M",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -2125,10 +2151,12 @@
 					"_id": "hhkN0EkQbBFGgJfr",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -2177,10 +2205,12 @@
 					"_id": "xURhvz16GozH0j8f",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -2240,8 +2270,9 @@
 				"bar2": {
 					"attribute": null
 				},
-				"detectionModes": [
-				],
+				"depth": 1,
+				"detectionModes": {
+				},
 				"displayBars": 0,
 				"displayName": 20,
 				"disposition": -1,
@@ -2310,9 +2341,6 @@
 					"anchorX": 0.5,
 					"anchorY": 0.5,
 					"fit": "contain",
-					"offsetX": 0,
-					"offsetY": 0,
-					"rotation": 0,
 					"scaleX": 1,
 					"scaleY": 1,
 					"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -2378,7 +2406,7 @@
 			"_id": "mdRstp355OUOyY7r",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.monster.k8tAgECWIzPIStGU",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629679,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -2400,10 +2428,12 @@
 					"_id": "4vlFF9RY0RInh7uU",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -2453,10 +2483,12 @@
 					"_id": "S9otkKlpEjmVLs8M",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -2496,8 +2528,9 @@
 				"bar2": {
 					"attribute": null
 				},
-				"detectionModes": [
-				],
+				"depth": 1,
+				"detectionModes": {
+				},
 				"displayBars": 0,
 				"displayName": 20,
 				"disposition": -1,
@@ -2566,9 +2599,6 @@
 					"anchorX": 0.5,
 					"anchorY": 0.5,
 					"fit": "contain",
-					"offsetX": 0,
-					"offsetY": 0,
-					"rotation": 0,
 					"scaleX": 1,
 					"scaleY": 1,
 					"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -2634,7 +2664,7 @@
 			"_id": "VIiW9qercPbgheGh",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.monster.k8tAgECWIzPIStGU",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629679,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -2656,10 +2686,12 @@
 					"_id": "4vlFF9RY0RInh7uU",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -2709,10 +2741,12 @@
 					"_id": "S9otkKlpEjmVLs8M",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -2752,8 +2786,9 @@
 				"bar2": {
 					"attribute": null
 				},
-				"detectionModes": [
-				],
+				"depth": 1,
+				"detectionModes": {
+				},
 				"displayBars": 0,
 				"displayName": 20,
 				"disposition": -1,
@@ -2822,9 +2857,6 @@
 					"anchorX": 0.5,
 					"anchorY": 0.5,
 					"fit": "contain",
-					"offsetX": 0,
-					"offsetY": 0,
-					"rotation": 0,
 					"scaleX": 1,
 					"scaleY": 1,
 					"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -2890,7 +2922,7 @@
 			"_id": "PZ6Pt3fz7LRaEWqU",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.monster.k8tAgECWIzPIStGU",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629679,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -2912,10 +2944,12 @@
 					"_id": "4vlFF9RY0RInh7uU",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -2965,10 +2999,12 @@
 					"_id": "S9otkKlpEjmVLs8M",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -3008,8 +3044,9 @@
 				"bar2": {
 					"attribute": null
 				},
-				"detectionModes": [
-				],
+				"depth": 1,
+				"detectionModes": {
+				},
 				"displayBars": 0,
 				"displayName": 20,
 				"disposition": -1,
@@ -3078,9 +3115,6 @@
 					"anchorX": 0.5,
 					"anchorY": 0.5,
 					"fit": "contain",
-					"offsetX": 0,
-					"offsetY": 0,
-					"rotation": 0,
 					"scaleX": 1,
 					"scaleY": 1,
 					"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -3146,7 +3180,7 @@
 			"_id": "XbO8sDu1ToDVVoh9",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.monster.k8tAgECWIzPIStGU",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629679,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -3168,10 +3202,12 @@
 					"_id": "4vlFF9RY0RInh7uU",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -3221,10 +3257,12 @@
 					"_id": "S9otkKlpEjmVLs8M",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -3264,8 +3302,9 @@
 				"bar2": {
 					"attribute": null
 				},
-				"detectionModes": [
-				],
+				"depth": 1,
+				"detectionModes": {
+				},
 				"displayBars": 0,
 				"displayName": 20,
 				"disposition": -1,
@@ -3334,9 +3373,6 @@
 					"anchorX": 0.5,
 					"anchorY": 0.5,
 					"fit": "contain",
-					"offsetX": 0,
-					"offsetY": 0,
-					"rotation": 0,
 					"scaleX": 1,
 					"scaleY": 1,
 					"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -3402,7 +3438,7 @@
 			"_id": "bERcM50HvKw0ZY6o",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.monster.k8tAgECWIzPIStGU",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629679,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -3424,10 +3460,12 @@
 					"_id": "4vlFF9RY0RInh7uU",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -3477,10 +3515,12 @@
 					"_id": "S9otkKlpEjmVLs8M",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -3520,8 +3560,9 @@
 				"bar2": {
 					"attribute": null
 				},
-				"detectionModes": [
-				],
+				"depth": 1,
+				"detectionModes": {
+				},
 				"displayBars": 0,
 				"displayName": 20,
 				"disposition": -1,
@@ -3590,9 +3631,6 @@
 					"anchorX": 0.5,
 					"anchorY": 0.5,
 					"fit": "contain",
-					"offsetX": 0,
-					"offsetY": 0,
-					"rotation": 0,
 					"scaleX": 1,
 					"scaleY": 1,
 					"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -3658,7 +3696,7 @@
 			"_id": "CDxRc2pIwG7SK73E",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.monster.k8tAgECWIzPIStGU",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629679,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -3680,10 +3718,12 @@
 					"_id": "4vlFF9RY0RInh7uU",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -3733,10 +3773,12 @@
 					"_id": "S9otkKlpEjmVLs8M",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -3776,8 +3818,9 @@
 				"bar2": {
 					"attribute": null
 				},
-				"detectionModes": [
-				],
+				"depth": 1,
+				"detectionModes": {
+				},
 				"displayBars": 0,
 				"displayName": 20,
 				"disposition": -1,
@@ -3846,9 +3889,6 @@
 					"anchorX": 0.5,
 					"anchorY": 0.5,
 					"fit": "contain",
-					"offsetX": 0,
-					"offsetY": 0,
-					"rotation": 0,
 					"scaleX": 1,
 					"scaleY": 1,
 					"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -3914,7 +3954,7 @@
 			"_id": "L91uEF4duAo8T5Eq",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.monster.k8tAgECWIzPIStGU",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629679,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -3936,10 +3976,12 @@
 					"_id": "4vlFF9RY0RInh7uU",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -3989,10 +4031,12 @@
 					"_id": "S9otkKlpEjmVLs8M",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -4032,8 +4076,9 @@
 				"bar2": {
 					"attribute": null
 				},
-				"detectionModes": [
-				],
+				"depth": 1,
+				"detectionModes": {
+				},
 				"displayBars": 0,
 				"displayName": 20,
 				"disposition": -1,
@@ -4102,9 +4147,6 @@
 					"anchorX": 0.5,
 					"anchorY": 0.5,
 					"fit": "contain",
-					"offsetX": 0,
-					"offsetY": 0,
-					"rotation": 0,
 					"scaleX": 1,
 					"scaleY": 1,
 					"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -4170,7 +4212,7 @@
 			"_id": "4Ou1RViS2GnqvRh9",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.monster.k8tAgECWIzPIStGU",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629679,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -4192,10 +4234,12 @@
 					"_id": "4vlFF9RY0RInh7uU",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -4245,10 +4289,12 @@
 					"_id": "S9otkKlpEjmVLs8M",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -4288,8 +4334,9 @@
 				"bar2": {
 					"attribute": null
 				},
-				"detectionModes": [
-				],
+				"depth": 1,
+				"detectionModes": {
+				},
 				"displayBars": 0,
 				"displayName": 20,
 				"disposition": -1,
@@ -4358,9 +4405,6 @@
 					"anchorX": 0.5,
 					"anchorY": 0.5,
 					"fit": "contain",
-					"offsetX": 0,
-					"offsetY": 0,
-					"rotation": 0,
 					"scaleX": 1,
 					"scaleY": 1,
 					"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -4426,7 +4470,7 @@
 			"_id": "hoL50RSbMvRNrrcY",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.monster.k8tAgECWIzPIStGU",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629679,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -4448,10 +4492,12 @@
 					"_id": "4vlFF9RY0RInh7uU",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -4501,10 +4547,12 @@
 					"_id": "S9otkKlpEjmVLs8M",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -4544,8 +4592,9 @@
 				"bar2": {
 					"attribute": null
 				},
-				"detectionModes": [
-				],
+				"depth": 1,
+				"detectionModes": {
+				},
 				"displayBars": 0,
 				"displayName": 20,
 				"disposition": -1,
@@ -4614,9 +4663,6 @@
 					"anchorX": 0.5,
 					"anchorY": 0.5,
 					"fit": "contain",
-					"offsetX": 0,
-					"offsetY": 0,
-					"rotation": 0,
 					"scaleX": 1,
 					"scaleY": 1,
 					"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -4682,7 +4728,7 @@
 			"_id": "Fg9DEqSk8eACtwOw",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.monster.k8tAgECWIzPIStGU",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629679,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -4704,10 +4750,12 @@
 					"_id": "4vlFF9RY0RInh7uU",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -4757,10 +4805,12 @@
 					"_id": "S9otkKlpEjmVLs8M",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -4800,8 +4850,9 @@
 				"bar2": {
 					"attribute": null
 				},
-				"detectionModes": [
-				],
+				"depth": 1,
+				"detectionModes": {
+				},
 				"displayBars": 0,
 				"displayName": 20,
 				"disposition": -1,
@@ -4870,9 +4921,6 @@
 					"anchorX": 0.5,
 					"anchorY": 0.5,
 					"fit": "contain",
-					"offsetX": 0,
-					"offsetY": 0,
-					"rotation": 0,
 					"scaleX": 1,
 					"scaleY": 1,
 					"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -4938,7 +4986,7 @@
 			"_id": "9u8T17Lwd08OZ4j3",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.monster.U9moCUg8DnL6C0Sq",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629679,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -4960,10 +5008,12 @@
 					"_id": "85Q2R6Yq41pn5iqr",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -5023,8 +5073,9 @@
 				"bar2": {
 					"attribute": null
 				},
-				"detectionModes": [
-				],
+				"depth": 1,
+				"detectionModes": {
+				},
 				"displayBars": 0,
 				"displayName": 20,
 				"disposition": -1,
@@ -5093,9 +5144,6 @@
 					"anchorX": 0.5,
 					"anchorY": 0.5,
 					"fit": "contain",
-					"offsetX": 0,
-					"offsetY": 0,
-					"rotation": 0,
 					"scaleX": 1,
 					"scaleY": 1,
 					"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -5161,7 +5209,7 @@
 			"_id": "hKMfJWF0yyMNRmJI",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.monster.cWzG0yEVgIk8ijk6",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629679,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -5183,10 +5231,12 @@
 					"_id": "fJL9lcfORjpzaBCe",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -5215,10 +5265,12 @@
 					"_id": "D2ICcZFerw1x6D7y",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -5267,10 +5319,12 @@
 					"_id": "9oxZTYPcCbLq6SV9",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -5330,8 +5384,9 @@
 				"bar2": {
 					"attribute": null
 				},
-				"detectionModes": [
-				],
+				"depth": 1,
+				"detectionModes": {
+				},
 				"displayBars": 0,
 				"displayName": 20,
 				"disposition": -1,
@@ -5400,9 +5455,6 @@
 					"anchorX": 0.5,
 					"anchorY": 0.5,
 					"fit": "contain",
-					"offsetX": 0,
-					"offsetY": 0,
-					"rotation": 0,
 					"scaleX": 1,
 					"scaleY": 1,
 					"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -5468,7 +5520,7 @@
 			"_id": "uSNyukMWUS52MqNM",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.monster.k8tAgECWIzPIStGU",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629679,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -5490,10 +5542,12 @@
 					"_id": "4vlFF9RY0RInh7uU",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -5543,10 +5597,12 @@
 					"_id": "S9otkKlpEjmVLs8M",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -5586,8 +5642,9 @@
 				"bar2": {
 					"attribute": null
 				},
-				"detectionModes": [
-				],
+				"depth": 1,
+				"detectionModes": {
+				},
 				"displayBars": 0,
 				"displayName": 20,
 				"disposition": -1,
@@ -5656,9 +5713,6 @@
 					"anchorX": 0.5,
 					"anchorY": 0.5,
 					"fit": "contain",
-					"offsetX": 0,
-					"offsetY": 0,
-					"rotation": 0,
 					"scaleX": 1,
 					"scaleY": 1,
 					"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -5724,7 +5778,7 @@
 			"_id": "wYDtLvGDkSJ4QRtW",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.monsters.Actor.qSeHWgP59WltutCz",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629679,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -5746,10 +5800,12 @@
 					"_id": "KiuWCB6C6OcmOl0g",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -5798,10 +5854,12 @@
 					"_id": "ViAocDndtudFnp38",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -5841,8 +5899,9 @@
 				"bar2": {
 					"attribute": null
 				},
-				"detectionModes": [
-				],
+				"depth": 1,
+				"detectionModes": {
+				},
 				"displayBars": 0,
 				"displayName": 20,
 				"disposition": -1,
@@ -5911,9 +5970,6 @@
 					"anchorX": 0.5,
 					"anchorY": 0.5,
 					"fit": "contain",
-					"offsetX": 0,
-					"offsetY": 0,
-					"rotation": 0,
 					"scaleX": 1,
 					"scaleY": 1,
 					"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -5979,7 +6035,7 @@
 			"_id": "S5x2m9KQEN2HoPMp",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.monsters.Actor.QErMaMVIbddgk9MX",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629679,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -6001,10 +6057,12 @@
 					"_id": "RdRiN1ZsfjQf8leu",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -6033,10 +6091,12 @@
 					"_id": "evZXcoBxPaeka6UA",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -6096,8 +6156,9 @@
 				"bar2": {
 					"attribute": null
 				},
-				"detectionModes": [
-				],
+				"depth": 1,
+				"detectionModes": {
+				},
 				"displayBars": 0,
 				"displayName": 20,
 				"disposition": -1,
@@ -6166,9 +6227,6 @@
 					"anchorX": 0.5,
 					"anchorY": 0.5,
 					"fit": "contain",
-					"offsetX": 0,
-					"offsetY": 0,
-					"rotation": 0,
 					"scaleX": 1,
 					"scaleY": 1,
 					"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -6245,7 +6303,7 @@
 			"_id": "bPrm5lY7z87YrtFK",
 			"_stats": {
 				"compendiumSource": "Folder.bPrm5lY7z87YrtFK",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351630093,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -6270,7 +6328,7 @@
 			"_id": "Mv4mtkqbmowIBW0i",
 			"_stats": {
 				"compendiumSource": "Folder.Mv4mtkqbmowIBW0i",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351630093,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -6295,10 +6353,12 @@
 			"_id": "IybXZJ2wVuOa5OAx",
 			"_stats": {
 				"compendiumSource": "Folder.IybXZJ2wVuOa5OAx",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
+				"createdTime": null,
 				"duplicateSource": null,
 				"exportSource": null,
 				"lastModifiedBy": null,
+				"modifiedTime": null,
 				"systemId": "shadowdark",
 				"systemVersion": "4.0.0"
 			},
@@ -6318,10 +6378,12 @@
 			"_id": "hPTJxYMb8Cs3TkNS",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
+				"createdTime": null,
 				"duplicateSource": null,
 				"exportSource": null,
 				"lastModifiedBy": null,
+				"modifiedTime": null,
 				"systemId": "shadowdark",
 				"systemVersion": "4.0.0"
 			},
@@ -6339,10 +6401,12 @@
 			"_id": "51VbSIfkmvCD0sGJ",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
+				"createdTime": null,
 				"duplicateSource": null,
 				"exportSource": null,
 				"lastModifiedBy": null,
+				"modifiedTime": null,
 				"systemId": "shadowdark",
 				"systemVersion": "4.0.0"
 			},
@@ -6360,7 +6424,7 @@
 			"_id": "G1kHYFAVnBCBQlS2",
 			"_stats": {
 				"compendiumSource": "Folder.G1kHYFAVnBCBQlS2",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351630093,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -6385,10 +6449,12 @@
 			"_id": "twdaDQr0Jo8qlJLQ",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
+				"createdTime": null,
 				"duplicateSource": null,
 				"exportSource": null,
 				"lastModifiedBy": null,
+				"modifiedTime": null,
 				"systemId": "shadowdark",
 				"systemVersion": "4.0.0"
 			},
@@ -6406,10 +6472,12 @@
 			"_id": "eAkRNjNAIkw5Filb",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
+				"createdTime": null,
 				"duplicateSource": null,
 				"exportSource": null,
 				"lastModifiedBy": null,
+				"modifiedTime": null,
 				"systemId": "shadowdark",
 				"systemVersion": "4.0.0"
 			},
@@ -6427,10 +6495,12 @@
 			"_id": "BDf1nVFV48fhhXJj",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
+				"createdTime": null,
 				"duplicateSource": null,
 				"exportSource": null,
 				"lastModifiedBy": null,
+				"modifiedTime": null,
 				"systemId": "shadowdark",
 				"systemVersion": "4.0.0"
 			},
@@ -6448,10 +6518,12 @@
 			"_id": "uE9nJqILEgInTyDf",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
+				"createdTime": null,
 				"duplicateSource": null,
 				"exportSource": null,
 				"lastModifiedBy": null,
+				"modifiedTime": null,
 				"systemId": "shadowdark",
 				"systemVersion": "4.0.0"
 			},
@@ -6469,10 +6541,12 @@
 			"_id": "ZsmLRJTwMl73j8lA",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
+				"createdTime": null,
 				"duplicateSource": null,
 				"exportSource": null,
 				"lastModifiedBy": null,
+				"modifiedTime": null,
 				"systemId": "shadowdark",
 				"systemVersion": "4.0.0"
 			},
@@ -6490,10 +6564,12 @@
 			"_id": "5IwCKSulxxpy8d9d",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
+				"createdTime": null,
 				"duplicateSource": null,
 				"exportSource": null,
 				"lastModifiedBy": null,
+				"modifiedTime": null,
 				"systemId": "shadowdark",
 				"systemVersion": "4.0.0"
 			},
@@ -6511,10 +6587,12 @@
 			"_id": "MhsKMzZZbZaBffuO",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
+				"createdTime": null,
 				"duplicateSource": null,
 				"exportSource": null,
 				"lastModifiedBy": null,
+				"modifiedTime": null,
 				"systemId": "shadowdark",
 				"systemVersion": "4.0.0"
 			},
@@ -6532,10 +6610,12 @@
 			"_id": "FVvvtsJct9vesF5q",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
+				"createdTime": null,
 				"duplicateSource": null,
 				"exportSource": null,
 				"lastModifiedBy": null,
+				"modifiedTime": null,
 				"systemId": "shadowdark",
 				"systemVersion": "4.0.0"
 			},
@@ -6553,10 +6633,12 @@
 			"_id": "yUwp3JQKkMzVOIyx",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
+				"createdTime": null,
 				"duplicateSource": null,
 				"exportSource": null,
 				"lastModifiedBy": null,
+				"modifiedTime": null,
 				"systemId": "shadowdark",
 				"systemVersion": "4.0.0"
 			},
@@ -6574,10 +6656,12 @@
 			"_id": "1stWQOKtwsdOoOQB",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
+				"createdTime": null,
 				"duplicateSource": null,
 				"exportSource": null,
 				"lastModifiedBy": null,
+				"modifiedTime": null,
 				"systemId": "shadowdark",
 				"systemVersion": "4.0.0"
 			},
@@ -6595,10 +6679,12 @@
 			"_id": "BGfXq4IxO0vX2IAa",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
+				"createdTime": null,
 				"duplicateSource": null,
 				"exportSource": null,
 				"lastModifiedBy": null,
+				"modifiedTime": null,
 				"systemId": "shadowdark",
 				"systemVersion": "4.0.0"
 			},
@@ -6616,10 +6702,12 @@
 			"_id": "A5wLqPec4AA3D0V6",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
+				"createdTime": null,
 				"duplicateSource": null,
 				"exportSource": null,
 				"lastModifiedBy": null,
+				"modifiedTime": null,
 				"systemId": "shadowdark",
 				"systemVersion": "4.0.0"
 			},
@@ -6637,10 +6725,12 @@
 			"_id": "ma7ldqSAyf9AV5RE",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
+				"createdTime": null,
 				"duplicateSource": null,
 				"exportSource": null,
 				"lastModifiedBy": null,
+				"modifiedTime": null,
 				"systemId": "shadowdark",
 				"systemVersion": "4.0.0"
 			},
@@ -6658,10 +6748,12 @@
 			"_id": "aIGRsiMzU2xwwAC6",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
+				"createdTime": null,
 				"duplicateSource": null,
 				"exportSource": null,
 				"lastModifiedBy": null,
+				"modifiedTime": null,
 				"systemId": "shadowdark",
 				"systemVersion": "4.0.0"
 			},
@@ -6679,10 +6771,12 @@
 			"_id": "WiEmicywQoEqloje",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
+				"createdTime": null,
 				"duplicateSource": null,
 				"exportSource": null,
 				"lastModifiedBy": null,
+				"modifiedTime": null,
 				"systemId": "shadowdark",
 				"systemVersion": "4.0.0"
 			},
@@ -6700,10 +6794,12 @@
 			"_id": "HQtdbjElPrvSvTlF",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
+				"createdTime": null,
 				"duplicateSource": null,
 				"exportSource": null,
 				"lastModifiedBy": null,
+				"modifiedTime": null,
 				"systemId": "shadowdark",
 				"systemVersion": "4.0.0"
 			},
@@ -6721,7 +6817,7 @@
 			"_id": "jaPLgbwC8oVu8EmT",
 			"_stats": {
 				"compendiumSource": "Folder.jaPLgbwC8oVu8EmT",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351630093,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -6746,7 +6842,7 @@
 			"_id": "63oECpAgouGrjOvX",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351630093,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -6769,7 +6865,7 @@
 			"_id": "GXwxJUMvopn2XeX3",
 			"_stats": {
 				"compendiumSource": "Folder.GXwxJUMvopn2XeX3",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351630093,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -6797,7 +6893,7 @@
 			"_id": "gtfx2i7YimBMi2bo",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -6811,41 +6907,43 @@
 					"_id": "OoYD72x4t1krOPn4",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
-					"changes": [
-						{
-							"key": "system.roll.attack.critical-multiplier.this",
-							"mode": 5,
-							"priority": null,
-							"value": "4"
-						}
-					],
 					"description": "",
 					"disabled": false,
 					"duration": {
-						"combat": null,
-						"rounds": null,
-						"seconds": null,
-						"startRound": null,
-						"startTime": null,
-						"startTurn": null,
-						"turns": null
+						"expired": false,
+						"expiry": null,
+						"units": "seconds",
+						"value": null
 					},
 					"flags": {
 					},
+					"folder": null,
 					"img": "icons/skills/melee/hand-grip-staff-yellow-brown.webp",
 					"name": "Critical Multiplier",
 					"origin": "Item.gtfx2i7YimBMi2bo",
+					"showIcon": 1,
 					"sort": 0,
+					"start": null,
 					"statuses": [
 					],
 					"system": {
+						"changes": [
+							{
+								"key": "system.roll.attack.critical-multiplier.this",
+								"priority": null,
+								"type": "override",
+								"value": 4
+							}
+						]
 					},
 					"tint": "#ffffff",
 					"transfer": true,
@@ -6855,41 +6953,43 @@
 					"_id": "tibvtEcTgk7rpHCK",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
-					"changes": [
-						{
-							"key": "system.roll.attack.bonus.this",
-							"mode": 2,
-							"priority": null,
-							"value": "1"
-						}
-					],
 					"description": "",
 					"disabled": false,
 					"duration": {
-						"combat": null,
-						"rounds": null,
-						"seconds": null,
-						"startRound": null,
-						"startTime": null,
-						"startTurn": null,
-						"turns": null
+						"expired": false,
+						"expiry": null,
+						"units": "seconds",
+						"value": null
 					},
 					"flags": {
 					},
+					"folder": null,
 					"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 					"name": "Weapon Attack Roll Bonus",
 					"origin": "Item.gtfx2i7YimBMi2bo",
+					"showIcon": 1,
 					"sort": 0,
+					"start": null,
 					"statuses": [
 					],
 					"system": {
+						"changes": [
+							{
+								"key": "system.roll.attack.bonus.this",
+								"priority": null,
+								"type": "add",
+								"value": 1
+							}
+						]
 					},
 					"tint": "#ffffff",
 					"transfer": true,
@@ -6899,41 +6999,43 @@
 					"_id": "Y7k4x0LKLRYCG7da",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
-					"changes": [
-						{
-							"key": "system.roll.attack.damage.this",
-							"mode": 2,
-							"priority": null,
-							"value": "1"
-						}
-					],
 					"description": "",
 					"disabled": false,
 					"duration": {
-						"combat": null,
-						"rounds": null,
-						"seconds": null,
-						"startRound": null,
-						"startTime": null,
-						"startTurn": null,
-						"turns": null
+						"expired": false,
+						"expiry": null,
+						"units": "seconds",
+						"value": null
 					},
 					"flags": {
 					},
+					"folder": null,
 					"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 					"name": "Weapon Attack Damage Bonus",
 					"origin": "Item.gtfx2i7YimBMi2bo",
+					"showIcon": 1,
 					"sort": 0,
+					"start": null,
 					"statuses": [
 					],
 					"system": {
+						"changes": [
+							{
+								"key": "system.roll.attack.damage.this",
+								"priority": null,
+								"type": "add",
+								"value": 1
+							}
+						]
 					},
 					"tint": "#ffffff",
 					"transfer": true,
@@ -6988,7 +7090,7 @@
 			"_id": "r893z0hIf4LSdPs3",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -7048,7 +7150,7 @@
 			"_id": "7unKOF9uy9ECqkEy",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -7098,7 +7200,7 @@
 			"_id": "Jo88wNZQdCtvuuuS",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -7158,7 +7260,7 @@
 			"_id": "TggK5foyVW9RXoHw",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -7218,7 +7320,7 @@
 			"_id": "U3dML6TSDUKJXBUh",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -7278,7 +7380,7 @@
 			"_id": "iW6GTpg33QYMca8k",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -7338,7 +7440,7 @@
 			"_id": "WKk0GVD1KHrI6fav",
 			"_stats": {
 				"compendiumSource": "Item.7unKOF9uy9ECqkEy",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -7390,7 +7492,7 @@
 			"_id": "BjWjRaMBbsv50AjU",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -7450,7 +7552,7 @@
 			"_id": "ToSK7skdC9OPzmwZ",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -7500,7 +7602,7 @@
 			"_id": "hiVLFYBR666Zm29e",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -7550,7 +7652,7 @@
 			"_id": "JpRmSUeNd7qwnXZa",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -7564,41 +7666,43 @@
 					"_id": "YdSXQDooWvID0Omk",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
-					"changes": [
-						{
-							"key": "system.roll.attack.bonus.this",
-							"mode": 2,
-							"priority": null,
-							"value": "1"
-						}
-					],
 					"description": "",
 					"disabled": false,
 					"duration": {
-						"combat": null,
-						"rounds": null,
-						"seconds": null,
-						"startRound": null,
-						"startTime": null,
-						"startTurn": null,
-						"turns": null
+						"expired": false,
+						"expiry": null,
+						"units": "seconds",
+						"value": null
 					},
 					"flags": {
 					},
+					"folder": null,
 					"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 					"name": "Weapon Attack Roll Bonus",
 					"origin": "Item.JpRmSUeNd7qwnXZa",
+					"showIcon": 1,
 					"sort": 0,
+					"start": null,
 					"statuses": [
 					],
 					"system": {
+						"changes": [
+							{
+								"key": "system.roll.attack.bonus.this",
+								"priority": null,
+								"type": "add",
+								"value": 1
+							}
+						]
 					},
 					"tint": "#ffffff",
 					"transfer": true,
@@ -7608,41 +7712,43 @@
 					"_id": "Ep6ApxGF6IQgIcZJ",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
-					"changes": [
-						{
-							"key": "system.roll.attack.damage.this",
-							"mode": 2,
-							"priority": null,
-							"value": "1"
-						}
-					],
 					"description": "",
 					"disabled": false,
 					"duration": {
-						"combat": null,
-						"rounds": null,
-						"seconds": null,
-						"startRound": null,
-						"startTime": null,
-						"startTurn": null,
-						"turns": null
+						"expired": false,
+						"expiry": null,
+						"units": "seconds",
+						"value": null
 					},
 					"flags": {
 					},
+					"folder": null,
 					"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 					"name": "Weapon Attack Damage Bonus",
 					"origin": "Item.JpRmSUeNd7qwnXZa",
+					"showIcon": 1,
 					"sort": 0,
+					"start": null,
 					"statuses": [
 					],
 					"system": {
+						"changes": [
+							{
+								"key": "system.roll.attack.damage.this",
+								"priority": null,
+								"type": "add",
+								"value": 1
+							}
+						]
 					},
 					"tint": "#ffffff",
 					"transfer": true,
@@ -7697,7 +7803,7 @@
 			"_id": "6NfZTinsbZBY5FVN",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -7747,7 +7853,7 @@
 			"_id": "Xc1NkStj6yilbnSa",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -7797,7 +7903,7 @@
 			"_id": "O98T6HjIZ9nrajO4",
 			"_stats": {
 				"compendiumSource": "Item.Tyv0gXYaTmYJjHP1",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -7859,7 +7965,7 @@
 			"_id": "R9rWEWg4biAMlj0U",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -7919,7 +8025,7 @@
 			"_id": "vykb09m5y4gCdVIS",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -7969,7 +8075,7 @@
 			"_id": "VO8hdwr2ulhRwwW0",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -8029,7 +8135,7 @@
 			"_id": "qQfrScSGMEBGHCFZ",
 			"_stats": {
 				"compendiumSource": "Item.Jo88wNZQdCtvuuuS",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -8091,7 +8197,7 @@
 			"_id": "0HvhZP8EOXqyT3p2",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.weapons.ZPUhNMmwXXrtbCXi",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -8151,7 +8257,7 @@
 			"_id": "yv6v0HqiSsnAGOHC",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.armor.UWp4WkkiaBMSXYPE",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -8211,7 +8317,7 @@
 			"_id": "a69T3oP2oVH2yqMn",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -8271,7 +8377,7 @@
 			"_id": "cY0UIbpokdT448Pw",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -8285,41 +8391,43 @@
 					"_id": "Y6Vmojz6HfSts4yn",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
-					"changes": [
-						{
-							"key": "system.roll.attack.bonus.this",
-							"mode": 2,
-							"priority": null,
-							"value": "1"
-						}
-					],
 					"description": "",
 					"disabled": false,
 					"duration": {
-						"combat": null,
-						"rounds": null,
-						"seconds": null,
-						"startRound": null,
-						"startTime": null,
-						"startTurn": null,
-						"turns": null
+						"expired": false,
+						"expiry": null,
+						"units": "seconds",
+						"value": null
 					},
 					"flags": {
 					},
+					"folder": null,
 					"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 					"name": "Weapon Attack Roll Bonus",
 					"origin": "Item.cY0UIbpokdT448Pw",
+					"showIcon": 1,
 					"sort": 0,
+					"start": null,
 					"statuses": [
 					],
 					"system": {
+						"changes": [
+							{
+								"key": "system.roll.attack.bonus.this",
+								"priority": null,
+								"type": "add",
+								"value": 1
+							}
+						]
 					},
 					"tint": "#ffffff",
 					"transfer": true,
@@ -8329,41 +8437,43 @@
 					"_id": "QytORFnGHpzgVLrQ",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
-					"changes": [
-						{
-							"key": "system.roll.attack.damage.this",
-							"mode": 2,
-							"priority": null,
-							"value": "1"
-						}
-					],
 					"description": "",
 					"disabled": false,
 					"duration": {
-						"combat": null,
-						"rounds": null,
-						"seconds": null,
-						"startRound": null,
-						"startTime": null,
-						"startTurn": null,
-						"turns": null
+						"expired": false,
+						"expiry": null,
+						"units": "seconds",
+						"value": null
 					},
 					"flags": {
 					},
+					"folder": null,
 					"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 					"name": "Weapon Attack Damage Bonus",
 					"origin": "Item.cY0UIbpokdT448Pw",
+					"showIcon": 1,
 					"sort": 0,
+					"start": null,
 					"statuses": [
 					],
 					"system": {
+						"changes": [
+							{
+								"key": "system.roll.attack.damage.this",
+								"priority": null,
+								"type": "add",
+								"value": 1
+							}
+						]
 					},
 					"tint": "#ffffff",
 					"transfer": true,
@@ -8418,7 +8528,7 @@
 			"_id": "xTOy6PVB5iu1asFa",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -8478,7 +8588,7 @@
 			"_id": "ip1i9MpeJeyf7ayu",
 			"_stats": {
 				"compendiumSource": "Item.ew2ZoOaQVO1uDB8I",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -8536,7 +8646,7 @@
 			"_id": "i3gSIEVGxXhlUkdn",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -8594,7 +8704,7 @@
 			"_id": "cFi2Wtbwz3qkiJMx",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -8654,7 +8764,7 @@
 			"_id": "C4Nwo8zX0SgvD0CN",
 			"_stats": {
 				"compendiumSource": null,
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629784,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -8716,7 +8826,7 @@
 			"_id": "Jd3mOMTNeoHyJ0o9",
 			"_stats": {
 				"compendiumSource": "JournalEntry.kC9OuLQOGZaI6gxk",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629808,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -8741,10 +8851,12 @@
 					"_id": "mk2XPtOkIUVJa1r6",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -8780,10 +8892,12 @@
 					"_id": "Ebnm0GKVZK0r4M1L",
 					"_stats": {
 						"compendiumSource": "JournalEntry.kC9OuLQOGZaI6gxk.JournalEntryPage.Ebnm0GKVZK0r4M1L",
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -8821,10 +8935,12 @@
 					"_id": "52HmUPhOmObKD066",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -8860,10 +8976,12 @@
 					"_id": "og8Nge1YJUy0vEZ1",
 					"_stats": {
 						"compendiumSource": "JournalEntry.kC9OuLQOGZaI6gxk.JournalEntryPage.og8Nge1YJUy0vEZ1",
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -8901,10 +9019,12 @@
 					"_id": "CDf6qPlOVU145qf1",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -8940,10 +9060,12 @@
 					"_id": "7wbBRL0EBS0HZnYo",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -8979,10 +9101,12 @@
 					"_id": "b07AUXqDrTMY4rdR",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -9018,10 +9142,12 @@
 					"_id": "tMeWP0O7br4N89Io",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -9057,10 +9183,12 @@
 					"_id": "wOGUory4OOBf3tK0",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -9096,10 +9224,12 @@
 					"_id": "i3V6SKaXvFSiMu6C",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -9135,10 +9265,12 @@
 					"_id": "VeLS9tCOvPgxGtVB",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -9174,10 +9306,12 @@
 					"_id": "V23yABkR5uwGET7L",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -9213,10 +9347,12 @@
 					"_id": "EDgODTLELhFewmfC",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -9252,10 +9388,12 @@
 					"_id": "mny9vaKHTw8QzAOH",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -9291,10 +9429,12 @@
 					"_id": "ij3UqKXLKbo4HEQv",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -9330,10 +9470,12 @@
 					"_id": "K89gip6LsipJKXR1",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -9369,10 +9511,12 @@
 					"_id": "VKhNxZxjNQMagHuB",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -9408,10 +9552,12 @@
 					"_id": "0inZOCDF3fXquc3E",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -9447,10 +9593,12 @@
 					"_id": "VaGKvoCmaxt3vVzU",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -9486,10 +9634,12 @@
 					"_id": "1RRASFNF0M0Nsdab",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -9525,10 +9675,12 @@
 					"_id": "8gh1tN3LaqiurWr5",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -9564,10 +9716,12 @@
 					"_id": "cG03UHWIl6QD2uuq",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -9603,10 +9757,12 @@
 					"_id": "0Fk22lPWSvFbArmd",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -9642,10 +9798,12 @@
 					"_id": "LNsH8ZnvP38gOFHw",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -9681,10 +9839,12 @@
 					"_id": "Uzf5XC3b0OggPLwI",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -9720,10 +9880,12 @@
 					"_id": "5t6le9aC9aHgWDmw",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -9759,10 +9921,12 @@
 					"_id": "S5RtOPxkr4qG4mwH",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -9798,10 +9962,12 @@
 					"_id": "5QLROV74bPrTfwZn",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -9837,10 +10003,12 @@
 					"_id": "WoT0LXffwbnbMAKW",
 					"_stats": {
 						"compendiumSource": "JournalEntry.Jd3mOMTNeoHyJ0o9.JournalEntryPage.WoT0LXffwbnbMAKW",
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -9875,10 +10043,12 @@
 					"_id": "ji9paT4DbaYTmMPm",
 					"_stats": {
 						"compendiumSource": "JournalEntry.Jd3mOMTNeoHyJ0o9.JournalEntryPage.ji9paT4DbaYTmMPm",
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -9918,7 +10088,7 @@
 			"_id": "b4peWtS82m3su5q1",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.macros.Macro.zNYDtS7XcT3IaQ4t",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351630085,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -9947,7 +10117,7 @@
 			"_id": "oYUJG4g7naduZNeb",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.macros.Macro.EropDDFL0DKcW8I6",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351630085,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -9976,7 +10146,7 @@
 			"_id": "uQOjVmE0co1U8yws",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.macros.Macro.C0TN1X2LOAPYWJmD",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351630085,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -10010,7 +10180,7 @@
 			"_id": "meMau7PRNLPMhWtA",
 			"_stats": {
 				"compendiumSource": "Scene.meMau7PRNLPMhWtA",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351629904,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -10020,20 +10190,6 @@
 				"systemVersion": "4.0.0"
 			},
 			"active": false,
-			"background": {
-				"alphaThreshold": 0,
-				"anchorX": 0,
-				"anchorY": 0,
-				"fit": "fill",
-				"offsetX": 0,
-				"offsetY": 0,
-				"rotation": 0,
-				"scaleX": 1,
-				"scaleY": 1,
-				"src": "systems/shadowdark/assets/quickstart/the-lost-citadel/the-lost-citadel-by-Futurewolf.webp",
-				"tint": "#ffffff"
-			},
-			"backgroundColor": "#999999",
 			"drawings": [
 				{
 					"_id": "5AXhCRalR70Qmo54",
@@ -10049,6 +10205,8 @@
 					"fontSize": 48,
 					"hidden": true,
 					"interface": true,
+					"levels": [
+					],
 					"locked": false,
 					"rotation": 0,
 					"shape": {
@@ -10114,12 +10272,9 @@
 					"explored": null,
 					"unexplored": null
 				},
-				"exploration": false,
-				"overlay": null
+				"mode": 0
 			},
 			"folder": "bPrm5lY7z87YrtFK",
-			"foreground": null,
-			"foregroundElevation": 20,
 			"grid": {
 				"alpha": 0.2,
 				"color": "#000000",
@@ -10136,8 +10291,50 @@
 				"x": null,
 				"y": null
 			},
+			"initialLevel": "defaultLevel0000",
 			"journal": null,
 			"journalEntryPage": null,
+			"levels": [
+				{
+					"_id": "defaultLevel0000",
+					"background": {
+						"alphaThreshold": 0.75,
+						"color": "#999999",
+						"src": "systems/shadowdark/assets/quickstart/the-lost-citadel/the-lost-citadel-by-Futurewolf.webp",
+						"tint": "#ffffff"
+					},
+					"elevation": {
+						"bottom": 0,
+						"top": 20
+					},
+					"flags": {
+					},
+					"fog": {
+						"src": null
+					},
+					"foreground": {
+						"alphaThreshold": 0.75,
+						"src": null,
+						"tint": "#ffffff"
+					},
+					"name": "The Lost Citadel",
+					"sort": 0,
+					"textures": {
+						"anchorX": 0.5,
+						"anchorY": 0.5,
+						"fit": "fill",
+						"offsetX": 0,
+						"offsetY": 0,
+						"rotation": 0,
+						"scaleX": 1,
+						"scaleY": 1
+					},
+					"visibility": {
+						"levels": [
+						]
+					}
+				}
+			],
 			"lights": [
 				{
 					"_id": "mEr7WMYOth9SKaeZ",
@@ -10170,6 +10367,9 @@
 					"flags": {
 					},
 					"hidden": true,
+					"levels": [
+					],
+					"locked": false,
 					"rotation": 0,
 					"vision": false,
 					"walls": true,
@@ -10207,6 +10407,9 @@
 					"flags": {
 					},
 					"hidden": true,
+					"levels": [
+					],
+					"locked": false,
 					"rotation": 0,
 					"vision": false,
 					"walls": true,
@@ -10244,6 +10447,9 @@
 					"flags": {
 					},
 					"hidden": true,
+					"levels": [
+					],
+					"locked": false,
 					"rotation": 0,
 					"vision": false,
 					"walls": true,
@@ -10281,6 +10487,9 @@
 					"flags": {
 					},
 					"hidden": true,
+					"levels": [
+					],
+					"locked": false,
 					"rotation": 0,
 					"vision": false,
 					"walls": true,
@@ -10318,6 +10527,9 @@
 					"flags": {
 					},
 					"hidden": false,
+					"levels": [
+					],
+					"locked": false,
 					"rotation": 0,
 					"vision": false,
 					"walls": true,
@@ -10355,6 +10567,9 @@
 					"flags": {
 					},
 					"hidden": false,
+					"levels": [
+					],
+					"locked": false,
 					"rotation": 0,
 					"vision": false,
 					"walls": true,
@@ -10392,6 +10607,9 @@
 					"flags": {
 					},
 					"hidden": false,
+					"levels": [
+					],
+					"locked": false,
 					"rotation": 0,
 					"vision": false,
 					"walls": true,
@@ -10429,6 +10647,9 @@
 					"flags": {
 					},
 					"hidden": false,
+					"levels": [
+					],
+					"locked": false,
 					"rotation": 0,
 					"vision": false,
 					"walls": true,
@@ -10466,6 +10687,9 @@
 					"flags": {
 					},
 					"hidden": false,
+					"levels": [
+					],
+					"locked": false,
 					"rotation": 0,
 					"vision": false,
 					"walls": true,
@@ -10503,6 +10727,9 @@
 					"flags": {
 					},
 					"hidden": false,
+					"levels": [
+					],
+					"locked": false,
 					"rotation": 0,
 					"vision": false,
 					"walls": true,
@@ -10540,6 +10767,9 @@
 					"flags": {
 					},
 					"hidden": false,
+					"levels": [
+					],
+					"locked": false,
 					"rotation": 0,
 					"vision": false,
 					"walls": true,
@@ -10554,6 +10784,7 @@
 			"notes": [
 				{
 					"_id": "KOifeKfcvvfTMVD5",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -10562,6 +10793,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "5QLROV74bPrTfwZn",
 					"sort": 0,
 					"text": "",
@@ -10572,9 +10806,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -10585,6 +10816,7 @@
 				},
 				{
 					"_id": "x9CP2tmjY52e6N7p",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -10593,6 +10825,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "S5RtOPxkr4qG4mwH",
 					"sort": 0,
 					"text": "",
@@ -10603,9 +10838,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -10616,6 +10848,7 @@
 				},
 				{
 					"_id": "9GJlawpQTYSrUbfG",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -10624,6 +10857,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "5t6le9aC9aHgWDmw",
 					"sort": 0,
 					"text": "",
@@ -10634,9 +10870,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -10647,6 +10880,7 @@
 				},
 				{
 					"_id": "rmvkRHeWbBdLX3ve",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -10655,6 +10889,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "Uzf5XC3b0OggPLwI",
 					"sort": 0,
 					"text": "",
@@ -10665,9 +10902,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -10678,6 +10912,7 @@
 				},
 				{
 					"_id": "GxYsM5aIYSyoZVOW",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -10686,6 +10921,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "VaGKvoCmaxt3vVzU",
 					"sort": 0,
 					"text": "",
@@ -10696,9 +10934,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -10709,6 +10944,7 @@
 				},
 				{
 					"_id": "H3RZUkBrndw41rWQ",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -10717,6 +10953,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "LNsH8ZnvP38gOFHw",
 					"sort": 0,
 					"text": "",
@@ -10727,9 +10966,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -10740,6 +10976,7 @@
 				},
 				{
 					"_id": "nQb8OhOpLz3sUDVh",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -10748,6 +10985,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "1RRASFNF0M0Nsdab",
 					"sort": 0,
 					"text": "",
@@ -10758,9 +10998,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -10771,6 +11008,7 @@
 				},
 				{
 					"_id": "NqticVerQ89XfUAX",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -10779,6 +11017,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "8gh1tN3LaqiurWr5",
 					"sort": 0,
 					"text": "",
@@ -10789,9 +11030,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -10802,6 +11040,7 @@
 				},
 				{
 					"_id": "nKQ7JDwbGXo6QRwT",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -10810,6 +11049,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "cG03UHWIl6QD2uuq",
 					"sort": 0,
 					"text": "",
@@ -10820,9 +11062,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -10833,6 +11072,7 @@
 				},
 				{
 					"_id": "j1LBsgk9qcNHn5GU",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -10841,6 +11081,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "0Fk22lPWSvFbArmd",
 					"sort": 0,
 					"text": "",
@@ -10851,9 +11094,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -10864,6 +11104,7 @@
 				},
 				{
 					"_id": "wYTIRSjdqDyL6jCf",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -10872,6 +11113,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "0Fk22lPWSvFbArmd",
 					"sort": 0,
 					"text": "",
@@ -10882,9 +11126,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -10895,6 +11136,7 @@
 				},
 				{
 					"_id": "pNVOofnLFVKhuHSn",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -10903,6 +11145,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "0Fk22lPWSvFbArmd",
 					"sort": 0,
 					"text": "",
@@ -10913,9 +11158,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -10926,6 +11168,7 @@
 				},
 				{
 					"_id": "WRy4Xj6I1nZrhioW",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -10934,6 +11177,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "VKhNxZxjNQMagHuB",
 					"sort": 0,
 					"text": "",
@@ -10944,9 +11190,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -10957,6 +11200,7 @@
 				},
 				{
 					"_id": "9YXa6N5ymBjpE596",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -10965,6 +11209,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "0inZOCDF3fXquc3E",
 					"sort": 0,
 					"text": "",
@@ -10975,9 +11222,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -10988,6 +11232,7 @@
 				},
 				{
 					"_id": "u0fh6SfaMNrJcOdl",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -10996,6 +11241,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "K89gip6LsipJKXR1",
 					"sort": 0,
 					"text": "",
@@ -11006,9 +11254,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -11019,6 +11264,7 @@
 				},
 				{
 					"_id": "0kCFquhPyOcLQlDc",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -11027,6 +11273,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "V23yABkR5uwGET7L",
 					"sort": 0,
 					"text": "",
@@ -11037,9 +11286,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -11050,6 +11296,7 @@
 				},
 				{
 					"_id": "7OWGluy2NtHHblFq",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -11058,6 +11305,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "tMeWP0O7br4N89Io",
 					"sort": 0,
 					"text": "",
@@ -11068,9 +11318,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -11081,6 +11328,7 @@
 				},
 				{
 					"_id": "IGOvrU2VocUBaa9M",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -11089,6 +11337,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "EDgODTLELhFewmfC",
 					"sort": 0,
 					"text": "",
@@ -11099,9 +11350,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -11112,6 +11360,7 @@
 				},
 				{
 					"_id": "lvz09afVYnVX9uBE",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -11120,6 +11369,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "ij3UqKXLKbo4HEQv",
 					"sort": 0,
 					"text": "",
@@ -11130,9 +11382,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -11143,6 +11392,7 @@
 				},
 				{
 					"_id": "6UZvnJThaNbk4MS3",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -11151,6 +11401,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "Ebnm0GKVZK0r4M1L",
 					"sort": 0,
 					"text": "",
@@ -11161,9 +11414,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -11174,6 +11424,7 @@
 				},
 				{
 					"_id": "HFwHhMdvDfHchTze",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -11182,6 +11433,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "52HmUPhOmObKD066",
 					"sort": 0,
 					"text": "",
@@ -11192,9 +11446,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -11205,6 +11456,7 @@
 				},
 				{
 					"_id": "b40chplZyhJQCpDU",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -11213,6 +11465,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "og8Nge1YJUy0vEZ1",
 					"sort": 0,
 					"text": "",
@@ -11223,9 +11478,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -11236,6 +11488,7 @@
 				},
 				{
 					"_id": "hOJhol0ybVa0hYx8",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -11244,6 +11497,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "CDf6qPlOVU145qf1",
 					"sort": 0,
 					"text": "",
@@ -11254,9 +11510,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -11267,6 +11520,7 @@
 				},
 				{
 					"_id": "L3Ku8dxgS0P5ZQPG",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -11275,6 +11529,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "7wbBRL0EBS0HZnYo",
 					"sort": 0,
 					"text": "",
@@ -11285,9 +11542,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -11298,6 +11552,7 @@
 				},
 				{
 					"_id": "jfeQ3fXQ8J7u1hyo",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -11306,6 +11561,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "b07AUXqDrTMY4rdR",
 					"sort": 0,
 					"text": "",
@@ -11316,9 +11574,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -11329,6 +11584,7 @@
 				},
 				{
 					"_id": "X4x3yGmbdANBYDv3",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -11337,6 +11593,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "wOGUory4OOBf3tK0",
 					"sort": 0,
 					"text": "",
@@ -11347,9 +11606,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -11360,6 +11616,7 @@
 				},
 				{
 					"_id": "16xyP3PTZ3izOAWP",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -11368,6 +11625,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "i3V6SKaXvFSiMu6C",
 					"sort": 0,
 					"text": "",
@@ -11378,9 +11638,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -11391,6 +11648,7 @@
 				},
 				{
 					"_id": "58yRYZNuH2GwYDis",
+					"author": null,
 					"elevation": 0,
 					"entryId": "Jd3mOMTNeoHyJ0o9",
 					"flags": {
@@ -11399,6 +11657,9 @@
 					"fontSize": 32,
 					"global": false,
 					"iconSize": 80,
+					"levels": [
+					],
+					"locked": false,
 					"pageId": "VeLS9tCOvPgxGtVB",
 					"sort": 0,
 					"text": "",
@@ -11409,9 +11670,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "icons/svg/book.svg",
@@ -11429,10 +11687,10 @@
 			"playlistSound": null,
 			"regions": [
 			],
+			"shiftX": 0,
+			"shiftY": 0,
 			"sort": 100000,
 			"sounds": [
-			],
-			"templates": [
 			],
 			"thumb": "systems/shadowdark/assets/scenes/meMau7PRNLPMhWtA-thumb.webp",
 			"tiles": [
@@ -11469,8 +11727,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -11479,6 +11738,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -11542,9 +11802,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -11590,8 +11847,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -11600,6 +11858,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -11663,9 +11922,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -11711,8 +11967,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -11721,6 +11978,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -11784,9 +12042,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -11832,8 +12087,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -11842,6 +12098,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -11905,9 +12162,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -11953,8 +12207,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -11963,6 +12218,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -12026,9 +12282,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -12074,8 +12327,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -12084,6 +12338,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -12147,9 +12402,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -12195,8 +12447,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -12205,6 +12458,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -12268,9 +12522,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -12316,8 +12567,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -12326,6 +12578,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -12389,9 +12642,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -12437,8 +12687,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -12447,6 +12698,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -12510,9 +12762,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -12558,8 +12807,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": 0,
@@ -12568,6 +12818,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -12631,9 +12882,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -12679,8 +12927,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -12689,6 +12938,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -12752,9 +13002,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -12800,8 +13047,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -12810,6 +13058,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -12873,9 +13122,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -12921,8 +13167,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -12931,6 +13178,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -12994,9 +13242,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -13042,8 +13287,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -13052,6 +13298,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -13115,9 +13362,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -13163,8 +13407,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -13173,6 +13418,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -13236,9 +13482,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -13284,8 +13527,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -13294,6 +13538,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -13357,9 +13602,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -13405,8 +13647,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -13415,6 +13658,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -13478,9 +13722,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -13526,8 +13767,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -13536,6 +13778,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -13599,9 +13842,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1.5,
 						"scaleY": 1.5,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -13647,8 +13887,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -13657,6 +13898,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -13720,9 +13962,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -13768,8 +14007,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -13778,6 +14018,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -13841,9 +14082,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -13889,8 +14127,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -13899,6 +14138,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -13962,9 +14202,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -14010,8 +14247,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -14020,6 +14258,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -14083,9 +14322,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -14131,8 +14367,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -14141,6 +14378,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -14204,9 +14442,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -14252,8 +14487,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -14262,6 +14498,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -14325,9 +14562,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -14373,8 +14607,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -14383,6 +14618,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -14446,9 +14682,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -14494,8 +14727,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -14504,6 +14738,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -14567,9 +14802,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -14615,8 +14847,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -14625,6 +14858,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -14688,9 +14922,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -14736,8 +14967,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -14746,6 +14978,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -14809,9 +15042,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -14857,8 +15087,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -14867,6 +15098,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -14930,9 +15162,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -14978,8 +15207,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -14988,6 +15218,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -15051,9 +15282,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -15099,8 +15327,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -15109,6 +15338,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -15172,9 +15402,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -15220,8 +15447,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -15230,6 +15458,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -15293,9 +15522,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -15341,8 +15567,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -15351,6 +15578,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -15414,9 +15642,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -15462,8 +15687,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -15472,6 +15698,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -15535,9 +15762,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -15583,8 +15807,9 @@
 						},
 						"type": null
 					},
-					"detectionModes": [
-					],
+					"depth": 1,
+					"detectionModes": {
+					},
 					"displayBars": 0,
 					"displayName": 20,
 					"disposition": -1,
@@ -15593,6 +15818,7 @@
 					},
 					"height": 1,
 					"hidden": true,
+					"level": "defaultLevel0000",
 					"light": {
 						"alpha": 0.5,
 						"angle": 360,
@@ -15656,9 +15882,6 @@
 						"anchorX": 0.5,
 						"anchorY": 0.5,
 						"fit": "contain",
-						"offsetX": 0,
-						"offsetY": 0,
-						"rotation": 0,
 						"scaleX": 1,
 						"scaleY": 1,
 						"src": "systems/shadowdark/assets/tokens/cowled_token.webp",
@@ -15675,6 +15898,11 @@
 					"y": 2800
 				}
 			],
+			"transition": {
+				"activeOnly": false,
+				"duration": 1500,
+				"type": null
+			},
 			"walls": [
 				{
 					"_id": "q0y0oqcYyzJJ2CoC",
@@ -15690,6 +15918,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -15715,6 +15945,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -15740,6 +15972,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -15765,6 +15999,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -15790,6 +16026,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -15815,6 +16053,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -15840,6 +16080,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -15865,6 +16107,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -15890,6 +16134,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -15915,6 +16161,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -15940,6 +16188,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -15965,6 +16215,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -15990,6 +16242,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16015,6 +16269,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16040,6 +16296,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16065,6 +16323,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16090,6 +16350,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16115,6 +16377,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16140,6 +16404,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16165,6 +16431,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16190,6 +16458,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16215,6 +16485,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16240,6 +16512,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16265,6 +16539,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16290,6 +16566,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16315,6 +16593,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16340,6 +16620,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16365,6 +16647,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16390,6 +16674,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16415,6 +16701,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16440,6 +16728,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16465,6 +16755,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16490,6 +16782,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16515,6 +16809,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16540,6 +16836,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16565,6 +16863,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16590,6 +16890,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16615,6 +16917,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16640,6 +16944,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16665,6 +16971,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16690,6 +16998,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16715,6 +17025,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16740,6 +17052,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16765,6 +17079,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16790,6 +17106,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16815,6 +17133,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16840,6 +17160,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16865,6 +17187,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16890,6 +17214,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16915,6 +17241,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16940,6 +17268,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16965,6 +17295,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -16990,6 +17322,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17015,6 +17349,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17040,6 +17376,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17065,6 +17403,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17090,6 +17430,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17115,6 +17457,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17140,6 +17484,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17165,6 +17511,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17190,6 +17538,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17215,6 +17565,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17240,6 +17592,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17265,6 +17619,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17290,6 +17646,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17315,6 +17673,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17340,6 +17700,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17365,6 +17727,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17390,6 +17754,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17415,6 +17781,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17440,6 +17808,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17465,6 +17835,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17490,6 +17862,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17515,6 +17889,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17540,6 +17916,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17565,6 +17943,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17590,6 +17970,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17615,6 +17997,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17640,6 +18024,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17665,6 +18051,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17690,6 +18078,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17715,6 +18105,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17740,6 +18132,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17765,6 +18159,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17790,6 +18186,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17815,6 +18213,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17840,6 +18240,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17865,6 +18267,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17890,6 +18294,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17915,6 +18321,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17940,6 +18348,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17965,6 +18375,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -17990,6 +18402,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18015,6 +18429,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18040,6 +18456,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18065,6 +18483,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18090,6 +18510,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18115,6 +18537,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18140,6 +18564,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18165,6 +18591,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18190,6 +18618,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18215,6 +18645,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18240,6 +18672,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18265,6 +18699,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18290,6 +18726,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18315,6 +18753,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18340,6 +18780,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18365,6 +18807,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18390,6 +18834,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18415,6 +18861,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18440,6 +18888,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18465,6 +18915,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18490,6 +18942,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18515,6 +18969,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18540,6 +18996,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18565,6 +19023,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18590,6 +19050,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18615,6 +19077,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18640,6 +19104,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18665,6 +19131,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18690,6 +19158,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18715,6 +19185,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18740,6 +19212,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18765,6 +19239,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18790,6 +19266,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18815,6 +19293,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18840,6 +19320,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18865,6 +19347,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18890,6 +19374,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18915,6 +19401,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18940,6 +19428,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18965,6 +19455,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -18990,6 +19482,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19015,6 +19509,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19040,6 +19536,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19065,6 +19563,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19090,6 +19590,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19115,6 +19617,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19140,6 +19644,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19165,6 +19671,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19190,6 +19698,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19215,6 +19725,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19240,6 +19752,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19265,6 +19779,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19290,6 +19806,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19315,6 +19833,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19340,6 +19860,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19365,6 +19887,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19390,6 +19914,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19415,6 +19941,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19440,6 +19968,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19465,6 +19995,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19490,6 +20022,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19515,6 +20049,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19540,6 +20076,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19565,6 +20103,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19590,6 +20130,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19615,6 +20157,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19640,6 +20184,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19665,6 +20211,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19690,6 +20238,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19715,6 +20265,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19740,6 +20292,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19765,6 +20319,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19790,6 +20346,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19815,6 +20373,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19840,6 +20400,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19865,6 +20427,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19890,6 +20454,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19915,6 +20481,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19940,6 +20508,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19965,6 +20535,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -19990,6 +20562,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20015,6 +20589,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20040,6 +20616,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20065,6 +20643,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20090,6 +20670,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20115,6 +20697,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20140,6 +20724,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20165,6 +20751,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20190,6 +20778,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20215,6 +20805,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20240,6 +20832,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20265,6 +20859,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20290,6 +20886,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20315,6 +20913,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20340,6 +20940,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20365,6 +20967,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20390,6 +20994,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20415,6 +21021,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20440,6 +21048,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20465,6 +21075,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20490,6 +21102,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20515,6 +21129,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20540,6 +21156,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20565,6 +21183,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20590,6 +21210,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20615,6 +21237,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20640,6 +21264,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20665,6 +21291,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20690,6 +21318,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20715,6 +21345,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20740,6 +21372,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20765,6 +21399,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20790,6 +21426,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20815,6 +21453,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20840,6 +21480,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20865,6 +21507,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20890,6 +21534,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20915,6 +21561,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20940,6 +21588,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20965,6 +21615,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -20990,6 +21642,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21015,6 +21669,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21040,6 +21696,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21065,6 +21723,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21090,6 +21750,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21115,6 +21777,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21140,6 +21804,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21165,6 +21831,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21190,6 +21858,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21215,6 +21885,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21240,6 +21912,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21265,6 +21939,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21290,6 +21966,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21315,6 +21993,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21340,6 +22020,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21365,6 +22047,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21390,6 +22074,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21415,6 +22101,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21440,6 +22128,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21465,6 +22155,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21490,6 +22182,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21515,6 +22209,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21540,6 +22236,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21565,6 +22263,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21590,6 +22290,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21615,6 +22317,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21640,6 +22344,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21665,6 +22371,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21690,6 +22398,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21715,6 +22425,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21740,6 +22452,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21765,6 +22479,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21790,6 +22506,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21815,6 +22533,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21840,6 +22560,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21865,6 +22587,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21890,6 +22614,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21915,6 +22641,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21940,6 +22668,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21965,6 +22695,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -21990,6 +22722,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22015,6 +22749,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22040,6 +22776,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22065,6 +22803,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22090,6 +22830,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22115,6 +22857,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22140,6 +22884,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22165,6 +22911,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22190,6 +22938,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22215,6 +22965,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22240,6 +22992,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22265,6 +23019,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22290,6 +23046,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22315,6 +23073,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22340,6 +23100,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22365,6 +23127,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22390,6 +23154,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22415,6 +23181,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22440,6 +23208,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22465,6 +23235,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22490,6 +23262,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22515,6 +23289,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22540,6 +23316,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22565,6 +23343,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22590,6 +23370,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22615,6 +23397,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22640,6 +23424,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22665,6 +23451,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22690,6 +23478,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22715,6 +23505,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22740,6 +23532,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22765,6 +23559,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22790,6 +23586,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22815,6 +23613,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22840,6 +23640,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22865,6 +23667,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22890,6 +23694,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22915,6 +23721,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22940,6 +23748,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22965,6 +23775,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -22990,6 +23802,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23015,6 +23829,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23040,6 +23856,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23065,6 +23883,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23090,6 +23910,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23115,6 +23937,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23140,6 +23964,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23165,6 +23991,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23190,6 +24018,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23215,6 +24045,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23240,6 +24072,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23265,6 +24099,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23290,6 +24126,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23315,6 +24153,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23340,6 +24180,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23365,6 +24207,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23390,6 +24234,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23415,6 +24261,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23440,6 +24288,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23465,6 +24315,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23490,6 +24342,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23515,6 +24369,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23540,6 +24396,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23565,6 +24423,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23590,6 +24450,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23615,6 +24477,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23640,6 +24504,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23665,6 +24531,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23690,6 +24558,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23715,6 +24585,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23740,6 +24612,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23765,6 +24639,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23790,6 +24666,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23815,6 +24693,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23840,6 +24720,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23865,6 +24747,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23890,6 +24774,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23915,6 +24801,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23940,6 +24828,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23965,6 +24855,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -23990,6 +24882,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24015,6 +24909,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24040,6 +24936,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24065,6 +24963,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24090,6 +24990,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24115,6 +25017,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24140,6 +25044,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24165,6 +25071,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24190,6 +25098,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24215,6 +25125,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24240,6 +25152,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24265,6 +25179,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24290,6 +25206,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24315,6 +25233,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24340,6 +25260,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24365,6 +25287,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24390,6 +25314,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24415,6 +25341,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24440,6 +25368,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24465,6 +25395,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24490,6 +25422,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24515,6 +25449,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24540,6 +25476,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24565,6 +25503,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24590,6 +25530,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24615,6 +25557,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24640,6 +25584,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24665,6 +25611,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24690,6 +25638,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24715,6 +25665,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24740,6 +25692,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24765,6 +25719,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24790,6 +25746,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24815,6 +25773,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24840,6 +25800,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24865,6 +25827,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24890,6 +25854,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24915,6 +25881,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24940,6 +25908,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24965,6 +25935,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -24990,6 +25962,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25015,6 +25989,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25040,6 +26016,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25065,6 +26043,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25090,6 +26070,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25115,6 +26097,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25140,6 +26124,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25165,6 +26151,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25190,6 +26178,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25215,6 +26205,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25240,6 +26232,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25265,6 +26259,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25290,6 +26286,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25315,6 +26313,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25340,6 +26340,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25365,6 +26367,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25390,6 +26394,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25415,6 +26421,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25440,6 +26448,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25465,6 +26475,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25490,6 +26502,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25515,6 +26529,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25540,6 +26556,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25565,6 +26583,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25590,6 +26610,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25615,6 +26637,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25640,6 +26664,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25665,6 +26691,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25690,6 +26718,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25715,6 +26745,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25740,6 +26772,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25765,6 +26799,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25790,6 +26826,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25815,6 +26853,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25840,6 +26880,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25865,6 +26907,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25890,6 +26934,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25915,6 +26961,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25940,6 +26988,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25965,6 +27015,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -25990,6 +27042,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26015,6 +27069,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26040,6 +27096,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26065,6 +27123,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26090,6 +27150,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26115,6 +27177,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26140,6 +27204,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26165,6 +27231,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26190,6 +27258,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26215,6 +27285,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26240,6 +27312,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26265,6 +27339,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26290,6 +27366,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26315,6 +27393,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26340,6 +27420,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26365,6 +27447,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26390,6 +27474,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26415,6 +27501,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26440,6 +27528,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26465,6 +27555,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26490,6 +27582,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26515,6 +27609,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26540,6 +27636,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26565,6 +27663,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26590,6 +27690,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26615,6 +27717,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26640,6 +27744,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26665,6 +27771,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26690,6 +27798,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26715,6 +27825,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26740,6 +27852,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26765,6 +27879,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26790,6 +27906,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26815,6 +27933,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26840,6 +27960,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26865,6 +27987,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26890,6 +28014,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26915,6 +28041,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26940,6 +28068,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26965,6 +28095,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -26990,6 +28122,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27015,6 +28149,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27040,6 +28176,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27065,6 +28203,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27090,6 +28230,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27115,6 +28257,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27140,6 +28284,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27165,6 +28311,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27190,6 +28338,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27215,6 +28365,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27240,6 +28392,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27265,6 +28419,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27290,6 +28446,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27315,6 +28473,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27340,6 +28500,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27365,6 +28527,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27390,6 +28554,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27415,6 +28581,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27440,6 +28608,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27465,6 +28635,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27490,6 +28662,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27515,6 +28689,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27540,6 +28716,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27565,6 +28743,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27590,6 +28770,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27615,6 +28797,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27640,6 +28824,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27665,6 +28851,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27690,6 +28878,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27715,6 +28905,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27740,6 +28932,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27765,6 +28959,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27790,6 +28986,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27815,6 +29013,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27840,6 +29040,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27865,6 +29067,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27890,6 +29094,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27915,6 +29121,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27940,6 +29148,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27965,6 +29175,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -27990,6 +29202,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28015,6 +29229,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28040,6 +29256,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28065,6 +29283,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28090,6 +29310,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28115,6 +29337,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28140,6 +29364,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28165,6 +29391,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28190,6 +29418,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28215,6 +29445,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28240,6 +29472,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28265,6 +29499,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28290,6 +29526,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28315,6 +29553,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28340,6 +29580,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28365,6 +29607,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28390,6 +29634,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28415,6 +29661,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28440,6 +29688,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28465,6 +29715,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28490,6 +29742,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28515,6 +29769,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28540,6 +29796,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28565,6 +29823,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28590,6 +29850,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28615,6 +29877,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28640,6 +29904,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28665,6 +29931,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28690,6 +29958,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28715,6 +29985,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28740,6 +30012,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28765,6 +30039,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28790,6 +30066,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28815,6 +30093,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28840,6 +30120,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28865,6 +30147,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28890,6 +30174,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28915,6 +30201,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28940,6 +30228,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28965,6 +30255,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -28990,6 +30282,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29015,6 +30309,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29040,6 +30336,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29065,6 +30363,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29090,6 +30390,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29115,6 +30417,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29140,6 +30444,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29165,6 +30471,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29190,6 +30498,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29215,6 +30525,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29240,6 +30552,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29265,6 +30579,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29290,6 +30606,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29315,6 +30633,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29340,6 +30660,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29365,6 +30687,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29390,6 +30714,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29415,6 +30741,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29440,6 +30768,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29465,6 +30795,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29490,6 +30822,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29515,6 +30849,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29540,6 +30876,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29565,6 +30903,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29590,6 +30930,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29615,6 +30957,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29640,6 +30984,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29665,6 +31011,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29690,6 +31038,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29715,6 +31065,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29740,6 +31092,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29765,6 +31119,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29790,6 +31146,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29815,6 +31173,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29840,6 +31200,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29865,6 +31227,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29890,6 +31254,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29915,6 +31281,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29940,6 +31308,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29965,6 +31335,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -29990,6 +31362,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30015,6 +31389,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30040,6 +31416,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30065,6 +31443,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30090,6 +31470,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30115,6 +31497,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30140,6 +31524,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30165,6 +31551,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30190,6 +31578,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30215,6 +31605,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30240,6 +31632,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30265,6 +31659,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30290,6 +31686,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30315,6 +31713,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30340,6 +31740,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30365,6 +31767,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30390,6 +31794,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30415,6 +31821,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30440,6 +31848,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30465,6 +31875,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30490,6 +31902,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30515,6 +31929,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30540,6 +31956,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30565,6 +31983,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30590,6 +32010,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30615,6 +32037,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30640,6 +32064,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30665,6 +32091,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30690,6 +32118,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30715,6 +32145,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30740,6 +32172,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30765,6 +32199,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30790,6 +32226,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30815,6 +32253,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30840,6 +32280,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30865,6 +32307,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30890,6 +32334,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30915,6 +32361,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30940,6 +32388,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30965,6 +32415,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -30990,6 +32442,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31015,6 +32469,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31040,6 +32496,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31065,6 +32523,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31090,6 +32550,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31115,6 +32577,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31140,6 +32604,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31165,6 +32631,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31190,6 +32658,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31215,6 +32685,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31240,6 +32712,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31265,6 +32739,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31290,6 +32766,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31315,6 +32793,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31340,6 +32820,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31365,6 +32847,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31390,6 +32874,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31415,6 +32901,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31440,6 +32928,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31465,6 +32955,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31490,6 +32982,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31515,6 +33009,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31540,6 +33036,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31565,6 +33063,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31590,6 +33090,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31615,6 +33117,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31640,6 +33144,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31665,6 +33171,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31690,6 +33198,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31715,6 +33225,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31740,6 +33252,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31765,6 +33279,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31790,6 +33306,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31815,6 +33333,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31840,6 +33360,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31865,6 +33387,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31890,6 +33414,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31915,6 +33441,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31940,6 +33468,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31965,6 +33495,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -31990,6 +33522,8 @@
 					"ds": 2,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -32015,6 +33549,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -32040,6 +33576,8 @@
 					"ds": 2,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -32066,6 +33604,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -32091,6 +33631,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -32116,6 +33658,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -32141,6 +33685,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -32166,6 +33712,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -32191,6 +33739,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -32216,6 +33766,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -32241,6 +33793,8 @@
 					"ds": 2,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -32266,6 +33820,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -32291,6 +33847,8 @@
 					"ds": 2,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -32316,6 +33874,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -32341,6 +33901,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -32366,6 +33928,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -32391,6 +33955,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -32416,6 +33982,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -32441,6 +34009,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -32466,6 +34036,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -32491,6 +34063,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -32516,6 +34090,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -32541,6 +34117,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -32566,6 +34144,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -32591,6 +34171,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -32616,6 +34198,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -32641,6 +34225,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -32666,6 +34252,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -32691,6 +34279,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -32716,6 +34306,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -32741,6 +34333,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -32766,6 +34360,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -32791,6 +34387,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -32816,6 +34414,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -32841,6 +34441,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -32866,6 +34468,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -32891,6 +34495,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -32916,6 +34522,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -32941,6 +34549,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -32966,6 +34576,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -32991,6 +34603,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33016,6 +34630,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33041,6 +34657,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33066,6 +34684,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33091,6 +34711,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33116,6 +34738,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33141,6 +34765,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33166,6 +34792,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33191,6 +34819,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33216,6 +34846,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33241,6 +34873,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33266,6 +34900,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33291,6 +34927,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33316,6 +34954,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33341,6 +34981,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33366,6 +35008,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33391,6 +35035,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33416,6 +35062,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33441,6 +35089,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33466,6 +35116,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33491,6 +35143,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33516,6 +35170,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33541,6 +35197,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33566,6 +35224,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33591,6 +35251,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33616,6 +35278,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33641,6 +35305,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33666,6 +35332,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33691,6 +35359,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33716,6 +35386,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33741,6 +35413,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33766,6 +35440,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33791,6 +35467,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33816,6 +35494,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33841,6 +35521,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33866,6 +35548,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33891,6 +35575,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33916,6 +35602,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33941,6 +35629,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33966,6 +35656,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -33991,6 +35683,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34016,6 +35710,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34041,6 +35737,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34066,6 +35764,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34091,6 +35791,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34116,6 +35818,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34141,6 +35845,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34166,6 +35872,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34191,6 +35899,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34216,6 +35926,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34241,6 +35953,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34266,6 +35980,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34291,6 +36007,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34316,6 +36034,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34341,6 +36061,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34366,6 +36088,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34391,6 +36115,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34416,6 +36142,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34441,6 +36169,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34466,6 +36196,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34491,6 +36223,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34516,6 +36250,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34541,6 +36277,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34566,6 +36304,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34591,6 +36331,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34616,6 +36358,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34641,6 +36385,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34666,6 +36412,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34691,6 +36439,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34716,6 +36466,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34741,6 +36493,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34766,6 +36520,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34791,6 +36547,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34816,6 +36574,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34841,6 +36601,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34866,6 +36628,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34891,6 +36655,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34916,6 +36682,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34941,6 +36709,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34966,6 +36736,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -34991,6 +36763,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35016,6 +36790,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35041,6 +36817,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35066,6 +36844,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35091,6 +36871,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35116,6 +36898,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35141,6 +36925,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35166,6 +36952,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35191,6 +36979,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35216,6 +37006,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35241,6 +37033,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35266,6 +37060,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35291,6 +37087,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35316,6 +37114,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35341,6 +37141,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35366,6 +37168,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35391,6 +37195,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35416,6 +37222,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35441,6 +37249,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35466,6 +37276,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35491,6 +37303,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35516,6 +37330,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35541,6 +37357,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35566,6 +37384,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35591,6 +37411,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35616,6 +37438,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35641,6 +37465,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35666,6 +37492,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35691,6 +37519,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35716,6 +37546,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35741,6 +37573,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35766,6 +37600,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35791,6 +37627,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35816,6 +37654,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35841,6 +37681,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35866,6 +37708,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35891,6 +37735,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35916,6 +37762,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35941,6 +37789,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35966,6 +37816,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -35991,6 +37843,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -36016,6 +37870,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -36041,6 +37897,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -36066,6 +37924,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -36091,6 +37951,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 10,
 					"move": 20,
 					"sight": 10,
@@ -36116,6 +37978,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -36141,6 +38005,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -36166,6 +38032,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -36191,6 +38059,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -36216,6 +38086,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -36241,6 +38113,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -36266,6 +38140,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -36291,6 +38167,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -36316,6 +38194,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -36341,6 +38221,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -36366,6 +38248,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -36391,6 +38275,8 @@
 					"ds": 0,
 					"flags": {
 					},
+					"levels": [
+					],
 					"light": 20,
 					"move": 20,
 					"sight": 20,
@@ -36412,7 +38298,7 @@
 			"_id": "8ZWuW34EAMWVBpz5",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.rollable-tables.RollTable.8ZWuW34EAMWVBpz5",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351630054,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -36440,10 +38326,12 @@
 					"_id": "PNpw6nD7pKPsyZvv",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -36464,10 +38352,12 @@
 					"_id": "0TeoE2IhY5MPVtpt",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -36488,10 +38378,12 @@
 					"_id": "5fijKDn1mZw2tGmk",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -36512,10 +38404,12 @@
 					"_id": "FCmvIX9dq7Gx7CGx",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -36536,10 +38430,12 @@
 					"_id": "Z782QLjicP2OtgUZ",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -36560,10 +38456,12 @@
 					"_id": "OOWLCaTG7gf35mEJ",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -36584,10 +38482,12 @@
 					"_id": "XgOMJ3aKqlfbIcIe",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -36608,10 +38508,12 @@
 					"_id": "kwVkNCssLLXRbqmE",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -36632,10 +38534,12 @@
 					"_id": "pUibqtWGHNwRpTsg",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -36656,10 +38560,12 @@
 					"_id": "JtJxWjxJ6yAYTU4p",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -36683,7 +38589,7 @@
 			"_id": "9PJHNS0mKp3wQ0h8",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.rollable-tables.RollTable.9PJHNS0mKp3wQ0h8",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351630054,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -36711,10 +38617,12 @@
 					"_id": "4m3vwcrI23ql5FS7",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -36735,10 +38643,12 @@
 					"_id": "49dNpYkfff54Sz7X",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -36759,10 +38669,12 @@
 					"_id": "XyrZQng5hx2J5gGA",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -36783,10 +38695,12 @@
 					"_id": "SQc3JuebpgeopMre",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -36807,10 +38721,12 @@
 					"_id": "560K86MkO5iLNx2i",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -36831,10 +38747,12 @@
 					"_id": "Gf3QnC2xZ37NJ9e3",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -36855,10 +38773,12 @@
 					"_id": "E5ydGaK19KrsZkKh",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -36879,10 +38799,12 @@
 					"_id": "LG2fjyaNNK2ydaYJ",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -36906,7 +38828,7 @@
 			"_id": "IkysQwv0TS6SripN",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.rollable-tables.RollTable.IkysQwv0TS6SripN",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351630054,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -36934,10 +38856,12 @@
 					"_id": "EAUtZ0VrlR8i9ogk",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -36958,10 +38882,12 @@
 					"_id": "dReTlIDGvIaqUmMQ",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -36982,10 +38908,12 @@
 					"_id": "NmAPRZCVnSsRHhg0",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37006,10 +38934,12 @@
 					"_id": "eV0exfr8KFihTPZ2",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37030,10 +38960,12 @@
 					"_id": "BTcVgcLnLjXbVh33",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37054,10 +38986,12 @@
 					"_id": "uL6mxFZ2b1E4LKsF",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37078,10 +39012,12 @@
 					"_id": "O86SvMaQcQLifOi3",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37102,10 +39038,12 @@
 					"_id": "TOUAvhgEGhoy61lp",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37126,10 +39064,12 @@
 					"_id": "NbT3dY5USCvrRreo",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37150,10 +39090,12 @@
 					"_id": "7rsC7OybpMxlp979",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37177,7 +39119,7 @@
 			"_id": "K3VLbRUdyBC65MOL",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.rollable-tables.RollTable.K3VLbRUdyBC65MOL",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351630054,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -37205,10 +39147,12 @@
 					"_id": "q3bQMTJYLYZ2ubQK",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37229,10 +39173,12 @@
 					"_id": "EX6CgmlHrzSDX2cU",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37253,10 +39199,12 @@
 					"_id": "Se54zJ2lj3ENTC6T",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37277,10 +39225,12 @@
 					"_id": "riYTxLqfGJNE6A47",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37301,10 +39251,12 @@
 					"_id": "bbUTUPrWQ7boDUhh",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37325,10 +39277,12 @@
 					"_id": "7eopJNP8dRSnk5C6",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37349,10 +39303,12 @@
 					"_id": "S9v7cBuOtwAttbzM",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37373,10 +39329,12 @@
 					"_id": "DA2H0SUWLCkRht4p",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37397,10 +39355,12 @@
 					"_id": "GKvG0XtwWLA1Z2o4",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37421,10 +39381,12 @@
 					"_id": "86lAewvO2dOSeL8C",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37448,7 +39410,7 @@
 			"_id": "VKT5qBn60tiWZWXL",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.rollable-tables.RollTable.VKT5qBn60tiWZWXL",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351630054,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -37476,10 +39438,12 @@
 					"_id": "EWmShpr6C8RYQMwc",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37500,10 +39464,12 @@
 					"_id": "lfgV14JzI3cJR3Vf",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37524,10 +39490,12 @@
 					"_id": "CUuTifdKGf7mTsZJ",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37548,10 +39516,12 @@
 					"_id": "7DLZzlLIWCHgSqTw",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37572,10 +39542,12 @@
 					"_id": "SIZOEjVYUdo6gm9D",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37596,10 +39568,12 @@
 					"_id": "37zZQtlmEvEr7Bmr",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37620,10 +39594,12 @@
 					"_id": "HMVXdv5jgsmFa8y3",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37644,10 +39620,12 @@
 					"_id": "6vbTKnNprrRNIUhF",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37668,10 +39646,12 @@
 					"_id": "pFPORoqgnEuAvFCz",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37692,10 +39672,12 @@
 					"_id": "9TQH7eqPSOZCavE1",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37719,7 +39701,7 @@
 			"_id": "iFdrtN3kJk5yth9S",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.rollable-tables.RollTable.iFdrtN3kJk5yth9S",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351630054,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -37747,10 +39729,12 @@
 					"_id": "i6g6ZhMkWdRw9emF",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37771,10 +39755,12 @@
 					"_id": "WgFjcngGtx6xwrS5",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37795,10 +39781,12 @@
 					"_id": "WHE79Lp99Q3aTTs4",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37819,10 +39807,12 @@
 					"_id": "mdUxcanzIZ5xEGN9",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37843,10 +39833,12 @@
 					"_id": "evkxhl9nXFRrFmXk",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37867,10 +39859,12 @@
 					"_id": "4LWh1Sa4QQFqUBKe",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37894,7 +39888,7 @@
 			"_id": "jDOXbODgNkT69ii5",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.rollable-tables.RollTable.jDOXbODgNkT69ii5",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351630054,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -37922,10 +39916,12 @@
 					"_id": "i1UNCtMUrYn0mvJ3",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37946,10 +39942,12 @@
 					"_id": "3I0u5nKPamYsnP2O",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37970,10 +39968,12 @@
 					"_id": "n98vO3wqbEQriBAi",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -37994,10 +39994,12 @@
 					"_id": "eDsrbV4lIQ0MoqKa",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -38018,10 +40020,12 @@
 					"_id": "3IYPHFRhWcwKD5cW",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -38042,10 +40046,12 @@
 					"_id": "iJPR52RsJybSVu2f",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -38066,10 +40072,12 @@
 					"_id": "0nCYUoTSNEeI5Zhh",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -38090,10 +40098,12 @@
 					"_id": "DfukqBRvgrBiZA9d",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -38114,10 +40124,12 @@
 					"_id": "O8SBQgDuyZhZTmR1",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -38138,10 +40150,12 @@
 					"_id": "LHNPRzLjqUevyT48",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -38165,7 +40179,7 @@
 			"_id": "l251PEOpGq6Ss7Z9",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.rollable-tables.RollTable.l251PEOpGq6Ss7Z9",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351630054,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -38193,10 +40207,12 @@
 					"_id": "sNm1c3c9Xmi7epsS",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -38218,10 +40234,12 @@
 					"_id": "vpzgnESPYhCNBmKS",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -38245,7 +40263,7 @@
 			"_id": "m7Xv2zw1KGYxsuJG",
 			"_stats": {
 				"compendiumSource": "Compendium.shadowdark.rollable-tables.RollTable.m7Xv2zw1KGYxsuJG",
-				"coreVersion": "13.351",
+				"coreVersion": "14.365",
 				"createdTime": 1771351630054,
 				"duplicateSource": null,
 				"exportSource": null,
@@ -38273,10 +40291,12 @@
 					"_id": "MX1cO9oGIBtxq14h",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -38297,10 +40317,12 @@
 					"_id": "waXamHE2a6uHVEdq",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -38321,10 +40343,12 @@
 					"_id": "FENNJJSn8osSOVRW",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -38345,10 +40369,12 @@
 					"_id": "orpcZ1RnG1DgY0FD",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -38369,10 +40395,12 @@
 					"_id": "V6gRqQVX0B3WCwvZ",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -38393,10 +40421,12 @@
 					"_id": "nMRP838wFMPiowvh",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -38417,10 +40447,12 @@
 					"_id": "lRkj1ihHEJfrM0uP",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -38441,10 +40473,12 @@
 					"_id": "xyaGjySkTM0GilvW",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -38465,10 +40499,12 @@
 					"_id": "RFwDvLnQaYxW9ot8",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},
@@ -38489,10 +40525,12 @@
 					"_id": "2RZcfWeWPhbUGGsA",
 					"_stats": {
 						"compendiumSource": null,
-						"coreVersion": "13.351",
+						"coreVersion": "14.365",
+						"createdTime": null,
 						"duplicateSource": null,
 						"exportSource": null,
 						"lastModifiedBy": null,
+						"modifiedTime": null,
 						"systemId": "shadowdark",
 						"systemVersion": "4.0.0"
 					},

--- a/data/packs/quickstart-pregens.db/_1_on_spellcasting_checks__SKaFT0NF4Jcc93LZ.json
+++ b/data/packs/quickstart-pregens.db/_1_on_spellcasting_checks__SKaFT0NF4Jcc93LZ.json
@@ -2,16 +2,18 @@
 	"_id": "SKaFT0NF4Jcc93LZ",
 	"_key": "!actors.items!Jnb0sFKKKrAfowY0.SKaFT0NF4Jcc93LZ",
 	"effects": [
-		"Bn3Kp7mRs4Vx2TqWc"
+		"p4dR7oWcYu24JYWu"
 	],
-	"flags": {},
+	"flags": {
+	},
 	"folder": "Z4zDnZoxthjHXo5V",
 	"img": "icons/magic/fire/flame-burning-fist-strike.webp",
 	"name": "+1 on Spellcasting Checks",
 	"system": {
 		"description": "",
 		"level": 1,
-		"properties": [],
+		"properties": [
+		],
 		"source": {
 			"title": "core-rules"
 		},

--- a/data/packs/quickstart-pregens.db/_1_on_spellcasting_checks__i2IfM7lJOqc8OTXl.json
+++ b/data/packs/quickstart-pregens.db/_1_on_spellcasting_checks__i2IfM7lJOqc8OTXl.json
@@ -2,16 +2,18 @@
 	"_id": "i2IfM7lJOqc8OTXl",
 	"_key": "!actors.items!CVFznZtBMmHG2w4a.i2IfM7lJOqc8OTXl",
 	"effects": [
-		"Cj8nLpSo3Rx5UyWd4"
+		"paNAWp35Yfp1mrF9"
 	],
-	"flags": {},
+	"flags": {
+	},
 	"folder": "Z4zDnZoxthjHXo5V",
 	"img": "icons/magic/fire/flame-burning-fist-strike.webp",
 	"name": "+1 on Spellcasting Checks",
 	"system": {
 		"description": "",
 		"level": 1,
-		"properties": [],
+		"properties": [
+		],
 		"source": {
 			"title": "core-rules"
 		},

--- a/data/packs/quickstart-pregens.db/_2_to_strength__LsCy1cxn3Qzh7Jh4.json
+++ b/data/packs/quickstart-pregens.db/_2_to_strength__LsCy1cxn3Qzh7Jh4.json
@@ -2,16 +2,18 @@
 	"_id": "LsCy1cxn3Qzh7Jh4",
 	"_key": "!actors.items!4gxXdPgUd0ofz89A.LsCy1cxn3Qzh7Jh4",
 	"effects": [
-		"Fm1qOsVr6Ua8XbZg7"
+		"mxgwYGHFtfThLBEO"
 	],
-	"flags": {},
+	"flags": {
+	},
 	"folder": "Z4zDnZoxthjHXo5V",
 	"img": "icons/skills/melee/hand-grip-staff-yellow-brown.webp",
 	"name": "+2 to Strength",
 	"system": {
 		"description": "",
 		"level": 1,
-		"properties": [],
+		"properties": [
+		],
 		"source": {
 			"title": "core-rules"
 		},

--- a/data/packs/quickstart-pregens.db/ability_score_improvement__dex___sx2uVw9MzQNA7mnd.json
+++ b/data/packs/quickstart-pregens.db/ability_score_improvement__dex___sx2uVw9MzQNA7mnd.json
@@ -1,33 +1,40 @@
 {
 	"_id": "sx2uVw9MzQNA7mnd",
 	"_key": "!actors.items.effects!uXk56wpEwdiTfAQN.kaO7TrtQ8kmZvf4j.sx2uVw9MzQNA7mnd",
-	"changes": [
-		{
-			"key": "system.abilities.dex.value",
-			"mode": 2,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": 0,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/hand-grip-staff-yellow-brown.webp",
 	"name": "Ability Score Improvement (Dex)",
 	"origin": null,
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.dex.value",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/quickstart-pregens.db/ability_score_improvement__int___lSaJHBE00pEuwfOx.json
+++ b/data/packs/quickstart-pregens.db/ability_score_improvement__int___lSaJHBE00pEuwfOx.json
@@ -1,33 +1,40 @@
 {
 	"_id": "lSaJHBE00pEuwfOx",
 	"_key": "!actors.items.effects!PTFsYZ8ni3MbSdw8.YZYT0ZS0YqnMWnH0.lSaJHBE00pEuwfOx",
-	"changes": [
-		{
-			"key": "system.abilities.int.value",
-			"mode": 2,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": 0,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/hand-grip-staff-yellow-brown.webp",
 	"name": "Ability Score Improvement (Int)",
 	"origin": null,
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.int.value",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/quickstart-pregens.db/ability_score_improvement__str___Fm1qOsVr6Ua8XbZg7.json
+++ b/data/packs/quickstart-pregens.db/ability_score_improvement__str___Fm1qOsVr6Ua8XbZg7.json
@@ -1,4 +1,6 @@
 {
+	"_id": "Fm1qOsVr6Ua8XbZg7",
+	"_key": "!actors.items.effects!4gxXdPgUd0ofz89A.LsCy1cxn3Qzh7Jh4.Fm1qOsVr6Ua8XbZg7",
 	"changes": [
 		{
 			"key": "system.abilities.str.value",
@@ -18,15 +20,16 @@
 		"startTurn": null,
 		"turns": null
 	},
-	"flags": {},
+	"flags": {
+	},
 	"img": "icons/skills/melee/hand-grip-staff-yellow-brown.webp",
 	"name": "Ability Score Improvement (Str)",
 	"origin": null,
-	"statuses": [],
-	"system": {},
+	"statuses": [
+	],
+	"system": {
+	},
 	"tint": "#ffffff",
 	"transfer": true,
-	"type": "base",
-	"_id": "Fm1qOsVr6Ua8XbZg7",
-	"_key": "!actors.items.effects!4gxXdPgUd0ofz89A.LsCy1cxn3Qzh7Jh4.Fm1qOsVr6Ua8XbZg7"
+	"type": "base"
 }

--- a/data/packs/quickstart-pregens.db/ability_score_improvement__str___mxgwYGHFtfThLBEO.json
+++ b/data/packs/quickstart-pregens.db/ability_score_improvement__str___mxgwYGHFtfThLBEO.json
@@ -1,0 +1,42 @@
+{
+	"_id": "mxgwYGHFtfThLBEO",
+	"_key": "!actors.items.effects!4gxXdPgUd0ofz89A.LsCy1cxn3Qzh7Jh4.mxgwYGHFtfThLBEO",
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
+	},
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/skills/melee/hand-grip-staff-yellow-brown.webp",
+	"name": "Ability Score Improvement (Str)",
+	"origin": null,
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
+	"statuses": [
+	],
+	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.str.value",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/quickstart-pregens.db/ability_score_improvement__str___peAz8xVvIeZ6SLHd.json
+++ b/data/packs/quickstart-pregens.db/ability_score_improvement__str___peAz8xVvIeZ6SLHd.json
@@ -1,33 +1,40 @@
 {
 	"_id": "peAz8xVvIeZ6SLHd",
 	"_key": "!actors.items.effects!wnjtoBC4k5dIiG8X.7DVvNFOWt2fobzd3.peAz8xVvIeZ6SLHd",
-	"changes": [
-		{
-			"key": "system.abilities.str.value",
-			"mode": 2,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": 0,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/hand-grip-staff-yellow-brown.webp",
 	"name": "Ability Score Improvement (Str)",
 	"origin": null,
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.str.value",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/quickstart-pregens.db/additional_backstab_die__AmcPerJgnykmMwVA.json
+++ b/data/packs/quickstart-pregens.db/additional_backstab_die__AmcPerJgnykmMwVA.json
@@ -1,33 +1,40 @@
 {
 	"_id": "AmcPerJgnykmMwVA",
 	"_key": "!actors.items.effects!uXk56wpEwdiTfAQN.0ladgOD68Mb1vY6j.AmcPerJgnykmMwVA",
-	"changes": [
-		{
-			"key": "system.bonus.backstabdice",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "<p>Your Backstab deals +1 dice of damage.</p>",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": 0,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-dagger-white-orange.webp",
 	"name": "Additional Backstab Die",
 	"origin": null,
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.bonus.backstabdice",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/quickstart-pregens.db/advantage_against_opposing_force__Kr6vTxAw1Zf3CgEl2.json
+++ b/data/packs/quickstart-pregens.db/advantage_against_opposing_force__Kr6vTxAw1Zf3CgEl2.json
@@ -1,4 +1,6 @@
 {
+	"_id": "Kr6vTxAw1Zf3CgEl2",
+	"_key": "!actors.items.effects!4gxXdPgUd0ofz89A.1NzWmVAz7KltbAj7.Kr6vTxAw1Zf3CgEl2",
 	"changes": [
 		{
 			"key": "system.roll.stat.advantage.str",
@@ -26,11 +28,11 @@
 	"img": "icons/environment/people/infantry.webp",
 	"name": "Advantage Against Opposing Force",
 	"origin": "Compendium.shadowdark.talents.Item.F0NXUJcnBOYKzhMi",
-	"statuses": [],
-	"system": {},
+	"statuses": [
+	],
+	"system": {
+	},
 	"tint": "#ffffff",
 	"transfer": true,
-	"type": "base",
-	"_id": "Kr6vTxAw1Zf3CgEl2",
-	"_key": "!actors.items.effects!4gxXdPgUd0ofz89A.1NzWmVAz7KltbAj7.Kr6vTxAw1Zf3CgEl2"
+	"type": "base"
 }

--- a/data/packs/quickstart-pregens.db/advantage_against_opposing_force__kLhJi9CIdP5waTkT.json
+++ b/data/packs/quickstart-pregens.db/advantage_against_opposing_force__kLhJi9CIdP5waTkT.json
@@ -1,36 +1,43 @@
 {
 	"_id": "kLhJi9CIdP5waTkT",
 	"_key": "!actors.items.effects!wnjtoBC4k5dIiG8X.To1hPc52sKvOdsVo.kLhJi9CIdP5waTkT",
-	"changes": [
-		{
-			"key": "system.roll.stat.advantage.str",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "<p>You have advantage on Strength checks to overcome an opposing force, such as kicking open a stuck door, etc.</p>",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": 0,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 		"shadowdark": {
 			"situational": true
 		}
 	},
+	"folder": null,
 	"img": "icons/environment/people/infantry.webp",
 	"name": "Advantage Against Opposing Force",
 	"origin": "Compendium.shadowdark.talents.Item.F0NXUJcnBOYKzhMi",
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.stat.advantage.str",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/quickstart-pregens.db/advantage_against_opposing_force__oMaIAVZupehtqBJ2.json
+++ b/data/packs/quickstart-pregens.db/advantage_against_opposing_force__oMaIAVZupehtqBJ2.json
@@ -1,0 +1,45 @@
+{
+	"_id": "oMaIAVZupehtqBJ2",
+	"_key": "!actors.items.effects!4gxXdPgUd0ofz89A.1NzWmVAz7KltbAj7.oMaIAVZupehtqBJ2",
+	"description": "<p>You have advantage on Strength checks to overcome an opposing force, such as kicking open a stuck door, etc.</p>",
+	"disabled": false,
+	"duration": {
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
+	},
+	"flags": {
+		"shadowdark": {
+			"situational": true
+		}
+	},
+	"folder": null,
+	"img": "icons/environment/people/infantry.webp",
+	"name": "Advantage Against Opposing Force",
+	"origin": "Compendium.shadowdark.talents.Item.F0NXUJcnBOYKzhMi",
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
+	"statuses": [
+	],
+	"system": {
+		"changes": [
+			{
+				"key": "system.roll.stat.advantage.str",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/quickstart-pregens.db/backstab__Ip4tRvYu9Xd1AeCj0.json
+++ b/data/packs/quickstart-pregens.db/backstab__Ip4tRvYu9Xd1AeCj0.json
@@ -1,4 +1,6 @@
 {
+	"_id": "Ip4tRvYu9Xd1AeCj0",
+	"_key": "!actors.items.effects!uXk56wpEwdiTfAQN.L7MXRXLxu29ZHm5m.Ip4tRvYu9Xd1AeCj0",
 	"changes": [
 		{
 			"key": "system.roll.attack.extra-damage-die.all",
@@ -26,11 +28,11 @@
 	"img": "icons/skills/melee/sword-stuck-glowing-pink.webp",
 	"name": "Backstab",
 	"origin": "Compendium.shadowdark.talents.Item.KLDZKFY6SrqQKSva",
-	"statuses": [],
-	"system": {},
+	"statuses": [
+	],
+	"system": {
+	},
 	"tint": "#ffffff",
 	"transfer": true,
-	"type": "base",
-	"_id": "Ip4tRvYu9Xd1AeCj0",
-	"_key": "!actors.items.effects!uXk56wpEwdiTfAQN.L7MXRXLxu29ZHm5m.Ip4tRvYu9Xd1AeCj0"
+	"type": "base"
 }

--- a/data/packs/quickstart-pregens.db/backstab__L7MXRXLxu29ZHm5m.json
+++ b/data/packs/quickstart-pregens.db/backstab__L7MXRXLxu29ZHm5m.json
@@ -2,16 +2,18 @@
 	"_id": "L7MXRXLxu29ZHm5m",
 	"_key": "!actors.items!uXk56wpEwdiTfAQN.L7MXRXLxu29ZHm5m",
 	"effects": [
-		"Ip4tRvYu9Xd1AeCj0"
+		"sKt8BUWlMxrlCr8l"
 	],
-	"flags": {},
+	"flags": {
+	},
 	"folder": "8t1Gmpgn1Q6HXJAz",
 	"img": "icons/skills/melee/sword-stuck-glowing-pink.webp",
 	"name": "Backstab",
 	"system": {
 		"description": "<p>If you hit a creature who is unaware of your attack, you deal an extra weapon die of damage. Add additional weapon dice of damage equal to half your level (round down).</p>",
 		"level": 1,
-		"properties": [],
+		"properties": [
+		],
 		"source": {
 			"title": "core-rules"
 		},

--- a/data/packs/quickstart-pregens.db/backstab__fsh7dPOotCEuj2ic.json
+++ b/data/packs/quickstart-pregens.db/backstab__fsh7dPOotCEuj2ic.json
@@ -1,36 +1,43 @@
 {
 	"_id": "fsh7dPOotCEuj2ic",
 	"_key": "!actors.items.effects!x3L0onniGSB97CU7.e4cl7SKLrvRFgWA2.fsh7dPOotCEuj2ic",
-	"changes": [
-		{
-			"key": "system.roll.attack.extra-damage-die.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1+@bonus.backstabdice+floor(@level.value/2)"
-		}
-	],
 	"description": "<p>If you hit a creature who is unaware of your attack, you deal an extra weapon die of damage. Add additional weapon dice of damage equal to half your level (round down).</p>",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": 0,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 		"shadowdark": {
 			"situational": true
 		}
 	},
+	"folder": null,
 	"img": "icons/skills/melee/sword-stuck-glowing-pink.webp",
 	"name": "Backstab",
 	"origin": "Compendium.shadowdark.talents.Item.KLDZKFY6SrqQKSva",
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.extra-damage-die.all",
+				"priority": null,
+				"type": "add",
+				"value": "1+@bonus.backstabdice+floor(@level.value/2)"
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/quickstart-pregens.db/backstab__sKt8BUWlMxrlCr8l.json
+++ b/data/packs/quickstart-pregens.db/backstab__sKt8BUWlMxrlCr8l.json
@@ -1,0 +1,45 @@
+{
+	"_id": "sKt8BUWlMxrlCr8l",
+	"_key": "!actors.items.effects!uXk56wpEwdiTfAQN.L7MXRXLxu29ZHm5m.sKt8BUWlMxrlCr8l",
+	"description": "<p>If you hit a creature who is unaware of your attack, you deal an extra weapon die of damage. Add additional weapon dice of damage equal to half your level (round down).</p>",
+	"disabled": false,
+	"duration": {
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
+	},
+	"flags": {
+		"shadowdark": {
+			"situational": true
+		}
+	},
+	"folder": null,
+	"img": "icons/skills/melee/sword-stuck-glowing-pink.webp",
+	"name": "Backstab",
+	"origin": "Compendium.shadowdark.talents.Item.KLDZKFY6SrqQKSva",
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
+	"statuses": [
+	],
+	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.extra-damage-die.all",
+				"priority": null,
+				"type": "add",
+				"value": "1+@bonus.backstabdice+floor(@level.value/2)"
+			}
+		]
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/quickstart-pregens.db/creeg_greythorn__PTFsYZ8ni3MbSdw8.json
+++ b/data/packs/quickstart-pregens.db/creeg_greythorn__PTFsYZ8ni3MbSdw8.json
@@ -40,8 +40,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 40,
 		"disposition": 1,
@@ -110,9 +111,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/quickstart/pregens/Creeg_Greythorn_token.webp",

--- a/data/packs/quickstart-pregens.db/elbin_grizzlegut__RfFy5Nq3izy5oVD6.json
+++ b/data/packs/quickstart-pregens.db/elbin_grizzlegut__RfFy5Nq3izy5oVD6.json
@@ -40,8 +40,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 40,
 		"disposition": 1,
@@ -110,9 +111,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/quickstart/pregens/Elbin_Grizzlegut_token.webp",

--- a/data/packs/quickstart-pregens.db/extra_hp_max__Pw1AYcFB6Ek8HlJq7.json
+++ b/data/packs/quickstart-pregens.db/extra_hp_max__Pw1AYcFB6Ek8HlJq7.json
@@ -1,4 +1,6 @@
 {
+	"_id": "Pw1AYcFB6Ek8HlJq7",
+	"_key": "!actors.items.effects!RfFy5Nq3izy5oVD6.6UXvmSt8z623qgXf.Pw1AYcFB6Ek8HlJq7",
 	"changes": [
 		{
 			"key": "system.attributes.hp.max",
@@ -18,15 +20,16 @@
 		"startTurn": null,
 		"turns": null
 	},
-	"flags": {},
+	"flags": {
+	},
 	"img": "icons/magic/life/heart-shadow-red.webp",
 	"name": "Extra HP Max",
 	"origin": "Item.SXuw8zzD6a8dwmJE",
-	"statuses": [],
-	"system": {},
+	"statuses": [
+	],
+	"system": {
+	},
 	"tint": "#ffffff",
 	"transfer": true,
-	"type": "base",
-	"_id": "Pw1AYcFB6Ek8HlJq7",
-	"_key": "!actors.items.effects!RfFy5Nq3izy5oVD6.6UXvmSt8z623qgXf.Pw1AYcFB6Ek8HlJq7"
+	"type": "base"
 }

--- a/data/packs/quickstart-pregens.db/extra_hp_max__qIFVq4PAB70lPkf9.json
+++ b/data/packs/quickstart-pregens.db/extra_hp_max__qIFVq4PAB70lPkf9.json
@@ -1,33 +1,40 @@
 {
 	"_id": "qIFVq4PAB70lPkf9",
 	"_key": "!actors.items.effects!wnjtoBC4k5dIiG8X.opyHNO5TCXjkgfZU.qIFVq4PAB70lPkf9",
-	"changes": [
-		{
-			"key": "system.attributes.hp.max",
-			"mode": 2,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": 0,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/life/heart-shadow-red.webp",
 	"name": "Extra HP Max",
 	"origin": "Item.SXuw8zzD6a8dwmJE",
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.attributes.hp.max",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/quickstart-pregens.db/extra_hp_max__z6VQjrz0RTIG6KH1.json
+++ b/data/packs/quickstart-pregens.db/extra_hp_max__z6VQjrz0RTIG6KH1.json
@@ -1,0 +1,42 @@
+{
+	"_id": "z6VQjrz0RTIG6KH1",
+	"_key": "!actors.items.effects!RfFy5Nq3izy5oVD6.6UXvmSt8z623qgXf.z6VQjrz0RTIG6KH1",
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
+	},
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/magic/life/heart-shadow-red.webp",
+	"name": "Extra HP Max",
+	"origin": "Item.SXuw8zzD6a8dwmJE",
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
+	"statuses": [
+	],
+	"system": {
+		"changes": [
+			{
+				"key": "system.attributes.hp.max",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/quickstart-pregens.db/grit__strength___1NzWmVAz7KltbAj7.json
+++ b/data/packs/quickstart-pregens.db/grit__strength___1NzWmVAz7KltbAj7.json
@@ -2,16 +2,18 @@
 	"_id": "1NzWmVAz7KltbAj7",
 	"_key": "!actors.items!4gxXdPgUd0ofz89A.1NzWmVAz7KltbAj7",
 	"effects": [
-		"Kr6vTxAw1Zf3CgEl2"
+		"oMaIAVZupehtqBJ2"
 	],
-	"flags": {},
+	"flags": {
+	},
 	"folder": "8t1Gmpgn1Q6HXJAz",
 	"img": "icons/environment/people/infantry.webp",
 	"name": "Grit (Strength)",
 	"system": {
 		"description": "<p>Choose Strength or Dexterity. You have advantage on checks of that type to overcome an opposing force, such as kicking open a stuck door (Strength) or slipping free of rusty chains (Dexterity).</p>",
 		"level": 1,
-		"properties": [],
+		"properties": [
+		],
 		"source": {
 			"title": "core-rules"
 		},

--- a/data/packs/quickstart-pregens.db/hauler__17y4Trb6UrlMNLt5.json
+++ b/data/packs/quickstart-pregens.db/hauler__17y4Trb6UrlMNLt5.json
@@ -2,16 +2,18 @@
 	"_id": "17y4Trb6UrlMNLt5",
 	"_key": "!actors.items!4gxXdPgUd0ofz89A.17y4Trb6UrlMNLt5",
 	"effects": [
-		"Ls7wUyBx2Ag4DhFm3"
+		"OuvqbIooxeQDAOwd"
 	],
-	"flags": {},
+	"flags": {
+	},
 	"folder": "8t1Gmpgn1Q6HXJAz",
 	"img": "icons/containers/bags/sack-leather-tan.webp",
 	"name": "Hauler",
 	"system": {
 		"description": "<p>Add your Constitution modifier, if positive, to your gear slots.</p>",
 		"level": 1,
-		"properties": [],
+		"properties": [
+		],
 		"source": {
 			"title": "core-rules"
 		},

--- a/data/packs/quickstart-pregens.db/hauler__Ls7wUyBx2Ag4DhFm3.json
+++ b/data/packs/quickstart-pregens.db/hauler__Ls7wUyBx2Ag4DhFm3.json
@@ -1,4 +1,6 @@
 {
+	"_id": "Ls7wUyBx2Ag4DhFm3",
+	"_key": "!actors.items.effects!4gxXdPgUd0ofz89A.17y4Trb6UrlMNLt5.Ls7wUyBx2Ag4DhFm3",
 	"changes": [
 		{
 			"key": "system.slots",
@@ -18,15 +20,16 @@
 		"startTurn": null,
 		"turns": null
 	},
-	"flags": {},
+	"flags": {
+	},
 	"img": "icons/containers/bags/sack-leather-tan.webp",
 	"name": "Hauler",
 	"origin": "Compendium.shadowdark.talents.7JTDRLtHc6FOrIEc",
-	"statuses": [],
-	"system": {},
+	"statuses": [
+	],
+	"system": {
+	},
 	"tint": "#ffffff",
 	"transfer": true,
-	"type": "base",
-	"_id": "Ls7wUyBx2Ag4DhFm3",
-	"_key": "!actors.items.effects!4gxXdPgUd0ofz89A.17y4Trb6UrlMNLt5.Ls7wUyBx2Ag4DhFm3"
+	"type": "base"
 }

--- a/data/packs/quickstart-pregens.db/hauler__OuvqbIooxeQDAOwd.json
+++ b/data/packs/quickstart-pregens.db/hauler__OuvqbIooxeQDAOwd.json
@@ -1,0 +1,42 @@
+{
+	"_id": "OuvqbIooxeQDAOwd",
+	"_key": "!actors.items.effects!4gxXdPgUd0ofz89A.17y4Trb6UrlMNLt5.OuvqbIooxeQDAOwd",
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
+	},
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/containers/bags/sack-leather-tan.webp",
+	"name": "Hauler",
+	"origin": "Compendium.shadowdark.talents.7JTDRLtHc6FOrIEc",
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
+	"statuses": [
+	],
+	"system": {
+		"changes": [
+			{
+				"key": "system.slots",
+				"priority": null,
+				"type": "add",
+				"value": "max(@abilities.con.mod, 0)"
+			}
+		]
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/quickstart-pregens.db/hauler__rqplFhIShnvmV0U4.json
+++ b/data/packs/quickstart-pregens.db/hauler__rqplFhIShnvmV0U4.json
@@ -1,33 +1,40 @@
 {
 	"_id": "rqplFhIShnvmV0U4",
 	"_key": "!actors.items.effects!wnjtoBC4k5dIiG8X.eVVKrkOAtkVDxU3X.rqplFhIShnvmV0U4",
-	"changes": [
-		{
-			"key": "system.slots",
-			"mode": 2,
-			"priority": null,
-			"value": "max(@abilities.con.mod, 0)"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": 0,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/containers/bags/sack-leather-tan.webp",
 	"name": "Hauler",
 	"origin": "Compendium.shadowdark.talents.7JTDRLtHc6FOrIEc",
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.slots",
+				"priority": null,
+				"type": "add",
+				"value": "max(@abilities.con.mod, 0)"
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/quickstart-pregens.db/hp_roll_advantage__0rcSjPSjHdvGwtOu.json
+++ b/data/packs/quickstart-pregens.db/hp_roll_advantage__0rcSjPSjHdvGwtOu.json
@@ -1,33 +1,40 @@
 {
 	"_id": "0rcSjPSjHdvGwtOu",
 	"_key": "!actors.items.effects!wnjtoBC4k5dIiG8X.opyHNO5TCXjkgfZU.0rcSjPSjHdvGwtOu",
-	"changes": [
-		{
-			"key": "system.roll.hp.advantage",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": 0,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/life/cross-area-circle-green-white.webp",
 	"name": "HP Roll Advantage",
 	"origin": null,
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.hp.advantage",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/quickstart-pregens.db/hp_roll_advantage__Qx2BZdGC7Fl9ImKr8.json
+++ b/data/packs/quickstart-pregens.db/hp_roll_advantage__Qx2BZdGC7Fl9ImKr8.json
@@ -1,4 +1,6 @@
 {
+	"_id": "Qx2BZdGC7Fl9ImKr8",
+	"_key": "!actors.items.effects!RfFy5Nq3izy5oVD6.6UXvmSt8z623qgXf.Qx2BZdGC7Fl9ImKr8",
 	"changes": [
 		{
 			"key": "system.roll.hp.advantage",
@@ -18,15 +20,16 @@
 		"startTurn": null,
 		"turns": null
 	},
-	"flags": {},
+	"flags": {
+	},
 	"img": "icons/magic/life/cross-area-circle-green-white.webp",
 	"name": "HP Roll Advantage",
 	"origin": null,
-	"statuses": [],
-	"system": {},
+	"statuses": [
+	],
+	"system": {
+	},
 	"tint": "#ffffff",
 	"transfer": true,
-	"type": "base",
-	"_id": "Qx2BZdGC7Fl9ImKr8",
-	"_key": "!actors.items.effects!RfFy5Nq3izy5oVD6.6UXvmSt8z623qgXf.Qx2BZdGC7Fl9ImKr8"
+	"type": "base"
 }

--- a/data/packs/quickstart-pregens.db/hp_roll_advantage__n4miIjuIBuXC1BRP.json
+++ b/data/packs/quickstart-pregens.db/hp_roll_advantage__n4miIjuIBuXC1BRP.json
@@ -1,0 +1,42 @@
+{
+	"_id": "n4miIjuIBuXC1BRP",
+	"_key": "!actors.items.effects!RfFy5Nq3izy5oVD6.6UXvmSt8z623qgXf.n4miIjuIBuXC1BRP",
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
+	},
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/magic/life/cross-area-circle-green-white.webp",
+	"name": "HP Roll Advantage",
+	"origin": null,
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
+	"statuses": [
+	],
+	"system": {
+		"changes": [
+			{
+				"key": "system.roll.hp.advantage",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/quickstart-pregens.db/initiative_advantage__71GTV8nPjnyTdFjT.json
+++ b/data/packs/quickstart-pregens.db/initiative_advantage__71GTV8nPjnyTdFjT.json
@@ -1,33 +1,40 @@
 {
 	"_id": "71GTV8nPjnyTdFjT",
 	"_key": "!actors.items.effects!x3L0onniGSB97CU7.CNE7mfLjwGeXOr7j.71GTV8nPjnyTdFjT",
-	"changes": [
-		{
-			"key": "system.roll.initiative.advantage",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": 0,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/movement/feet-winged-boots-glowing-yellow.webp",
 	"name": "Initiative Advantage",
 	"origin": "Compendium.shadowdark.talents.Item.UVsf7VJCOrBm42Yz",
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.initiative.advantage",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/quickstart-pregens.db/iraga_draguul__CVFznZtBMmHG2w4a.json
+++ b/data/packs/quickstart-pregens.db/iraga_draguul__CVFznZtBMmHG2w4a.json
@@ -41,8 +41,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 40,
 		"disposition": 1,
@@ -111,9 +112,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/quickstart/pregens/Iraga_Draguul_token.webp",

--- a/data/packs/quickstart-pregens.db/jorbin_ironhelm__wnjtoBC4k5dIiG8X.json
+++ b/data/packs/quickstart-pregens.db/jorbin_ironhelm__wnjtoBC4k5dIiG8X.json
@@ -39,8 +39,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 40,
 		"disposition": 1,
@@ -109,9 +110,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/quickstart/pregens/Jorbin_Ironhelm_token.webp",

--- a/data/packs/quickstart-pregens.db/magic_missile_advantage__7d0PZnt5RXA1EBoW.json
+++ b/data/packs/quickstart-pregens.db/magic_missile_advantage__7d0PZnt5RXA1EBoW.json
@@ -2,16 +2,18 @@
 	"_id": "7d0PZnt5RXA1EBoW",
 	"_key": "!actors.items!Jnb0sFKKKrAfowY0.7d0PZnt5RXA1EBoW",
 	"effects": [
-		"Mt8xVzCy3Bh5EiGn4"
+		"stZoDtJvqII5obJJ"
 	],
-	"flags": {},
+	"flags": {
+	},
 	"folder": "8t1Gmpgn1Q6HXJAz",
 	"img": "icons/magic/light/projectiles-trio-pink.webp",
 	"name": "Magic Missile Advantage",
 	"system": {
 		"description": "<p>Wizards always have advantage on casting Magic Missile.</p>",
 		"level": null,
-		"properties": [],
+		"properties": [
+		],
 		"source": {
 			"title": "core-rules"
 		},

--- a/data/packs/quickstart-pregens.db/martin_rast__uXk56wpEwdiTfAQN.json
+++ b/data/packs/quickstart-pregens.db/martin_rast__uXk56wpEwdiTfAQN.json
@@ -36,8 +36,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 40,
 		"disposition": 1,
@@ -106,9 +107,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/quickstart/pregens/Martin_Rast_token.webp",

--- a/data/packs/quickstart-pregens.db/mighty__A9g8ZeATepsz2xvP.json
+++ b/data/packs/quickstart-pregens.db/mighty__A9g8ZeATepsz2xvP.json
@@ -1,39 +1,46 @@
 {
 	"_id": "A9g8ZeATepsz2xvP",
 	"_key": "!actors.items.effects!CVFznZtBMmHG2w4a.gyW8ctwFLkwZrFek.A9g8ZeATepsz2xvP",
-	"changes": [
-		{
-			"key": "system.roll.melee.bonus.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		},
-		{
-			"key": "system.roll.melee.damage.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "<p>You have a +1 bonus to attack and damage rolls with melee weapons.</p>",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": 0,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-axe-blood-red.webp",
 	"name": "Mighty",
 	"origin": "Compendium.shadowdark.talents.Item.LR6h4lXVXwx7AFQ6",
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.melee.bonus.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			},
+			{
+				"key": "system.roll.melee.damage.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/quickstart-pregens.db/ralina_biggins__x3L0onniGSB97CU7.json
+++ b/data/packs/quickstart-pregens.db/ralina_biggins__x3L0onniGSB97CU7.json
@@ -36,8 +36,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 40,
 		"disposition": 1,
@@ -106,9 +107,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/quickstart/pregens/Ralina_Biggins_token.webp",

--- a/data/packs/quickstart-pregens.db/ranged_attack_roll_bonus__p0eEwLNQh9oSEtEj.json
+++ b/data/packs/quickstart-pregens.db/ranged_attack_roll_bonus__p0eEwLNQh9oSEtEj.json
@@ -1,33 +1,40 @@
 {
 	"_id": "p0eEwLNQh9oSEtEj",
 	"_key": "!actors.items.effects!4gxXdPgUd0ofz89A.F2moDaLM7RD9aMb8.p0eEwLNQh9oSEtEj",
-	"changes": [
-		{
-			"key": "system.roll.ranged.bonus.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": 0,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Ranged Attack Roll Bonus",
 	"origin": null,
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.ranged.bonus.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/quickstart-pregens.db/spell_class__Ov0zXbEA5Dj7GkIp6.json
+++ b/data/packs/quickstart-pregens.db/spell_class__Ov0zXbEA5Dj7GkIp6.json
@@ -1,4 +1,6 @@
 {
+	"_id": "Ov0zXbEA5Dj7GkIp6",
+	"_key": "!actors.items.effects!CVFznZtBMmHG2w4a.lXBa2beUZOwgmD8w.Ov0zXbEA5Dj7GkIp6",
 	"changes": [
 		{
 			"key": "system.spellcasting.classes",
@@ -18,15 +20,16 @@
 		"startTurn": null,
 		"turns": null
 	},
-	"flags": {},
+	"flags": {
+	},
 	"img": "icons/magic/symbols/runes-star-pentagon-blue.webp",
 	"name": "Spell Class",
 	"origin": "Compendium.shadowdark.talents.Item.EYRxfb5BUEzH1w3b",
-	"statuses": [],
-	"system": {},
+	"statuses": [
+	],
+	"system": {
+	},
 	"tint": "#ffffff",
 	"transfer": true,
-	"type": "base",
-	"_id": "Ov0zXbEA5Dj7GkIp6",
-	"_key": "!actors.items.effects!CVFznZtBMmHG2w4a.lXBa2beUZOwgmD8w.Ov0zXbEA5Dj7GkIp6"
+	"type": "base"
 }

--- a/data/packs/quickstart-pregens.db/spell_class__SpCl8zRm2NwVxKd3.json
+++ b/data/packs/quickstart-pregens.db/spell_class__SpCl8zRm2NwVxKd3.json
@@ -1,33 +1,40 @@
 {
 	"_id": "SpCl8zRm2NwVxKd3",
 	"_key": "!actors.items.effects!Jnb0sFKKKrAfowY0.Gl9xK1TrcmMaFfCN.SpCl8zRm2NwVxKd3",
-	"changes": [
-		{
-			"key": "system.spellcasting.classes",
-			"mode": 2,
-			"priority": null,
-			"value": "wizard"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": 0,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/symbols/runes-star-pentagon-orange.webp",
 	"name": "Spell Class",
 	"origin": "Compendium.shadowdark.talents.Item.Td6iQW4hVJLZLVLi",
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.spellcasting.classes",
+				"priority": null,
+				"type": "add",
+				"value": "wizard"
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/quickstart-pregens.db/spell_class__aN53nPLLScKRopJC.json
+++ b/data/packs/quickstart-pregens.db/spell_class__aN53nPLLScKRopJC.json
@@ -1,0 +1,42 @@
+{
+	"_id": "aN53nPLLScKRopJC",
+	"_key": "!actors.items.effects!CVFznZtBMmHG2w4a.lXBa2beUZOwgmD8w.aN53nPLLScKRopJC",
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
+	},
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/magic/symbols/runes-star-pentagon-blue.webp",
+	"name": "Spell Class",
+	"origin": "Compendium.shadowdark.talents.Item.EYRxfb5BUEzH1w3b",
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
+	"statuses": [
+	],
+	"system": {
+		"changes": [
+			{
+				"key": "system.spellcasting.classes",
+				"priority": null,
+				"type": "add",
+				"value": "priest"
+			}
+		]
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/quickstart-pregens.db/spell_class__dejbAcycqE6ujmcJ.json
+++ b/data/packs/quickstart-pregens.db/spell_class__dejbAcycqE6ujmcJ.json
@@ -1,33 +1,40 @@
 {
 	"_id": "dejbAcycqE6ujmcJ",
 	"_key": "!actors.items.effects!RfFy5Nq3izy5oVD6.FfVoAYskj2Jn090z.dejbAcycqE6ujmcJ",
-	"changes": [
-		{
-			"key": "system.spellcasting.classes",
-			"mode": 2,
-			"priority": null,
-			"value": "priest"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": 0,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/symbols/runes-star-pentagon-blue.webp",
 	"name": "Spell Class",
 	"origin": "Compendium.shadowdark.talents.Item.EYRxfb5BUEzH1w3b",
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.spellcasting.classes",
+				"priority": null,
+				"type": "add",
+				"value": "priest"
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/quickstart-pregens.db/spell_class__zi1nJjmtxnx0lJaZ.json
+++ b/data/packs/quickstart-pregens.db/spell_class__zi1nJjmtxnx0lJaZ.json
@@ -1,33 +1,40 @@
 {
 	"_id": "zi1nJjmtxnx0lJaZ",
 	"_key": "!actors.items.effects!PTFsYZ8ni3MbSdw8.TnJe84PRjCQzFxRN.zi1nJjmtxnx0lJaZ",
-	"changes": [
-		{
-			"key": "system.spellcasting.classes",
-			"mode": 2,
-			"priority": null,
-			"value": "wizard"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": 0,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/symbols/runes-star-pentagon-orange.webp",
 	"name": "Spell Class",
 	"origin": "Compendium.shadowdark.talents.Item.Td6iQW4hVJLZLVLi",
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.spellcasting.classes",
+				"priority": null,
+				"type": "add",
+				"value": "wizard"
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/quickstart-pregens.db/spellcasting__priest___lXBa2beUZOwgmD8w.json
+++ b/data/packs/quickstart-pregens.db/spellcasting__priest___lXBa2beUZOwgmD8w.json
@@ -2,16 +2,18 @@
 	"_id": "lXBa2beUZOwgmD8w",
 	"_key": "!actors.items!CVFznZtBMmHG2w4a.lXBa2beUZOwgmD8w",
 	"effects": [
-		"Ov0zXbEA5Dj7GkIp6"
+		"aN53nPLLScKRopJC"
 	],
-	"flags": {},
+	"flags": {
+	},
 	"folder": "8t1Gmpgn1Q6HXJAz",
 	"img": "icons/magic/symbols/runes-star-pentagon-blue.webp",
 	"name": "Spellcasting (Priest)",
 	"system": {
 		"description": "<p><strong>Spellcasting.</strong> You can cast priest spells you know.</p><p>You know two tier 1 spells of your choice from the priest spell list on pg. 57.</p><p>Each time you gain a level, you choose new priest spells to learn according to the Priest Spells Known table.</p><p>For casting priest spells, see Spellcasting on pg. 52.</p>",
 		"level": 1,
-		"properties": [],
+		"properties": [
+		],
 		"source": {
 			"title": "core-rules"
 		},

--- a/data/packs/quickstart-pregens.db/spellcasting_advantage_on_spell__Mt8xVzCy3Bh5EiGn4.json
+++ b/data/packs/quickstart-pregens.db/spellcasting_advantage_on_spell__Mt8xVzCy3Bh5EiGn4.json
@@ -1,4 +1,6 @@
 {
+	"_id": "Mt8xVzCy3Bh5EiGn4",
+	"_key": "!actors.items.effects!Jnb0sFKKKrAfowY0.7d0PZnt5RXA1EBoW.Mt8xVzCy3Bh5EiGn4",
 	"changes": [
 		{
 			"key": "system.roll.spell.advantage.magic-missile",
@@ -18,15 +20,16 @@
 		"startTurn": null,
 		"turns": null
 	},
-	"flags": {},
+	"flags": {
+	},
 	"img": "icons/magic/air/air-smoke-casting.webp",
 	"name": "Spellcasting Advantage on Spell",
 	"origin": null,
-	"statuses": [],
-	"system": {},
+	"statuses": [
+	],
+	"system": {
+	},
 	"tint": "#ffffff",
 	"transfer": true,
-	"type": "base",
-	"_id": "Mt8xVzCy3Bh5EiGn4",
-	"_key": "!actors.items.effects!Jnb0sFKKKrAfowY0.7d0PZnt5RXA1EBoW.Mt8xVzCy3Bh5EiGn4"
+	"type": "base"
 }

--- a/data/packs/quickstart-pregens.db/spellcasting_advantage_on_spell__ZjpQVS9L1baZZ2PF.json
+++ b/data/packs/quickstart-pregens.db/spellcasting_advantage_on_spell__ZjpQVS9L1baZZ2PF.json
@@ -1,33 +1,40 @@
 {
 	"_id": "ZjpQVS9L1baZZ2PF",
 	"_key": "!actors.items.effects!PTFsYZ8ni3MbSdw8.t0co0RRkXIDiwyyv.ZjpQVS9L1baZZ2PF",
-	"changes": [
-		{
-			"key": "system.roll.spell.advantage.magic-missile",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": 0,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/air/air-smoke-casting.webp",
 	"name": "Spellcasting Advantage on Spell",
 	"origin": null,
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.spell.advantage.magic-missile",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/quickstart-pregens.db/spellcasting_advantage_on_spell__stZoDtJvqII5obJJ.json
+++ b/data/packs/quickstart-pregens.db/spellcasting_advantage_on_spell__stZoDtJvqII5obJJ.json
@@ -1,0 +1,42 @@
+{
+	"_id": "stZoDtJvqII5obJJ",
+	"_key": "!actors.items.effects!Jnb0sFKKKrAfowY0.7d0PZnt5RXA1EBoW.stZoDtJvqII5obJJ",
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
+	},
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/magic/air/air-smoke-casting.webp",
+	"name": "Spellcasting Advantage on Spell",
+	"origin": null,
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
+	"statuses": [
+	],
+	"system": {
+		"changes": [
+			{
+				"key": "system.roll.spell.advantage.magic-missile",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/quickstart-pregens.db/spellcasting_check_bonus__Bn3Kp7mRs4Vx2TqWc.json
+++ b/data/packs/quickstart-pregens.db/spellcasting_check_bonus__Bn3Kp7mRs4Vx2TqWc.json
@@ -1,4 +1,6 @@
 {
+	"_id": "Bn3Kp7mRs4Vx2TqWc",
+	"_key": "!actors.items.effects!Jnb0sFKKKrAfowY0.SKaFT0NF4Jcc93LZ.Bn3Kp7mRs4Vx2TqWc",
 	"changes": [
 		{
 			"key": "system.roll.spell.bonus.all",
@@ -18,15 +20,16 @@
 		"startTurn": null,
 		"turns": null
 	},
-	"flags": {},
+	"flags": {
+	},
 	"img": "icons/magic/fire/flame-burning-fist-strike.webp",
 	"name": "Spellcasting Check Bonus",
 	"origin": null,
-	"statuses": [],
-	"system": {},
+	"statuses": [
+	],
+	"system": {
+	},
 	"tint": "#ffffff",
 	"transfer": true,
-	"type": "base",
-	"_id": "Bn3Kp7mRs4Vx2TqWc",
-	"_key": "!actors.items.effects!Jnb0sFKKKrAfowY0.SKaFT0NF4Jcc93LZ.Bn3Kp7mRs4Vx2TqWc"
+	"type": "base"
 }

--- a/data/packs/quickstart-pregens.db/spellcasting_check_bonus__Cj8nLpSo3Rx5UyWd4.json
+++ b/data/packs/quickstart-pregens.db/spellcasting_check_bonus__Cj8nLpSo3Rx5UyWd4.json
@@ -1,4 +1,6 @@
 {
+	"_id": "Cj8nLpSo3Rx5UyWd4",
+	"_key": "!actors.items.effects!CVFznZtBMmHG2w4a.i2IfM7lJOqc8OTXl.Cj8nLpSo3Rx5UyWd4",
 	"changes": [
 		{
 			"key": "system.roll.spell.bonus.all",
@@ -18,15 +20,16 @@
 		"startTurn": null,
 		"turns": null
 	},
-	"flags": {},
+	"flags": {
+	},
 	"img": "icons/magic/fire/flame-burning-fist-strike.webp",
 	"name": "Spellcasting Check Bonus",
 	"origin": null,
-	"statuses": [],
-	"system": {},
+	"statuses": [
+	],
+	"system": {
+	},
 	"tint": "#ffffff",
 	"transfer": true,
-	"type": "base",
-	"_id": "Cj8nLpSo3Rx5UyWd4",
-	"_key": "!actors.items.effects!CVFznZtBMmHG2w4a.i2IfM7lJOqc8OTXl.Cj8nLpSo3Rx5UyWd4"
+	"type": "base"
 }

--- a/data/packs/quickstart-pregens.db/spellcasting_check_bonus__QBX0EGnKmDfPJ8gQ.json
+++ b/data/packs/quickstart-pregens.db/spellcasting_check_bonus__QBX0EGnKmDfPJ8gQ.json
@@ -1,33 +1,40 @@
 {
 	"_id": "QBX0EGnKmDfPJ8gQ",
 	"_key": "!actors.items.effects!RfFy5Nq3izy5oVD6.xdukM7u6LkuSd6gX.QBX0EGnKmDfPJ8gQ",
-	"changes": [
-		{
-			"key": "system.roll.spell.bonus.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": 0,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/fire/flame-burning-fist-strike.webp",
 	"name": "Spellcasting Check Bonus",
 	"origin": null,
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.spell.bonus.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/quickstart-pregens.db/spellcasting_check_bonus__p4dR7oWcYu24JYWu.json
+++ b/data/packs/quickstart-pregens.db/spellcasting_check_bonus__p4dR7oWcYu24JYWu.json
@@ -1,0 +1,42 @@
+{
+	"_id": "p4dR7oWcYu24JYWu",
+	"_key": "!actors.items.effects!Jnb0sFKKKrAfowY0.SKaFT0NF4Jcc93LZ.p4dR7oWcYu24JYWu",
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
+	},
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/magic/fire/flame-burning-fist-strike.webp",
+	"name": "Spellcasting Check Bonus",
+	"origin": null,
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
+	"statuses": [
+	],
+	"system": {
+		"changes": [
+			{
+				"key": "system.roll.spell.bonus.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/quickstart-pregens.db/spellcasting_check_bonus__paNAWp35Yfp1mrF9.json
+++ b/data/packs/quickstart-pregens.db/spellcasting_check_bonus__paNAWp35Yfp1mrF9.json
@@ -1,0 +1,42 @@
+{
+	"_id": "paNAWp35Yfp1mrF9",
+	"_key": "!actors.items.effects!CVFznZtBMmHG2w4a.i2IfM7lJOqc8OTXl.paNAWp35Yfp1mrF9",
+	"description": "",
+	"disabled": false,
+	"duration": {
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
+	},
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/magic/fire/flame-burning-fist-strike.webp",
+	"name": "Spellcasting Check Bonus",
+	"origin": null,
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
+	"statuses": [
+	],
+	"system": {
+		"changes": [
+			{
+				"key": "system.roll.spell.bonus.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/quickstart-pregens.db/stout__6UXvmSt8z623qgXf.json
+++ b/data/packs/quickstart-pregens.db/stout__6UXvmSt8z623qgXf.json
@@ -2,17 +2,19 @@
 	"_id": "6UXvmSt8z623qgXf",
 	"_key": "!actors.items!RfFy5Nq3izy5oVD6.6UXvmSt8z623qgXf",
 	"effects": [
-		"Pw1AYcFB6Ek8HlJq7",
-		"Qx2BZdGC7Fl9ImKr8"
+		"z6VQjrz0RTIG6KH1",
+		"n4miIjuIBuXC1BRP"
 	],
-	"flags": {},
+	"flags": {
+	},
 	"folder": "MFeFmA2ubOJxaTwm",
 	"img": "icons/environment/people/group.webp",
 	"name": "Stout",
 	"system": {
 		"description": "<p>Start with +2 HP. Roll your hit point gains with advantage.</p>",
 		"level": 1,
-		"properties": [],
+		"properties": [
+		],
 		"source": {
 			"title": "core-rules"
 		},

--- a/data/packs/quickstart-pregens.db/thievery__Ry3CaEhD8Gm0JnLs9.json
+++ b/data/packs/quickstart-pregens.db/thievery__Ry3CaEhD8Gm0JnLs9.json
@@ -1,4 +1,6 @@
 {
+	"_id": "Ry3CaEhD8Gm0JnLs9",
+	"_key": "!actors.items.effects!uXk56wpEwdiTfAQN.ZgPiv6ttj4KbiA5X.Ry3CaEhD8Gm0JnLs9",
 	"changes": [
 		{
 			"key": "system.roll.stat.advantage.all",
@@ -18,15 +20,16 @@
 		"startTurn": null,
 		"turns": null
 	},
-	"flags": {},
+	"flags": {
+	},
 	"img": "icons/skills/social/theft-pickpocket-bribery-brown.webp",
 	"name": "Thievery",
 	"origin": "Compendium.shadowdark.talents.Item.TiaXUSTLoJpjfyxD",
-	"statuses": [],
-	"system": {},
+	"statuses": [
+	],
+	"system": {
+	},
 	"tint": "#ffffff",
 	"transfer": true,
-	"type": "base",
-	"_id": "Ry3CaEhD8Gm0JnLs9",
-	"_key": "!actors.items.effects!uXk56wpEwdiTfAQN.ZgPiv6ttj4KbiA5X.Ry3CaEhD8Gm0JnLs9"
+	"type": "base"
 }

--- a/data/packs/quickstart-pregens.db/thievery__WhDG16TyQPUp85cQ.json
+++ b/data/packs/quickstart-pregens.db/thievery__WhDG16TyQPUp85cQ.json
@@ -1,0 +1,42 @@
+{
+	"_id": "WhDG16TyQPUp85cQ",
+	"_key": "!actors.items.effects!uXk56wpEwdiTfAQN.ZgPiv6ttj4KbiA5X.WhDG16TyQPUp85cQ",
+	"description": "<p>You are trained in the following tasks and have advantage on any associated checks: Climbing, Sneaking and hiding, Applying disguises, Finding and disabling traps and delicate tasks such as picking pockets and opening locks.</p>",
+	"disabled": false,
+	"duration": {
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
+	},
+	"flags": {
+	},
+	"folder": null,
+	"img": "icons/skills/social/theft-pickpocket-bribery-brown.webp",
+	"name": "Thievery",
+	"origin": "Compendium.shadowdark.talents.Item.TiaXUSTLoJpjfyxD",
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
+	"statuses": [
+	],
+	"system": {
+		"changes": [
+			{
+				"key": "system.roll.stat.advantage.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
+	},
+	"tint": "#ffffff",
+	"transfer": true,
+	"type": "base"
+}

--- a/data/packs/quickstart-pregens.db/thievery__ZgPiv6ttj4KbiA5X.json
+++ b/data/packs/quickstart-pregens.db/thievery__ZgPiv6ttj4KbiA5X.json
@@ -2,16 +2,18 @@
 	"_id": "ZgPiv6ttj4KbiA5X",
 	"_key": "!actors.items!uXk56wpEwdiTfAQN.ZgPiv6ttj4KbiA5X",
 	"effects": [
-		"Ry3CaEhD8Gm0JnLs9"
+		"WhDG16TyQPUp85cQ"
 	],
-	"flags": {},
+	"flags": {
+	},
 	"folder": "8t1Gmpgn1Q6HXJAz",
 	"img": "icons/skills/social/theft-pickpocket-bribery-brown.webp",
 	"name": "Thievery",
 	"system": {
 		"description": "<p>You are adept at thieving skills and have the necessary tools of the trade secreted on your person (they take up no gear slots).</p><p>You are trained in the following tasks and have advantage on any associated checks:</p><ul><li><p>Climbing</p></li><li><p>Sneaking and hiding</p></li><li><p>Applying disguises</p></li><li><p>Finding and disabling traps</p></li><li><p>Delicate tasks such as picking pockets and opening locks</p></li></ul>",
 		"level": 1,
-		"properties": [],
+		"properties": [
+		],
 		"source": {
 			"title": "core-rules"
 		},

--- a/data/packs/quickstart-pregens.db/thievery__aGa3IciSFPQKDtkc.json
+++ b/data/packs/quickstart-pregens.db/thievery__aGa3IciSFPQKDtkc.json
@@ -1,33 +1,40 @@
 {
 	"_id": "aGa3IciSFPQKDtkc",
 	"_key": "!actors.items.effects!x3L0onniGSB97CU7.BXGdD0rx1RWFnBLv.aGa3IciSFPQKDtkc",
-	"changes": [
-		{
-			"key": "system.roll.stat.advantage.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "<p>You are trained in the following tasks and have advantage on any associated checks: Climbing, Sneaking and hiding, Applying disguises, Finding and disabling traps and delicate tasks such as picking pockets and opening locks.</p>",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": 0,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/social/theft-pickpocket-bribery-brown.webp",
 	"name": "Thievery",
 	"origin": "Compendium.shadowdark.talents.Item.TiaXUSTLoJpjfyxD",
+	"showIcon": 1,
+	"start": {
+		"combat": null,
+		"combatant": null,
+		"initiative": null,
+		"round": null,
+		"time": 0,
+		"turn": null
+	},
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.stat.advantage.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/quickstart-pregens.db/weapon_mastery__E7SwrOhzSAyMZ1Ec.json
+++ b/data/packs/quickstart-pregens.db/weapon_mastery__E7SwrOhzSAyMZ1Ec.json
@@ -1,38 +1,38 @@
 {
 	"_id": "E7SwrOhzSAyMZ1Ec",
 	"_key": "!actors.items.effects!wnjtoBC4k5dIiG8X.ys29FVZBITfUFwra.E7SwrOhzSAyMZ1Ec",
-	"changes": [
-		{
-			"key": "system.roll.melee.bonus.greataxe",
-			"mode": 2,
-			"priority": null,
-			"value": "1+floor(@level.value/2)"
-		},
-		{
-			"key": "system.roll.melee.damage.greataxe",
-			"mode": 2,
-			"value": "1+floor(@level.value/2)"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/weapons-crossed-swords-white-blue.webp",
 	"name": "Weapon Mastery",
 	"origin": "Compendium.shadowdark.talents.eg8u9L4gcJAxBxVX",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.melee.bonus.greataxe",
+				"priority": null,
+				"type": "add",
+				"value": "1+floor(@level.value/2)"
+			},
+			{
+				"key": "system.roll.melee.damage.greataxe",
+				"type": "add",
+				"value": "1+floor(@level.value/2)"
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/quickstart-pregens.db/weapon_mastery__XmlEQByLpzXULngp.json
+++ b/data/packs/quickstart-pregens.db/weapon_mastery__XmlEQByLpzXULngp.json
@@ -1,38 +1,38 @@
 {
 	"_id": "XmlEQByLpzXULngp",
 	"_key": "!actors.items.effects!4gxXdPgUd0ofz89A.q4XASzehX7TfLgjb.XmlEQByLpzXULngp",
-	"changes": [
-		{
-			"key": "system.roll.melee.bonus.bastard-sword",
-			"mode": 2,
-			"priority": null,
-			"value": "1+floor(@level.value/2)"
-		},
-		{
-			"key": "system.roll.melee.damage.bastard-sword",
-			"mode": 2,
-			"value": "1+floor(@level.value/2)"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/weapons-crossed-swords-white-blue.webp",
 	"name": "Weapon Mastery",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.melee.bonus.bastard-sword",
+				"priority": null,
+				"type": "add",
+				"value": "1+floor(@level.value/2)"
+			},
+			{
+				"key": "system.roll.melee.damage.bastard-sword",
+				"type": "add",
+				"value": "1+floor(@level.value/2)"
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/quickstart-pregens.db/yriel_lirandar__4gxXdPgUd0ofz89A.json
+++ b/data/packs/quickstart-pregens.db/yriel_lirandar__4gxXdPgUd0ofz89A.json
@@ -39,8 +39,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 40,
 		"disposition": 1,
@@ -109,9 +110,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/quickstart/pregens/Yriel_Lirandar_token.webp",

--- a/data/packs/quickstart-pregens.db/zaldini_the_red__Jnb0sFKKKrAfowY0.json
+++ b/data/packs/quickstart-pregens.db/zaldini_the_red__Jnb0sFKKKrAfowY0.json
@@ -38,8 +38,9 @@
 		"bar2": {
 			"attribute": null
 		},
-		"detectionModes": [
-		],
+		"depth": 1,
+		"detectionModes": {
+		},
 		"displayBars": 0,
 		"displayName": 40,
 		"disposition": 1,
@@ -108,9 +109,6 @@
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"fit": "contain",
-			"offsetX": 0,
-			"offsetY": 0,
-			"rotation": 0,
 			"scaleX": 1,
 			"scaleY": 1,
 			"src": "systems/shadowdark/assets/quickstart/pregens/Zaldini_the_Red_token.webp",

--- a/data/packs/spell-effects.db/ac_bonus__GKcLELNdIj1o3OX3.json
+++ b/data/packs/spell-effects.db/ac_bonus__GKcLELNdIj1o3OX3.json
@@ -1,33 +1,33 @@
 {
 	"_id": "GKcLELNdIj1o3OX3",
 	"_key": "!items.effects!4dCcpPeyRKWt9XkC.GKcLELNdIj1o3OX3",
-	"changes": [
-		{
-			"key": "system.attributes.ac.value",
-			"mode": 2,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 5,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 5
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/defensive/shield-barrier-blue.webp",
 	"name": "AC Bonus",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.attributes.ac.value",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/acid_arrow__xJe5blefAwRNfYJk.json
+++ b/data/packs/spell-effects.db/acid_arrow__xJe5blefAwRNfYJk.json
@@ -1,27 +1,27 @@
 {
 	"_id": "xJe5blefAwRNfYJk",
 	"_key": "!items.effects!NXZlCiZI9X3AJc4m.xJe5blefAwRNfYJk",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/acid/projectile-bolts-salvo-green.webp",
 	"name": "Acid Arrow",
 	"origin": "Item.aAdqy5QwVJrT8JWE",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/alter_self__W3lcwErj4xWLokVF.json
+++ b/data/packs/spell-effects.db/alter_self__W3lcwErj4xWLokVF.json
@@ -1,27 +1,27 @@
 {
 	"_id": "W3lcwErj4xWLokVF",
 	"_key": "!items.effects!f2RsbovyTLEZvxuF.W3lcwErj4xWLokVF",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 5,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 5
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/control/energy-stream-link-spiral-orange.webp",
 	"name": "Alter Self",
 	"origin": "Item.f2RsbovyTLEZvxuF",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/anima__LPNXfI1s4dWE9gjl.json
+++ b/data/packs/spell-effects.db/anima__LPNXfI1s4dWE9gjl.json
@@ -1,27 +1,27 @@
 {
 	"_id": "LPNXfI1s4dWE9gjl",
 	"_key": "!items.effects!dc6hmJeeFqTACiQO.LPNXfI1s4dWE9gjl",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/environment/wilderness/terrain-rocks-brown.webp",
 	"name": "Anima",
 	"origin": "Compendium.shadowdark.spell-effects.Item.dc6hmJeeFqTACiQO",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/asleep__qohPOvbaVcxpRumR.json
+++ b/data/packs/spell-effects.db/asleep__qohPOvbaVcxpRumR.json
@@ -1,27 +1,27 @@
 {
 	"_id": "qohPOvbaVcxpRumR",
 	"_key": "!items.effects!FrFilluk4S5VaWut.qohPOvbaVcxpRumR",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/control/sleep-bubble-purple.webp",
 	"name": "Asleep",
 	"origin": "Item.FrFilluk4S5VaWut",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/barkskin__critical___goCqveYikTO4tTA0.json
+++ b/data/packs/spell-effects.db/barkskin__critical___goCqveYikTO4tTA0.json
@@ -1,33 +1,33 @@
 {
 	"_id": "goCqveYikTO4tTA0",
 	"_key": "!items.effects!qbCPO5ftwWImjRIG.goCqveYikTO4tTA0",
-	"changes": [
-		{
-			"key": "system.attributes.ac.value",
-			"mode": 5,
-			"priority": null,
-			"value": "18"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/nature/tree-spirit-glow-black-yellow.webp",
 	"name": "Barkskin (Critical)",
 	"origin": "Compendium.shadowdark.spell-effects.Item.7GAeLAX0xl65gxer",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.attributes.ac.value",
+				"priority": null,
+				"type": "override",
+				"value": 18
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/barkskin__goCqveYikTO4tTA0.json
+++ b/data/packs/spell-effects.db/barkskin__goCqveYikTO4tTA0.json
@@ -1,33 +1,33 @@
 {
 	"_id": "goCqveYikTO4tTA0",
 	"_key": "!items.effects!7GAeLAX0xl65gxer.goCqveYikTO4tTA0",
-	"changes": [
-		{
-			"key": "system.attributes.ac.value",
-			"mode": 5,
-			"priority": null,
-			"value": "14"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/nature/tree-spirit-glow-black-yellow.webp",
 	"name": "Barkskin",
 	"origin": "Compendium.shadowdark.spell-effects.Item.7GAeLAX0xl65gxer",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.attributes.ac.value",
+				"priority": null,
+				"type": "override",
+				"value": 14
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/berserk__kYzSScmkTg4o1DKM.json
+++ b/data/packs/spell-effects.db/berserk__kYzSScmkTg4o1DKM.json
@@ -1,27 +1,27 @@
 {
 	"_id": "kYzSScmkTg4o1DKM",
 	"_key": "!items.effects!sfeg7jRt0oW5qXO4.kYzSScmkTg4o1DKM",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/movement/abstract-ribbons-red-orange.webp",
 	"name": "Berserk",
 	"origin": "Compendium.shadowdark.spell-effects.Item.sfeg7jRt0oW5qXO4",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/blind__ItjPVhv2obp0MEhy.json
+++ b/data/packs/spell-effects.db/blind__ItjPVhv2obp0MEhy.json
@@ -1,27 +1,27 @@
 {
 	"_id": "ItjPVhv2obp0MEhy",
 	"_key": "!items.effects!SOkcvkzrGMGQKhmk.ItjPVhv2obp0MEhy",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/creatures/eyes/humanoid-single-blind.webp",
 	"name": "Blind",
 	"origin": "Item.SOkcvkzrGMGQKhmk",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/breath__cBbGoho9OMDVIR8n.json
+++ b/data/packs/spell-effects.db/breath__cBbGoho9OMDVIR8n.json
@@ -1,27 +1,27 @@
 {
 	"_id": "cBbGoho9OMDVIR8n",
 	"_key": "!items.effects!9fGlLVuMyuJeOHRU.cBbGoho9OMDVIR8n",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/air/air-pressure-shield-blue.webp",
 	"name": "Breath",
 	"origin": "Compendium.shadowdark.spell-effects.Item.9fGlLVuMyuJeOHRU",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/broomstick__gbIJz5HZymMEOrpU.json
+++ b/data/packs/spell-effects.db/broomstick__gbIJz5HZymMEOrpU.json
@@ -1,27 +1,27 @@
 {
 	"_id": "gbIJz5HZymMEOrpU",
 	"_key": "!items.effects!23KrUIOKwPNwVSCh.gbIJz5HZymMEOrpU",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 5,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 5
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/tools/hand/broom-straw-brown.webp",
 	"name": "Broomstick",
 	"origin": "Item.NzzijebUPYIGcakX",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/cast_out__rRaOIGFZ6RzYlvUI.json
+++ b/data/packs/spell-effects.db/cast_out__rRaOIGFZ6RzYlvUI.json
@@ -1,27 +1,27 @@
 {
 	"_id": "rRaOIGFZ6RzYlvUI",
 	"_key": "!items.effects!8vSJhm0X9PRdKTyX.rRaOIGFZ6RzYlvUI",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/control/energy-stream-link-large-white.webp",
 	"name": "Cast Out",
 	"origin": "Item.XIVFQdlFLE6VjDfs",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/cat_s_eye__4v6DbfBT6c4qzSEc.json
+++ b/data/packs/spell-effects.db/cat_s_eye__4v6DbfBT6c4qzSEc.json
@@ -1,27 +1,27 @@
 {
 	"_id": "4v6DbfBT6c4qzSEc",
 	"_key": "!items.effects!jKkFbA7VzDfOKvN5.4v6DbfBT6c4qzSEc",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/creatures/mammals/cat-hunched-glowing-red.webp",
 	"name": "Cat's Eye",
 	"origin": "Item.74WjFjHmUmLAiNGC",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/chanting__4v6DbfBT6c4qzSEc.json
+++ b/data/packs/spell-effects.db/chanting__4v6DbfBT6c4qzSEc.json
@@ -1,27 +1,27 @@
 {
 	"_id": "4v6DbfBT6c4qzSEc",
 	"_key": "!items.effects!ZLO5oq3gTJ762o3F.4v6DbfBT6c4qzSEc",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/perception/eye-slit-pink.webp",
 	"name": "Chanting",
 	"origin": "Item.74WjFjHmUmLAiNGC",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/charmed__6ILACQIHM3Gp8EVG.json
+++ b/data/packs/spell-effects.db/charmed__6ILACQIHM3Gp8EVG.json
@@ -1,27 +1,27 @@
 {
 	"_id": "6ILACQIHM3Gp8EVG",
 	"_key": "!items.effects!Z0YwWUGs3WYC6OGn.6ILACQIHM3Gp8EVG",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 86400,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 86400
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/life/heart-shadow-red.webp",
 	"name": "Charmed",
 	"origin": "Item.Z0YwWUGs3WYC6OGn",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/cleansing_weapon__MA4nY85bYnfw0Kah.json
+++ b/data/packs/spell-effects.db/cleansing_weapon__MA4nY85bYnfw0Kah.json
@@ -1,27 +1,27 @@
 {
 	"_id": "MA4nY85bYnfw0Kah",
 	"_key": "!items.effects!7hKYL9hdnsvCUM9c.MA4nY85bYnfw0Kah",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 5,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 5
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/swords/sword-winged-pink.webp",
 	"name": "Cleansing Weapon",
 	"origin": "Item.7hKYL9hdnsvCUM9c",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/cloak_of_night__441BBv90QacBfojj.json
+++ b/data/packs/spell-effects.db/cloak_of_night__441BBv90QacBfojj.json
@@ -1,33 +1,33 @@
 {
 	"_id": "441BBv90QacBfojj",
 	"_key": "!items.effects!vP9UrCnOXOe2ViZU.441BBv90QacBfojj",
-	"changes": [
-		{
-			"key": "system.attributes.ac.value",
-			"mode": 5,
-			"priority": null,
-			"value": "20"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 8,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 8
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/equipment/back/cloak-layered-tattered-purple.webp",
 	"name": "Cloak of Night",
 	"origin": "Item.h9MTxzrrPmyhEmRL",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.attributes.ac.value",
+				"priority": null,
+				"type": "override",
+				"value": 20
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/cloak_of_night__LTmspz6ojZ8MtHnL.json
+++ b/data/packs/spell-effects.db/cloak_of_night__LTmspz6ojZ8MtHnL.json
@@ -1,33 +1,33 @@
 {
 	"_id": "LTmspz6ojZ8MtHnL",
 	"_key": "!items.effects!3viSgI4JpKsXdaFd.LTmspz6ojZ8MtHnL",
-	"changes": [
-		{
-			"key": "system.attributes.ac.value",
-			"mode": 5,
-			"priority": null,
-			"value": "17"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 8,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 8
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/equipment/back/cloak-layered-tattered-purple.webp",
 	"name": "Cloak of Night",
 	"origin": "Compendium.shadowdark.spell-effects.Item.3viSgI4JpKsXdaFd",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.attributes.ac.value",
+				"priority": null,
+				"type": "override",
+				"value": 17
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/commanded__xJe5blefAwRNfYJk.json
+++ b/data/packs/spell-effects.db/commanded__xJe5blefAwRNfYJk.json
@@ -1,27 +1,27 @@
 {
 	"_id": "xJe5blefAwRNfYJk",
 	"_key": "!items.effects!y7UlIRecQ47S8qCy.xJe5blefAwRNfYJk",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/social/wave-halt-stop.webp",
 	"name": "Commanded",
 	"origin": "Item.aAdqy5QwVJrT8JWE",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/confused__rRaOIGFZ6RzYlvUI.json
+++ b/data/packs/spell-effects.db/confused__rRaOIGFZ6RzYlvUI.json
@@ -1,27 +1,27 @@
 {
 	"_id": "rRaOIGFZ6RzYlvUI",
 	"_key": "!items.effects!T0Lrknq9zQry0wwR.rRaOIGFZ6RzYlvUI",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/control/hypnosis-mesmerism-eye.webp",
 	"name": "Confused",
 	"origin": "Item.XIVFQdlFLE6VjDfs",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/controlled__3Pnp7zzDGQb638LU.json
+++ b/data/packs/spell-effects.db/controlled__3Pnp7zzDGQb638LU.json
@@ -1,27 +1,27 @@
 {
 	"_id": "3Pnp7zzDGQb638LU",
 	"_key": "!items.effects!nctlTXcIkACzb0yd.3Pnp7zzDGQb638LU",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/creatures/eyes/void-single-black-purple.webp",
 	"name": "Controlled",
 	"origin": "Item.sLb9GOXx9F6XCb2o",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/deaf__xJe5blefAwRNfYJk.json
+++ b/data/packs/spell-effects.db/deaf__xJe5blefAwRNfYJk.json
@@ -1,27 +1,27 @@
 {
 	"_id": "xJe5blefAwRNfYJk",
 	"_key": "!items.effects!aAdqy5QwVJrT8JWE.xJe5blefAwRNfYJk",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/sonic/scream-wail-shout-teal.webp",
 	"name": "Deaf",
 	"origin": "Item.aAdqy5QwVJrT8JWE",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/detecting_magic__4v6DbfBT6c4qzSEc.json
+++ b/data/packs/spell-effects.db/detecting_magic__4v6DbfBT6c4qzSEc.json
@@ -1,27 +1,27 @@
 {
 	"_id": "4v6DbfBT6c4qzSEc",
 	"_key": "!items.effects!74WjFjHmUmLAiNGC.4v6DbfBT6c4qzSEc",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/perception/eye-slit-pink.webp",
 	"name": "Detecting Magic",
 	"origin": "Item.74WjFjHmUmLAiNGC",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/dire_wolf__vMxGVAApQXuIeBXk.json
+++ b/data/packs/spell-effects.db/dire_wolf__vMxGVAApQXuIeBXk.json
@@ -1,57 +1,57 @@
 {
 	"_id": "vMxGVAApQXuIeBXk",
 	"_key": "!items.effects!3vCyl2kqfz31N1yP.vMxGVAApQXuIeBXk",
-	"changes": [
-		{
-			"key": "system.abilities.str.value",
-			"mode": 5,
-			"priority": null,
-			"value": "16"
-		},
-		{
-			"key": "system.abilities.dex.value",
-			"mode": 5,
-			"priority": null,
-			"value": "14"
-		},
-		{
-			"key": "system.abilities.con.value",
-			"mode": 5,
-			"priority": null,
-			"value": "12"
-		},
-		{
-			"key": "system.attributes.hp.max",
-			"mode": 5,
-			"priority": null,
-			"value": "19"
-		},
-		{
-			"key": "system.attributes.ac.all",
-			"mode": 5,
-			"priority": null,
-			"value": "12"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/creatures/mammals/wolf-howl-moon-forest-blue.webp",
 	"name": "Dire Wolf",
 	"origin": "Item.hVsjl5GZqSajuFU6",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.str.value",
+				"priority": null,
+				"type": "override",
+				"value": 16
+			},
+			{
+				"key": "system.abilities.dex.value",
+				"priority": null,
+				"type": "override",
+				"value": 14
+			},
+			{
+				"key": "system.abilities.con.value",
+				"priority": null,
+				"type": "override",
+				"value": 12
+			},
+			{
+				"key": "system.attributes.hp.max",
+				"priority": null,
+				"type": "override",
+				"value": 19
+			},
+			{
+				"key": "system.attributes.ac.all",
+				"priority": null,
+				"type": "override",
+				"value": 12
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/divine_vengeance__RftwcR3tZiYQwCZy.json
+++ b/data/packs/spell-effects.db/divine_vengeance__RftwcR3tZiYQwCZy.json
@@ -1,51 +1,51 @@
 {
 	"_id": "RftwcR3tZiYQwCZy",
 	"_key": "!items.effects!o74l0TnCb0E2fAKp.RftwcR3tZiYQwCZy",
-	"changes": [
-		{
-			"key": "system.roll.melee.bonus.all",
-			"mode": 2,
-			"priority": null,
-			"value": "4"
-		},
-		{
-			"key": "system.roll.ranged.bonus.all",
-			"mode": 2,
-			"priority": null,
-			"value": "4"
-		},
-		{
-			"key": "system.roll.melee.damage.all",
-			"mode": 2,
-			"priority": null,
-			"value": "4"
-		},
-		{
-			"key": "system.roll.ranged.damage.all",
-			"mode": 2,
-			"priority": null,
-			"value": "4"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 5,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 5
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/light/explosion-beam-impact-silhouette.webp",
 	"name": "Divine Vengeance",
 	"origin": "Item.xOHpjBx4PhrNXQ4U",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.melee.bonus.all",
+				"priority": null,
+				"type": "add",
+				"value": 4
+			},
+			{
+				"key": "system.roll.ranged.bonus.all",
+				"priority": null,
+				"type": "add",
+				"value": 4
+			},
+			{
+				"key": "system.roll.melee.damage.all",
+				"priority": null,
+				"type": "add",
+				"value": 4
+			},
+			{
+				"key": "system.roll.ranged.damage.all",
+				"priority": null,
+				"type": "add",
+				"value": 4
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/enchanted__qohPOvbaVcxpRumR.json
+++ b/data/packs/spell-effects.db/enchanted__qohPOvbaVcxpRumR.json
@@ -1,27 +1,27 @@
 {
 	"_id": "qohPOvbaVcxpRumR",
 	"_key": "!items.effects!CFnP5fuBHsNZzrkY.qohPOvbaVcxpRumR",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 86400,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 86400
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/consumables/fruit/huckleberry.webp",
 	"name": "Enchanted",
 	"origin": "Item.FrFilluk4S5VaWut",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/envenomed__441BBv90QacBfojj.json
+++ b/data/packs/spell-effects.db/envenomed__441BBv90QacBfojj.json
@@ -1,33 +1,33 @@
 {
 	"_id": "441BBv90QacBfojj",
 	"_key": "!items.effects!sZ6msFePi3R6DUju.441BBv90QacBfojj",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.all",
-			"mode": 1,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/creatures/reptiles/serpent-horned-green.webp",
 	"name": "Envenomed",
 	"origin": "Item.h9MTxzrrPmyhEmRL",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.all",
+				"priority": null,
+				"type": "multiply",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/eyebit__ayif1AZ50Ji9yhIi.json
+++ b/data/packs/spell-effects.db/eyebit__ayif1AZ50Ji9yhIi.json
@@ -1,27 +1,27 @@
 {
 	"_id": "ayif1AZ50Ji9yhIi",
 	"_key": "!items.effects!0RrksUfAZkp4LpGe.ayif1AZ50Ji9yhIi",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/perception/eye-ringed-glow-angry-teal.webp",
 	"name": "Eyebit",
 	"origin": "Item.jz1fW4KgYERtTtXC",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/feeble__cha___441BBv90QacBfojj.json
+++ b/data/packs/spell-effects.db/feeble__cha___441BBv90QacBfojj.json
@@ -1,33 +1,33 @@
 {
 	"_id": "441BBv90QacBfojj",
 	"_key": "!items.effects!OTHSzCFY9zLlwzFF.441BBv90QacBfojj",
-	"changes": [
-		{
-			"key": "system.abilities.cha.value",
-			"mode": 3,
-			"priority": null,
-			"value": "3"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 864000,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 864000
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/control/fear-fright-white.webp",
 	"name": "Feeble (CHA)",
 	"origin": "Item.h9MTxzrrPmyhEmRL",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.cha.value",
+				"priority": null,
+				"type": "downgrade",
+				"value": 3
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/feeble__con___441BBv90QacBfojj.json
+++ b/data/packs/spell-effects.db/feeble__con___441BBv90QacBfojj.json
@@ -1,33 +1,33 @@
 {
 	"_id": "441BBv90QacBfojj",
 	"_key": "!items.effects!Eojo6v3WsiHEDcKm.441BBv90QacBfojj",
-	"changes": [
-		{
-			"key": "system.abilities.con.value",
-			"mode": 3,
-			"priority": null,
-			"value": "3"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 864000,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 864000
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/control/fear-fright-white.webp",
 	"name": "Feeble (CON)",
 	"origin": "Item.h9MTxzrrPmyhEmRL",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.con.value",
+				"priority": null,
+				"type": "downgrade",
+				"value": 3
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/feeble__dex___441BBv90QacBfojj.json
+++ b/data/packs/spell-effects.db/feeble__dex___441BBv90QacBfojj.json
@@ -1,33 +1,33 @@
 {
 	"_id": "441BBv90QacBfojj",
 	"_key": "!items.effects!1PzBYve4rd4MH6K2.441BBv90QacBfojj",
-	"changes": [
-		{
-			"key": "system.abilities.dex.value",
-			"mode": 3,
-			"priority": null,
-			"value": "3"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 864000,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 864000
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/control/fear-fright-white.webp",
 	"name": "Feeble (DEX)",
 	"origin": "Item.h9MTxzrrPmyhEmRL",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.dex.value",
+				"priority": null,
+				"type": "downgrade",
+				"value": 3
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/feeble__int___441BBv90QacBfojj.json
+++ b/data/packs/spell-effects.db/feeble__int___441BBv90QacBfojj.json
@@ -1,33 +1,33 @@
 {
 	"_id": "441BBv90QacBfojj",
 	"_key": "!items.effects!0DDkeYKSrNj6JG1l.441BBv90QacBfojj",
-	"changes": [
-		{
-			"key": "system.abilities.int.value",
-			"mode": 3,
-			"priority": null,
-			"value": "3"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 864000,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 864000
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/control/fear-fright-white.webp",
 	"name": "Feeble (INT)",
 	"origin": "Item.h9MTxzrrPmyhEmRL",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.int.value",
+				"priority": null,
+				"type": "downgrade",
+				"value": 3
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/feeble__str___441BBv90QacBfojj.json
+++ b/data/packs/spell-effects.db/feeble__str___441BBv90QacBfojj.json
@@ -1,33 +1,33 @@
 {
 	"_id": "441BBv90QacBfojj",
 	"_key": "!items.effects!Ya5tD4kFDne19zZO.441BBv90QacBfojj",
-	"changes": [
-		{
-			"key": "system.abilities.str.value",
-			"mode": 3,
-			"priority": null,
-			"value": "3"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 864000,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 864000
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/control/fear-fright-white.webp",
 	"name": "Feeble (STR)",
 	"origin": "Item.h9MTxzrrPmyhEmRL",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.str.value",
+				"priority": null,
+				"type": "downgrade",
+				"value": 3
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/feeble__wis___441BBv90QacBfojj.json
+++ b/data/packs/spell-effects.db/feeble__wis___441BBv90QacBfojj.json
@@ -1,33 +1,33 @@
 {
 	"_id": "441BBv90QacBfojj",
 	"_key": "!items.effects!Jlv9MzbDrXu92djm.441BBv90QacBfojj",
-	"changes": [
-		{
-			"key": "system.abilities.wis.value",
-			"mode": 3,
-			"priority": null,
-			"value": "3"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 864000,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 864000
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/control/fear-fright-white.webp",
 	"name": "Feeble (WIS)",
 	"origin": "Item.h9MTxzrrPmyhEmRL",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.wis.value",
+				"priority": null,
+				"type": "downgrade",
+				"value": 3
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/floating__3Pnp7zzDGQb638LU.json
+++ b/data/packs/spell-effects.db/floating__3Pnp7zzDGQb638LU.json
@@ -1,27 +1,27 @@
 {
 	"_id": "3Pnp7zzDGQb638LU",
 	"_key": "!items.effects!sLb9GOXx9F6XCb2o.3Pnp7zzDGQb638LU",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/air/air-smoke-casting.webp",
 	"name": "Floating",
 	"origin": "Item.sLb9GOXx9F6XCb2o",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/floating_disk__yp7OciSIM5iKgRlU.json
+++ b/data/packs/spell-effects.db/floating_disk__yp7OciSIM5iKgRlU.json
@@ -1,27 +1,27 @@
 {
 	"_id": "yp7OciSIM5iKgRlU",
 	"_key": "!items.effects!VMkeCfccn7zp2up7.yp7OciSIM5iKgRlU",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 10,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 10
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/commodities/metal/plate-steel-pink.webp",
 	"name": "Floating disk",
 	"origin": "Item.VMkeCfccn7zp2up7",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/flying__gbIJz5HZymMEOrpU.json
+++ b/data/packs/spell-effects.db/flying__gbIJz5HZymMEOrpU.json
@@ -1,27 +1,27 @@
 {
 	"_id": "gbIJz5HZymMEOrpU",
 	"_key": "!items.effects!IzCONbtholryomxC.gbIJz5HZymMEOrpU",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 5,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 5
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/movement/feet-winged-sandals-tan.webp",
 	"name": "Flying",
 	"origin": "Item.NzzijebUPYIGcakX",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/fragile__xJe5blefAwRNfYJk.json
+++ b/data/packs/spell-effects.db/fragile__xJe5blefAwRNfYJk.json
@@ -1,27 +1,27 @@
 {
 	"_id": "xJe5blefAwRNfYJk",
 	"_key": "!items.effects!qNd9stCSD6ZJyoOj.xJe5blefAwRNfYJk",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/wounds/bone-broken-knee-beam.webp",
 	"name": "Fragile",
 	"origin": "Item.aAdqy5QwVJrT8JWE",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/freya_s_omen__71bMZvK0yxmAAcUL.json
+++ b/data/packs/spell-effects.db/freya_s_omen__71bMZvK0yxmAAcUL.json
@@ -1,27 +1,27 @@
 {
 	"_id": "71bMZvK0yxmAAcUL",
 	"_key": "!items.effects!HBIVwYRcojImlOOx.71bMZvK0yxmAAcUL",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/holy/angel-wings-gray.webp",
 	"name": "Freya's Omen",
 	"origin": "Item.iiLI7kRr7y0PLSXK",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/gaseous__zwulssk0c4SQwWbC.json
+++ b/data/packs/spell-effects.db/gaseous__zwulssk0c4SQwWbC.json
@@ -1,27 +1,27 @@
 {
 	"_id": "zwulssk0c4SQwWbC",
 	"_key": "!items.effects!u6apLIMU1w4EIW06.zwulssk0c4SQwWbC",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 10,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 10
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/air/wind-tornado-wall-blue.webp",
 	"name": "Gaseous",
 	"origin": "Item.u2mS6xCKAG1oiEWX",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/hallucinating__rRaOIGFZ6RzYlvUI.json
+++ b/data/packs/spell-effects.db/hallucinating__rRaOIGFZ6RzYlvUI.json
@@ -1,27 +1,27 @@
 {
 	"_id": "rRaOIGFZ6RzYlvUI",
 	"_key": "!items.effects!PLPiCgwZaEetlx5O.rRaOIGFZ6RzYlvUI",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/control/hypnosis-mesmerism-eye.webp",
 	"name": "Hallucinating",
 	"origin": "Item.XIVFQdlFLE6VjDfs",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/holding_portal__4OcH6wsgdH5jqY0k.json
+++ b/data/packs/spell-effects.db/holding_portal__4OcH6wsgdH5jqY0k.json
@@ -1,27 +1,27 @@
 {
 	"_id": "4OcH6wsgdH5jqY0k",
 	"_key": "!items.effects!q109XEqMceJBEX7m.4OcH6wsgdH5jqY0k",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 10,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 10
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/movement/portal-vortex-orange.webp",
 	"name": "Holding Portal",
 	"origin": "Item.q109XEqMceJBEX7m",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/holy_weapon__7yErzttRT6Zaz8pz.json
+++ b/data/packs/spell-effects.db/holy_weapon__7yErzttRT6Zaz8pz.json
@@ -1,39 +1,39 @@
 {
 	"_id": "7yErzttRT6Zaz8pz",
 	"_key": "!items.effects!r2JNgS2474vuq9oy.7yErzttRT6Zaz8pz",
-	"changes": [
-		{
-			"key": "system.roll.attack.bonus.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		},
-		{
-			"key": "system.roll.attack.damage.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "<p>The weapon becomes magical and has +1 to attack and damage rolls for the duration.</p>",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/swords/sword-gold-holy.webp",
 	"name": "Holy Weapon",
 	"origin": "Compendium.shadowdark.spell-effects.Item.r2JNgS2474vuq9oy",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			},
+			{
+				"key": "system.roll.attack.damage.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/hypnotized__rRaOIGFZ6RzYlvUI.json
+++ b/data/packs/spell-effects.db/hypnotized__rRaOIGFZ6RzYlvUI.json
@@ -1,27 +1,27 @@
 {
 	"_id": "rRaOIGFZ6RzYlvUI",
 	"_key": "!items.effects!6wfBZBYV85NQTcJz.rRaOIGFZ6RzYlvUI",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/control/hypnosis-mesmerism-eye.webp",
 	"name": "Hypnotized",
 	"origin": "Item.XIVFQdlFLE6VjDfs",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/instill__ZdO7fIT4Y62U19ut.json
+++ b/data/packs/spell-effects.db/instill__ZdO7fIT4Y62U19ut.json
@@ -1,27 +1,27 @@
 {
 	"_id": "ZdO7fIT4Y62U19ut",
 	"_key": "!items.effects!tplKQpO6Q94eMnGI.ZdO7fIT4Y62U19ut",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/staves/staff-forest-jewel.webp",
 	"name": "Instill",
 	"origin": "Compendium.shadowdark.spell-effects.Item.tplKQpO6Q94eMnGI",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/invisible__LmXXpHviIuB684gX.json
+++ b/data/packs/spell-effects.db/invisible__LmXXpHviIuB684gX.json
@@ -1,27 +1,27 @@
 {
 	"_id": "LmXXpHviIuB684gX",
 	"_key": "!items.effects!SMXbMbXcj5hLvTjY.LmXXpHviIuB684gX",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 10,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 10
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/light/explosion-star-glow-silhouette.webp",
 	"name": "Invisible",
 	"origin": "Item.SMXbMbXcj5hLvTjY",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/laughing__pTKFUJ3czAqssXCu.json
+++ b/data/packs/spell-effects.db/laughing__pTKFUJ3czAqssXCu.json
@@ -1,27 +1,27 @@
 {
 	"_id": "pTKFUJ3czAqssXCu",
 	"_key": "!items.effects!9E4RVp3xfAK1uxrl.pTKFUJ3czAqssXCu",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 5,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 5
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/control/mouth-smile-deception-purple.webp",
 	"name": "Laughing",
 	"origin": "Item.28PPFz1MYTsfPwzh",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/locusts__SeGDXtfZW1ZclMlC.json
+++ b/data/packs/spell-effects.db/locusts__SeGDXtfZW1ZclMlC.json
@@ -1,27 +1,27 @@
 {
 	"_id": "SeGDXtfZW1ZclMlC",
 	"_key": "!items.effects!S56vv5Gz3Pcy4DxZ.SeGDXtfZW1ZclMlC",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/creatures/invertebrates/wasp-swarm-tan.webp",
 	"name": "Locusts",
 	"origin": "Compendium.shadowdark.spell-effects.Item.S56vv5Gz3Pcy4DxZ",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/mage_armor__441BBv90QacBfojj.json
+++ b/data/packs/spell-effects.db/mage_armor__441BBv90QacBfojj.json
@@ -1,33 +1,33 @@
 {
 	"_id": "441BBv90QacBfojj",
 	"_key": "!items.effects!h9MTxzrrPmyhEmRL.441BBv90QacBfojj",
-	"changes": [
-		{
-			"key": "system.attributes.ac.value",
-			"mode": 5,
-			"priority": null,
-			"value": "14"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 10,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 10
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/defensive/shield-barrier-glowing-blue.webp",
 	"name": "Mage Armor",
 	"origin": "Item.h9MTxzrrPmyhEmRL",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.attributes.ac.value",
+				"priority": null,
+				"type": "override",
+				"value": 14
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/mage_armor__gyGa1ckOLwWnF86M.json
+++ b/data/packs/spell-effects.db/mage_armor__gyGa1ckOLwWnF86M.json
@@ -1,33 +1,33 @@
 {
 	"_id": "gyGa1ckOLwWnF86M",
 	"_key": "!items.effects!Gyol5I0ZdApO8MPe.gyGa1ckOLwWnF86M",
-	"changes": [
-		{
-			"key": "system.attributes.ac.value",
-			"mode": 5,
-			"priority": null,
-			"value": "18"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 10,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 10
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/defensive/shield-barrier-glowing-blue.webp",
 	"name": "Mage Armor",
 	"origin": "Compendium.shadowdark.spell-effects.Item.Gyol5I0ZdApO8MPe",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.attributes.ac.value",
+				"priority": null,
+				"type": "override",
+				"value": 18
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/magnetize__ENBQPzsgEeuzEYvU.json
+++ b/data/packs/spell-effects.db/magnetize__ENBQPzsgEeuzEYvU.json
@@ -1,27 +1,27 @@
 {
 	"_id": "ENBQPzsgEeuzEYvU",
 	"_key": "!items.effects!LyVUb5XbziOGsLXM.ENBQPzsgEeuzEYvU",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/tools/navigation/compass-brass-blue-red.webp",
 	"name": "Magnetize",
 	"origin": "Compendium.shadowdark.spell-effects.Item.LyVUb5XbziOGsLXM",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/mirror_image__P1QXkErKypSKB6bl.json
+++ b/data/packs/spell-effects.db/mirror_image__P1QXkErKypSKB6bl.json
@@ -1,27 +1,27 @@
 {
 	"_id": "P1QXkErKypSKB6bl",
 	"_key": "!items.effects!vI70AaskCqH9tKJ7.P1QXkErKypSKB6bl",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 5,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 5
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/defensive/illusion-evasion-echo-purple.webp",
 	"name": "Mirror Image",
 	"origin": "Item.vI70AaskCqH9tKJ7",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/oak__ash__thorn__1OnR6BmpQBNIxZYK.json
+++ b/data/packs/spell-effects.db/oak__ash__thorn__1OnR6BmpQBNIxZYK.json
@@ -1,27 +1,27 @@
 {
 	"_id": "1OnR6BmpQBNIxZYK",
 	"_key": "!items.effects!88nOOPKvH7t6mhVu.1OnR6BmpQBNIxZYK",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/commodities/wood/kindling-sticks-yellow.webp",
 	"name": "Oak, Ash, Thorn",
 	"origin": "Item.H7v5Izebo8O45DXB",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/odin_s_wisdom__71bMZvK0yxmAAcUL.json
+++ b/data/packs/spell-effects.db/odin_s_wisdom__71bMZvK0yxmAAcUL.json
@@ -1,27 +1,27 @@
 {
 	"_id": "71bMZvK0yxmAAcUL",
 	"_key": "!items.effects!1zAGVkhuWYmSaxgy.71bMZvK0yxmAAcUL",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/defensive/shield-barrier-blades-teal.webp",
 	"name": "Odin's Wisdom",
 	"origin": "Item.iiLI7kRr7y0PLSXK",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/paralyzed__6sDtwzG4ddaew8SZ.json
+++ b/data/packs/spell-effects.db/paralyzed__6sDtwzG4ddaew8SZ.json
@@ -1,27 +1,27 @@
 {
 	"_id": "6sDtwzG4ddaew8SZ",
 	"_key": "!items.effects!PUFCnXLjvBQSM2YO.6sDtwzG4ddaew8SZ",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/control/debuff-chains-shackles-movement-blue.webp",
 	"name": "Paralyzed",
 	"origin": "Compendium.shadowdark.spell-effects.Item.PUFCnXLjvBQSM2YO",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/paralyzed__QXmMqpV6wqoS6fd5.json
+++ b/data/packs/spell-effects.db/paralyzed__QXmMqpV6wqoS6fd5.json
@@ -1,27 +1,27 @@
 {
 	"_id": "QXmMqpV6wqoS6fd5",
 	"_key": "!items.effects!SN9lU9LUViWo1Plm.QXmMqpV6wqoS6fd5",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/control/debuff-chains-shackles-movement-blue.webp",
 	"name": "Paralyzed",
 	"origin": "Item.SN9lU9LUViWo1Plm",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/pin_doll__xJe5blefAwRNfYJk.json
+++ b/data/packs/spell-effects.db/pin_doll__xJe5blefAwRNfYJk.json
@@ -1,27 +1,27 @@
 {
 	"_id": "xJe5blefAwRNfYJk",
 	"_key": "!items.effects!zjm48oHhbVG4XeoB.xJe5blefAwRNfYJk",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/control/voodoo-doll-pain-damage-pink.webp",
 	"name": "Pin Doll",
 	"origin": "Item.aAdqy5QwVJrT8JWE",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/polymorphed__71bMZvK0yxmAAcUL.json
+++ b/data/packs/spell-effects.db/polymorphed__71bMZvK0yxmAAcUL.json
@@ -1,27 +1,27 @@
 {
 	"_id": "71bMZvK0yxmAAcUL",
 	"_key": "!items.effects!Hc3xUBBlZLxWNKYV.71bMZvK0yxmAAcUL",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 10,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 10
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/creatures/amphibians/frog-confused-green-blue.webp",
 	"name": "Polymorphed",
 	"origin": "Item.iiLI7kRr7y0PLSXK",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/protection_from_cold__tRdfqDgHVkm9KicF.json
+++ b/data/packs/spell-effects.db/protection_from_cold__tRdfqDgHVkm9KicF.json
@@ -1,27 +1,27 @@
 {
 	"_id": "tRdfqDgHVkm9KicF",
 	"_key": "!items.effects!8mFFTIDKLulz3Yp6.tRdfqDgHVkm9KicF",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/defensive/shield-barrier-flaming-pentagon-blue.webp",
 	"name": "Protection from Cold",
 	"origin": "Item.0mJBRk2Uw05LtZde",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/protection_from_electricity__Jg6Jkbl7zFxeQvW5.json
+++ b/data/packs/spell-effects.db/protection_from_electricity__Jg6Jkbl7zFxeQvW5.json
@@ -1,27 +1,27 @@
 {
 	"_id": "Jg6Jkbl7zFxeQvW5",
 	"_key": "!items.effects!HxMd3lV8CPpvL3my.Jg6Jkbl7zFxeQvW5",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/defensive/shield-barrier-flaming-pentagon-blue-yellow.webp",
 	"name": "Protection from Electricity",
 	"origin": "Item.qqgYJ0vX64GVKLMu",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/protection_from_evil__1OnR6BmpQBNIxZYK.json
+++ b/data/packs/spell-effects.db/protection_from_evil__1OnR6BmpQBNIxZYK.json
@@ -1,27 +1,27 @@
 {
 	"_id": "1OnR6BmpQBNIxZYK",
 	"_key": "!items.effects!H7v5Izebo8O45DXB.1OnR6BmpQBNIxZYK",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/defensive/shield-barrier-deflect-teal.webp",
 	"name": "Protection From Evil",
 	"origin": "Item.H7v5Izebo8O45DXB",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/protection_from_fire__Ivoesj08KB4Fg49z.json
+++ b/data/packs/spell-effects.db/protection_from_fire__Ivoesj08KB4Fg49z.json
@@ -1,27 +1,27 @@
 {
 	"_id": "Ivoesj08KB4Fg49z",
 	"_key": "!items.effects!KXfv6edqcRQdnc7m.Ivoesj08KB4Fg49z",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/defensive/shield-barrier-flaming-pentagon-orange.webp",
 	"name": "Protection from Fire",
 	"origin": "Item.rEfRjUeHNEs2Efo6",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/puppeted__ItjPVhv2obp0MEhy.json
+++ b/data/packs/spell-effects.db/puppeted__ItjPVhv2obp0MEhy.json
@@ -1,27 +1,27 @@
 {
 	"_id": "ItjPVhv2obp0MEhy",
 	"_key": "!items.effects!Cu3dona3PiHxO1lK.ItjPVhv2obp0MEhy",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/control/control-influence-puppet.webp",
 	"name": "Puppeted",
 	"origin": "Item.SOkcvkzrGMGQKhmk",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/raging__gbIJz5HZymMEOrpU.json
+++ b/data/packs/spell-effects.db/raging__gbIJz5HZymMEOrpU.json
@@ -1,27 +1,27 @@
 {
 	"_id": "gbIJz5HZymMEOrpU",
 	"_key": "!items.effects!79D3CwKRi78k9BM7.gbIJz5HZymMEOrpU",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/wounds/injury-face-impact-orange.webp",
 	"name": "Raging",
 	"origin": "Item.NzzijebUPYIGcakX",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/reviled__qohPOvbaVcxpRumR.json
+++ b/data/packs/spell-effects.db/reviled__qohPOvbaVcxpRumR.json
@@ -1,27 +1,27 @@
 {
 	"_id": "qohPOvbaVcxpRumR",
 	"_key": "!items.effects!vApjjHkL9nghvbQT.qohPOvbaVcxpRumR",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": 86400,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "seconds",
+		"value": 86400
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/social/wave-halt-stop.webp",
 	"name": "Reviled",
 	"origin": "Item.FrFilluk4S5VaWut",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/shapechanged__vMxGVAApQXuIeBXk.json
+++ b/data/packs/spell-effects.db/shapechanged__vMxGVAApQXuIeBXk.json
@@ -1,27 +1,27 @@
 {
 	"_id": "vMxGVAApQXuIeBXk",
 	"_key": "!items.effects!F89CJeindj8k8oiC.vMxGVAApQXuIeBXk",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 10,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 10
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/nature/wolf-paw-glow-orange.webp",
 	"name": "Shapechanged",
 	"origin": "Item.hVsjl5GZqSajuFU6",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/soulbound__rRaOIGFZ6RzYlvUI.json
+++ b/data/packs/spell-effects.db/soulbound__rRaOIGFZ6RzYlvUI.json
@@ -1,27 +1,27 @@
 {
 	"_id": "rRaOIGFZ6RzYlvUI",
 	"_key": "!items.effects!z7X1jRQHFTnSXpds.rRaOIGFZ6RzYlvUI",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/control/debuff-energy-hold-blue-yellow.webp",
 	"name": "Soulbound",
 	"origin": "Item.XIVFQdlFLE6VjDfs",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/spidersilk__3Pnp7zzDGQb638LU.json
+++ b/data/packs/spell-effects.db/spidersilk__3Pnp7zzDGQb638LU.json
@@ -1,27 +1,27 @@
 {
 	"_id": "3Pnp7zzDGQb638LU",
 	"_key": "!items.effects!4UAVHmqFCt47sh7D.3Pnp7zzDGQb638LU",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/creatures/webs/web-spider-caught-hand-purple.webp",
 	"name": "Spidersilk",
 	"origin": "Item.sLb9GOXx9F6XCb2o",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/stoneskin__441BBv90QacBfojj.json
+++ b/data/packs/spell-effects.db/stoneskin__441BBv90QacBfojj.json
@@ -1,33 +1,33 @@
 {
 	"_id": "441BBv90QacBfojj",
 	"_key": "!items.effects!deNtIVyGoXaDPrmJ.441BBv90QacBfojj",
-	"changes": [
-		{
-			"key": "system.attributes.ac.value",
-			"mode": 5,
-			"priority": null,
-			"value": "17"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 10,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 10
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/defensive/armor-stone-skin.webp",
 	"name": "Stoneskin",
 	"origin": "Item.h9MTxzrrPmyhEmRL",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.attributes.ac.value",
+				"priority": null,
+				"type": "override",
+				"value": 17
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/stoneskin__JiT09XfIkqCuIOiD.json
+++ b/data/packs/spell-effects.db/stoneskin__JiT09XfIkqCuIOiD.json
@@ -1,33 +1,33 @@
 {
 	"_id": "JiT09XfIkqCuIOiD",
 	"_key": "!items.effects!5rK6guXTllcryhLv.JiT09XfIkqCuIOiD",
-	"changes": [
-		{
-			"key": "system.attributes.ac.value",
-			"mode": 5,
-			"priority": null,
-			"value": "20"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 10,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 10
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/defensive/armor-stone-skin.webp",
 	"name": "Stoneskin",
 	"origin": "Compendium.shadowdark.spell-effects.Item.5rK6guXTllcryhLv",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.attributes.ac.value",
+				"priority": null,
+				"type": "override",
+				"value": 20
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/stuck__VHYrzR2yKp3dWr5N.json
+++ b/data/packs/spell-effects.db/stuck__VHYrzR2yKp3dWr5N.json
@@ -1,27 +1,27 @@
 {
 	"_id": "VHYrzR2yKp3dWr5N",
 	"_key": "!items.effects!28PPFz1MYTsfPwzh.VHYrzR2yKp3dWr5N",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 5,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 5
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/commodities/materials/material-webbing.webp",
 	"name": "Stuck",
 	"origin": "Compendium.shadowdark.spell-effects.Item.28PPFz1MYTsfPwzh",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/stuck__pTKFUJ3czAqssXCu.json
+++ b/data/packs/spell-effects.db/stuck__pTKFUJ3czAqssXCu.json
@@ -1,27 +1,27 @@
 {
 	"_id": "pTKFUJ3czAqssXCu",
 	"_key": "!items.effects!VOx6yLlQ23XwVvuG.pTKFUJ3czAqssXCu",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 5,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 5
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/commodities/materials/material-webbing.webp",
 	"name": "Stuck",
 	"origin": "Item.28PPFz1MYTsfPwzh",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/summon_storm__uhBasLNp1gdVJtjj.json
+++ b/data/packs/spell-effects.db/summon_storm__uhBasLNp1gdVJtjj.json
@@ -1,27 +1,27 @@
 {
 	"_id": "uhBasLNp1gdVJtjj",
 	"_key": "!items.effects!wr0hnCfjAaNiTGkU.uhBasLNp1gdVJtjj",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/lightning/bolt-strike-cloud-gray.webp",
 	"name": "Summon Storm",
 	"origin": "Compendium.shadowdark.spell-effects.Item.wr0hnCfjAaNiTGkU",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/treeshape__BE3TXDe8GjBaucS0.json
+++ b/data/packs/spell-effects.db/treeshape__BE3TXDe8GjBaucS0.json
@@ -1,27 +1,27 @@
 {
 	"_id": "BE3TXDe8GjBaucS0",
 	"_key": "!items.effects!rgfyqmZvgYX1PWqw.BE3TXDe8GjBaucS0",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/nature/tree-animated-smile.webp",
 	"name": "Treeshape",
 	"origin": "Compendium.shadowdark.spell-effects.Item.rgfyqmZvgYX1PWqw",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/truthful__tx8UjK6umZHVyLJ6.json
+++ b/data/packs/spell-effects.db/truthful__tx8UjK6umZHVyLJ6.json
@@ -1,27 +1,27 @@
 {
 	"_id": "tx8UjK6umZHVyLJ6",
 	"_key": "!items.effects!cL5aPfXcad9FtHoK.tx8UjK6umZHVyLJ6",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/social/trading-justice-scale-gold.webp",
 	"name": "Truthful",
 	"origin": "Item.cL5aPfXcad9FtHoK",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/turned__Z8y5ZzvVyfE2irPi.json
+++ b/data/packs/spell-effects.db/turned__Z8y5ZzvVyfE2irPi.json
@@ -1,27 +1,27 @@
 {
 	"_id": "Z8y5ZzvVyfE2irPi",
 	"_key": "!items.effects!T4LUCIffieQPMGsN.Z8y5ZzvVyfE2irPi",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 5,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 5
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/death/skeleton-skull-soul-blue.webp",
 	"name": "Turned",
 	"origin": "Compendium.shadowdark.spell-effects.Item.T4LUCIffieQPMGsN",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/turned__pTKFUJ3czAqssXCu.json
+++ b/data/packs/spell-effects.db/turned__pTKFUJ3czAqssXCu.json
@@ -1,27 +1,27 @@
 {
 	"_id": "pTKFUJ3czAqssXCu",
 	"_key": "!items.effects!aQfBagCGogkjgCS8.pTKFUJ3czAqssXCu",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 5,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 5
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/death/skeleton-skull-soul-blue.webp",
 	"name": "Turned",
 	"origin": "Item.28PPFz1MYTsfPwzh",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/turned_to_salt__rRaOIGFZ6RzYlvUI.json
+++ b/data/packs/spell-effects.db/turned_to_salt__rRaOIGFZ6RzYlvUI.json
@@ -1,27 +1,27 @@
 {
 	"_id": "rRaOIGFZ6RzYlvUI",
 	"_key": "!items.effects!6yYj2FkmYppGAl9N.rRaOIGFZ6RzYlvUI",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/earth/strike-fist-stone-light.webp",
 	"name": "Turned to Salt",
 	"origin": "Item.XIVFQdlFLE6VjDfs",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/winter_wolf__vMxGVAApQXuIeBXk.json
+++ b/data/packs/spell-effects.db/winter_wolf__vMxGVAApQXuIeBXk.json
@@ -1,57 +1,57 @@
 {
 	"_id": "vMxGVAApQXuIeBXk",
 	"_key": "!items.effects!cC4hF54uctVhvvCo.vMxGVAApQXuIeBXk",
-	"changes": [
-		{
-			"key": "system.abilities.str.value",
-			"mode": 5,
-			"priority": null,
-			"value": "16"
-		},
-		{
-			"key": "system.abilities.dex.value",
-			"mode": 5,
-			"priority": null,
-			"value": "14"
-		},
-		{
-			"key": "system.abilities.con.value",
-			"mode": 5,
-			"priority": null,
-			"value": "12"
-		},
-		{
-			"key": "system.attributes.hp.max",
-			"mode": 5,
-			"priority": null,
-			"value": "23"
-		},
-		{
-			"key": "system.attributes.ac.all",
-			"mode": 5,
-			"priority": null,
-			"value": "12"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/creatures/mammals/wolf-howl-moon-forest-blue.webp",
 	"name": "Winter Wolf",
 	"origin": "Item.hVsjl5GZqSajuFU6",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.str.value",
+				"priority": null,
+				"type": "override",
+				"value": 16
+			},
+			{
+				"key": "system.abilities.dex.value",
+				"priority": null,
+				"type": "override",
+				"value": 14
+			},
+			{
+				"key": "system.abilities.con.value",
+				"priority": null,
+				"type": "override",
+				"value": 12
+			},
+			{
+				"key": "system.attributes.hp.max",
+				"priority": null,
+				"type": "override",
+				"value": 23
+			},
+			{
+				"key": "system.attributes.ac.all",
+				"priority": null,
+				"type": "override",
+				"value": 12
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/wolf__vMxGVAApQXuIeBXk.json
+++ b/data/packs/spell-effects.db/wolf__vMxGVAApQXuIeBXk.json
@@ -1,57 +1,57 @@
 {
 	"_id": "vMxGVAApQXuIeBXk",
 	"_key": "!items.effects!B9ChlhtUjECrLlre.vMxGVAApQXuIeBXk",
-	"changes": [
-		{
-			"key": "system.abilities.str.value",
-			"mode": 5,
-			"priority": null,
-			"value": "14"
-		},
-		{
-			"key": "system.abilities.dex.value",
-			"mode": 5,
-			"priority": null,
-			"value": "14"
-		},
-		{
-			"key": "system.abilities.con.value",
-			"mode": 5,
-			"priority": null,
-			"value": "12"
-		},
-		{
-			"key": "system.attributes.hp.max",
-			"mode": 5,
-			"priority": null,
-			"value": "10"
-		},
-		{
-			"key": "system.attributes.ac.all",
-			"mode": 5,
-			"priority": null,
-			"value": "12"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/creatures/mammals/wolf-howl-moon-forest-blue.webp",
 	"name": "Wolf",
 	"origin": "Item.hVsjl5GZqSajuFU6",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.str.value",
+				"priority": null,
+				"type": "override",
+				"value": 14
+			},
+			{
+				"key": "system.abilities.dex.value",
+				"priority": null,
+				"type": "override",
+				"value": 14
+			},
+			{
+				"key": "system.abilities.con.value",
+				"priority": null,
+				"type": "override",
+				"value": 12
+			},
+			{
+				"key": "system.attributes.hp.max",
+				"priority": null,
+				"type": "override",
+				"value": 10
+			},
+			{
+				"key": "system.attributes.ac.all",
+				"priority": null,
+				"type": "override",
+				"value": 12
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/world_tree__IVfimqsISUjg71IF.json
+++ b/data/packs/spell-effects.db/world_tree__IVfimqsISUjg71IF.json
@@ -1,27 +1,27 @@
 {
 	"_id": "IVfimqsISUjg71IF",
 	"_key": "!items.effects!FDyJAnR0Fk9cZZEf.IVfimqsISUjg71IF",
-	"changes": [
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 1,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 1
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/nature/tree-spirit-glow-black-yellow.webp",
 	"name": "World Tree",
 	"origin": "Item.3t26sCGhwGJjEasN",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/spell-effects.db/wrath__RftwcR3tZiYQwCZy.json
+++ b/data/packs/spell-effects.db/wrath__RftwcR3tZiYQwCZy.json
@@ -1,39 +1,39 @@
 {
 	"_id": "RftwcR3tZiYQwCZy",
 	"_key": "!items.effects!pKu2XsypNq65vkbV.RftwcR3tZiYQwCZy",
-	"changes": [
-		{
-			"key": "system.roll.melee.bonus.all",
-			"mode": 2,
-			"priority": null,
-			"value": "2"
-		},
-		{
-			"key": "system.roll.ranged.bonus.all",
-			"mode": 2,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": 10,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": "turnStart",
+		"units": "rounds",
+		"value": 10
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/hammers/hammer-double-glowing-yellow.webp",
 	"name": "Wrath",
 	"origin": "Item.xOHpjBx4PhrNXQ4U",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.melee.bonus.all",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			},
+			{
+				"key": "system.roll.ranged.bonus.all",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/_1_ac_dual_wield__cGGttIknipaR4UIo.json
+++ b/data/packs/talents.db/_1_ac_dual_wield__cGGttIknipaR4UIo.json
@@ -1,36 +1,36 @@
 {
 	"_id": "cGGttIknipaR4UIo",
 	"_key": "!items.effects!quYUUqTTAX3QlAGa.cGGttIknipaR4UIo",
-	"changes": [
-		{
-			"key": "system.attributes.ac.value",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 		"shadowdark": {
 			"situational": true
 		}
 	},
+	"folder": null,
 	"img": "icons/skills/melee/swords-parry-block-blue.webp",
 	"name": "+1 AC Dual Wield",
 	"origin": "Compendium.shadowdark.talents.Item.quYUUqTTAX3QlAGa",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.attributes.ac.value",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/ability_score_improvement__cha___hkfq4SGF4mkDjQmt.json
+++ b/data/packs/talents.db/ability_score_improvement__cha___hkfq4SGF4mkDjQmt.json
@@ -1,33 +1,33 @@
 {
 	"_id": "hkfq4SGF4mkDjQmt",
 	"_key": "!items.effects!UE2xABVKD0oCDtdx.hkfq4SGF4mkDjQmt",
-	"changes": [
-		{
-			"key": "system.abilities.cha.value",
-			"mode": 2,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/hand-grip-staff-yellow-brown.webp",
 	"name": "Ability Score Improvement (Cha)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.cha.value",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/ability_score_improvement__cha___pBT8eBhcaKSnzbcq.json
+++ b/data/packs/talents.db/ability_score_improvement__cha___pBT8eBhcaKSnzbcq.json
@@ -1,33 +1,33 @@
 {
 	"_id": "pBT8eBhcaKSnzbcq",
 	"_key": "!items.effects!5INkcbMVFxK6cW5Z.pBT8eBhcaKSnzbcq",
-	"changes": [
-		{
-			"key": "system.abilities.cha.value",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/hand-grip-staff-yellow-brown.webp",
 	"name": "Ability Score Improvement (Cha)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.cha.value",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/ability_score_improvement__con___CUwCZOHDW1XRT1ce.json
+++ b/data/packs/talents.db/ability_score_improvement__con___CUwCZOHDW1XRT1ce.json
@@ -1,33 +1,33 @@
 {
 	"_id": "CUwCZOHDW1XRT1ce",
 	"_key": "!items.effects!8SXPsiWvG2UcXGgW.CUwCZOHDW1XRT1ce",
-	"changes": [
-		{
-			"key": "system.abilities.con.value",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/hand-grip-staff-yellow-brown.webp",
 	"name": "Ability Score Improvement (Con)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.con.value",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/ability_score_improvement__con___R6opds1dM2LQdca1.json
+++ b/data/packs/talents.db/ability_score_improvement__con___R6opds1dM2LQdca1.json
@@ -1,33 +1,33 @@
 {
 	"_id": "R6opds1dM2LQdca1",
 	"_key": "!items.effects!ZfaFn8TDum3NXYZN.R6opds1dM2LQdca1",
-	"changes": [
-		{
-			"key": "system.abilities.con.value",
-			"mode": 2,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/hand-grip-staff-yellow-brown.webp",
 	"name": "Ability Score Improvement (Con)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.con.value",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/ability_score_improvement__dex___sx2uVw9MzQNA7mnd.json
+++ b/data/packs/talents.db/ability_score_improvement__dex___sx2uVw9MzQNA7mnd.json
@@ -1,33 +1,33 @@
 {
 	"_id": "sx2uVw9MzQNA7mnd",
 	"_key": "!items.effects!vIbwotCa1eqCVZMU.sx2uVw9MzQNA7mnd",
-	"changes": [
-		{
-			"key": "system.abilities.dex.value",
-			"mode": 2,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/hand-grip-staff-yellow-brown.webp",
 	"name": "Ability Score Improvement (Dex)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.dex.value",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/ability_score_improvement__int___7ADLFBANMORl70Nm.json
+++ b/data/packs/talents.db/ability_score_improvement__int___7ADLFBANMORl70Nm.json
@@ -1,33 +1,33 @@
 {
 	"_id": "7ADLFBANMORl70Nm",
 	"_key": "!items.effects!LDJCx5syOcenLMZf.7ADLFBANMORl70Nm",
-	"changes": [
-		{
-			"key": "system.abilities.int.value",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/hand-grip-staff-yellow-brown.webp",
 	"name": "Ability Score Improvement (Int)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.int.value",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/ability_score_improvement__int___lSaJHBE00pEuwfOx.json
+++ b/data/packs/talents.db/ability_score_improvement__int___lSaJHBE00pEuwfOx.json
@@ -1,33 +1,33 @@
 {
 	"_id": "lSaJHBE00pEuwfOx",
 	"_key": "!items.effects!aRY0hjpvzYpdRbfR.lSaJHBE00pEuwfOx",
-	"changes": [
-		{
-			"key": "system.abilities.int.value",
-			"mode": 2,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/hand-grip-staff-yellow-brown.webp",
 	"name": "Ability Score Improvement (Int)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.int.value",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/ability_score_improvement__str___jzxgJvPfazpI6udq.json
+++ b/data/packs/talents.db/ability_score_improvement__str___jzxgJvPfazpI6udq.json
@@ -1,33 +1,33 @@
 {
 	"_id": "jzxgJvPfazpI6udq",
 	"_key": "!items.effects!IDGFaxKnYJWWuWQ7.jzxgJvPfazpI6udq",
-	"changes": [
-		{
-			"key": "system.abilities.str.value",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/hand-grip-staff-yellow-brown.webp",
 	"name": "Ability Score Improvement (Str)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.str.value",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/ability_score_improvement__str___peAz8xVvIeZ6SLHd.json
+++ b/data/packs/talents.db/ability_score_improvement__str___peAz8xVvIeZ6SLHd.json
@@ -1,33 +1,33 @@
 {
 	"_id": "peAz8xVvIeZ6SLHd",
 	"_key": "!items.effects!6t06nSjj1hd6o5SV.peAz8xVvIeZ6SLHd",
-	"changes": [
-		{
-			"key": "system.abilities.str.value",
-			"mode": 2,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/hand-grip-staff-yellow-brown.webp",
 	"name": "Ability Score Improvement (Str)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.str.value",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/ability_score_improvement__wis___isMVMARzqqQVLmZ4.json
+++ b/data/packs/talents.db/ability_score_improvement__wis___isMVMARzqqQVLmZ4.json
@@ -1,33 +1,33 @@
 {
 	"_id": "isMVMARzqqQVLmZ4",
 	"_key": "!items.effects!vRW8GSIKWXyOAKbw.isMVMARzqqQVLmZ4",
-	"changes": [
-		{
-			"key": "system.abilities.wis.value",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/hand-grip-staff-yellow-brown.webp",
 	"name": "Ability Score Improvement (Wis)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.wis.value",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/ability_score_improvement__wis___rG2EB3u5Q4eUDash.json
+++ b/data/packs/talents.db/ability_score_improvement__wis___rG2EB3u5Q4eUDash.json
@@ -1,33 +1,33 @@
 {
 	"_id": "rG2EB3u5Q4eUDash",
 	"_key": "!items.effects!excvhYcpm1qd09IV.rG2EB3u5Q4eUDash",
-	"changes": [
-		{
-			"key": "system.abilities.wis.value",
-			"mode": 2,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/hand-grip-staff-yellow-brown.webp",
 	"name": "Ability Score Improvement (Wis)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.wis.value",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/abilityimprovement__GJXEM96MY9ydNQ47.json
+++ b/data/packs/talents.db/abilityimprovement__GJXEM96MY9ydNQ47.json
@@ -1,33 +1,33 @@
 {
 	"_id": "GJXEM96MY9ydNQ47",
 	"_key": "!items.effects!eJHwfYQZ9LmLQeSn.GJXEM96MY9ydNQ47",
-	"changes": [
-		{
-			"key": "system.abilities.dex.value",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/hand-grip-staff-yellow-brown.webp",
 	"name": "abilityImprovement",
 	"origin": "Item.6iZplEBazA2f66A3",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.abilities.dex.value",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/additional_backstab_die__AmcPerJgnykmMwVA.json
+++ b/data/packs/talents.db/additional_backstab_die__AmcPerJgnykmMwVA.json
@@ -1,33 +1,33 @@
 {
 	"_id": "AmcPerJgnykmMwVA",
 	"_key": "!items.effects!HzzgAIdhoAyfeItJ.AmcPerJgnykmMwVA",
-	"changes": [
-		{
-			"key": "system.bonus.backstabdice",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "<p>Your Backstab deals +1 dice of damage.</p>",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-dagger-white-orange.webp",
 	"name": "Additional Backstab Die",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.bonus.backstabdice",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/advantage_against_opposing_force__kLhJi9CIdP5waTkT.json
+++ b/data/packs/talents.db/advantage_against_opposing_force__kLhJi9CIdP5waTkT.json
@@ -1,36 +1,36 @@
 {
 	"_id": "kLhJi9CIdP5waTkT",
 	"_key": "!items.effects!F0NXUJcnBOYKzhMi.kLhJi9CIdP5waTkT",
-	"changes": [
-		{
-			"key": "system.roll.stat.advantage.str",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "<p>You have advantage on Strength checks to overcome an opposing force, such as kicking open a stuck door, etc.</p>",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 		"shadowdark": {
 			"situational": true
 		}
 	},
+	"folder": null,
 	"img": "icons/environment/people/infantry.webp",
 	"name": "Advantage Against Opposing Force",
 	"origin": "Compendium.shadowdark.talents.Item.F0NXUJcnBOYKzhMi",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.stat.advantage.str",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/advantage_against_opposing_force__uiRL8aHCDWjd3e8w.json
+++ b/data/packs/talents.db/advantage_against_opposing_force__uiRL8aHCDWjd3e8w.json
@@ -1,36 +1,36 @@
 {
 	"_id": "uiRL8aHCDWjd3e8w",
 	"_key": "!items.effects!DGZqkVUtcmxejdm1.uiRL8aHCDWjd3e8w",
-	"changes": [
-		{
-			"key": "system.roll.stat.advantage.dex",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "<p>You have advantage on Dexterity checks to overcome an opposing force, such as slipping free of rusty chains, etc.</p>",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 		"shadowdark": {
 			"situational": true
 		}
 	},
+	"folder": null,
 	"img": "icons/environment/people/infantry.webp",
 	"name": "Advantage Against Opposing Force",
 	"origin": "Compendium.shadowdark.talents.Item.DGZqkVUtcmxejdm1",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.stat.advantage.dex",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/allow_magic_items__7Rv0ynJ2wKOIJGnw.json
+++ b/data/packs/talents.db/allow_magic_items__7Rv0ynJ2wKOIJGnw.json
@@ -1,39 +1,39 @@
 {
 	"_id": "7Rv0ynJ2wKOIJGnw",
 	"_key": "!items.effects!Om7QWre7U4Tbh84B.7Rv0ynJ2wKOIJGnw",
-	"changes": [
-		{
-			"key": "system.spellcasting.allowAllItems",
-			"mode": 2,
-			"priority": null,
-			"value": "true"
-		},
-		{
-			"key": "system.spellcasting.itemAbility",
-			"mode": 2,
-			"priority": null,
-			"value": "cha"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/symbols/runes-triangle-magenta.webp",
 	"name": "Allow Magic Items",
 	"origin": "Compendium.shadowdark.talents.Item.Om7QWre7U4Tbh84B",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.spellcasting.allowAllItems",
+				"priority": null,
+				"type": "add",
+				"value": true
+			},
+			{
+				"key": "system.spellcasting.itemAbility",
+				"priority": null,
+				"type": "add",
+				"value": "cha"
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/allow_magic_items__Fzx8i0bzbmuK8IoZ.json
+++ b/data/packs/talents.db/allow_magic_items__Fzx8i0bzbmuK8IoZ.json
@@ -1,33 +1,33 @@
 {
 	"_id": "Fzx8i0bzbmuK8IoZ",
 	"_key": "!items.effects!uMEh2Cwn7uKjEVSK.Fzx8i0bzbmuK8IoZ",
-	"changes": [
-		{
-			"key": "system.spellcasting.allowAllItems",
-			"mode": 2,
-			"priority": null,
-			"value": "true"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/sundries/scrolls/scroll-bound-green.webp",
 	"name": "Allow Magic Items",
 	"origin": "Compendium.shadowdark.talents.Item.uMEh2Cwn7uKjEVSK",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.spellcasting.allowAllItems",
+				"priority": null,
+				"type": "add",
+				"value": true
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/armor_mastery__0g9MUhj9Tr3AWRXl.json
+++ b/data/packs/talents.db/armor_mastery__0g9MUhj9Tr3AWRXl.json
@@ -1,33 +1,33 @@
 {
 	"_id": "0g9MUhj9Tr3AWRXl",
 	"_key": "!items.effects!BsRPGhKXYwJBI9ex.0g9MUhj9Tr3AWRXl",
-	"changes": [
-		{
-			"key": "system.attributes.ac.REPLACEME",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/defensive/shield-barrier-deflect-teal.webp",
 	"name": "Armor Mastery",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.attributes.ac.REPLACEME",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/backstab__fsh7dPOotCEuj2ic.json
+++ b/data/packs/talents.db/backstab__fsh7dPOotCEuj2ic.json
@@ -1,36 +1,36 @@
 {
 	"_id": "fsh7dPOotCEuj2ic",
 	"_key": "!items.effects!KLDZKFY6SrqQKSva.fsh7dPOotCEuj2ic",
-	"changes": [
-		{
-			"key": "system.roll.attack.extra-damage-die.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1+@bonus.backstabdice+floor(@level.value/2)"
-		}
-	],
 	"description": "<p>If you hit a creature who is unaware of your attack, you deal an extra weapon die of damage. Add additional weapon dice of damage equal to half your level (round down).</p>",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 		"shadowdark": {
 			"situational": true
 		}
 	},
+	"folder": null,
 	"img": "icons/skills/melee/sword-stuck-glowing-pink.webp",
 	"name": "Backstab",
 	"origin": "Compendium.shadowdark.talents.Item.KLDZKFY6SrqQKSva",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.extra-damage-die.all",
+				"priority": null,
+				"type": "add",
+				"value": "1+@bonus.backstabdice+floor(@level.value/2)"
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/destine_die_upgrade__0auHRW7slkgAluWk.json
+++ b/data/packs/talents.db/destine_die_upgrade__0auHRW7slkgAluWk.json
@@ -1,33 +1,33 @@
 {
 	"_id": "0auHRW7slkgAluWk",
 	"_key": "!items.effects!kX94lNYCOdjAuSYx.0auHRW7slkgAluWk",
-	"changes": [
-		{
-			"key": "system.bonus.destineddie",
-			"mode": 2,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/sundries/gaming/dice-runed-brown.webp",
 	"name": "Destine Die Upgrade",
 	"origin": "Compendium.shadowdark.talents.Item.kX94lNYCOdjAuSYx",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.bonus.destineddie",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/destined__FEdSh6J89u9qZv2w.json
+++ b/data/packs/talents.db/destined__FEdSh6J89u9qZv2w.json
@@ -1,48 +1,48 @@
 {
 	"_id": "FEdSh6J89u9qZv2w",
 	"_key": "!items.effects!Az2fXCwgo5C3x2X7.FEdSh6J89u9qZv2w",
-	"changes": [
-		{
-			"key": "system.roll.stat.bonus.all",
-			"mode": 2,
-			"priority": null,
-			"value": "d@bonus.destineddie"
-		},
-		{
-			"key": "system.roll.attack.bonus.all",
-			"mode": 2,
-			"priority": null,
-			"value": "d@bonus.destineddie"
-		},
-		{
-			"key": "system.roll.spell.bonus.all",
-			"mode": 2,
-			"priority": null,
-			"value": "d@bonus.destineddie"
-		}
-	],
 	"description": "<p>Whenever you use a luck token, add 1d6 to the roll.</p>",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 		"shadowdark": {
 			"situational": true
 		}
 	},
+	"folder": null,
 	"img": "icons/sundries/gaming/dice-runed-brown.webp",
 	"name": "Destined",
 	"origin": "Compendium.shadowdark.talents.Item.Az2fXCwgo5C3x2X7",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.stat.bonus.all",
+				"priority": null,
+				"type": "add",
+				"value": "d@bonus.destineddie"
+			},
+			{
+				"key": "system.roll.attack.bonus.all",
+				"priority": null,
+				"type": "add",
+				"value": "d@bonus.destineddie"
+			},
+			{
+				"key": "system.roll.spell.bonus.all",
+				"priority": null,
+				"type": "add",
+				"value": "d@bonus.destineddie"
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/destined__dmg___87uOTjxp5i1LkLYh.json
+++ b/data/packs/talents.db/destined__dmg___87uOTjxp5i1LkLYh.json
@@ -1,42 +1,42 @@
 {
 	"_id": "87uOTjxp5i1LkLYh",
 	"_key": "!items.effects!Az2fXCwgo5C3x2X7.87uOTjxp5i1LkLYh",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.all",
-			"mode": 2,
-			"priority": null,
-			"value": "d@bonus.destineddie"
-		},
-		{
-			"key": "system.roll.spell.damage.all",
-			"mode": 2,
-			"priority": null,
-			"value": "d@bonus.destineddie"
-		}
-	],
 	"description": "<p>Whenever you use a luck token, add 1d6 to the roll. Damage.</p>",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 		"shadowdark": {
 			"situational": true
 		}
 	},
+	"folder": null,
 	"img": "icons/sundries/gaming/dice-runed-brown.webp",
 	"name": "Destined (Dmg)",
 	"origin": "Compendium.shadowdark.talents.Item.Az2fXCwgo5C3x2X7",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.all",
+				"priority": null,
+				"type": "add",
+				"value": "d@bonus.destineddie"
+			},
+			{
+				"key": "system.roll.spell.damage.all",
+				"priority": null,
+				"type": "add",
+				"value": "d@bonus.destineddie"
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/destined_die__Q0oigGQzoSdYMv5s.json
+++ b/data/packs/talents.db/destined_die__Q0oigGQzoSdYMv5s.json
@@ -1,33 +1,33 @@
 {
 	"_id": "Q0oigGQzoSdYMv5s",
 	"_key": "!items.effects!Az2fXCwgo5C3x2X7.Q0oigGQzoSdYMv5s",
-	"changes": [
-		{
-			"key": "system.bonus.destineddie",
-			"mode": 2,
-			"priority": null,
-			"value": "6"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/sundries/gaming/dice-runed-brown.webp",
 	"name": "Destined Die",
 	"origin": "Compendium.shadowdark.talents.Item.Az2fXCwgo5C3x2X7",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.bonus.destineddie",
+				"priority": null,
+				"type": "add",
+				"value": 6
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/extra_hp_max__qIFVq4PAB70lPkf9.json
+++ b/data/packs/talents.db/extra_hp_max__qIFVq4PAB70lPkf9.json
@@ -1,33 +1,33 @@
 {
 	"_id": "qIFVq4PAB70lPkf9",
 	"_key": "!items.effects!MW43tnJr6lqE1Ty8.qIFVq4PAB70lPkf9",
-	"changes": [
-		{
-			"key": "system.attributes.hp.max",
-			"mode": 2,
-			"priority": null,
-			"value": "2"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/life/heart-shadow-red.webp",
 	"name": "Extra HP Max",
 	"origin": "Item.SXuw8zzD6a8dwmJE",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.attributes.hp.max",
+				"priority": null,
+				"type": "add",
+				"value": 2
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/hauler__rqplFhIShnvmV0U4.json
+++ b/data/packs/talents.db/hauler__rqplFhIShnvmV0U4.json
@@ -1,33 +1,33 @@
 {
 	"_id": "rqplFhIShnvmV0U4",
 	"_key": "!items.effects!7JTDRLtHc6FOrIEc.rqplFhIShnvmV0U4",
-	"changes": [
-		{
-			"key": "system.slots",
-			"mode": 2,
-			"priority": null,
-			"value": "max(@abilities.con.mod, 0)"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/containers/bags/sack-leather-tan.webp",
 	"name": "Hauler",
 	"origin": "Compendium.shadowdark.talents.7JTDRLtHc6FOrIEc",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.slots",
+				"priority": null,
+				"type": "add",
+				"value": "max(@abilities.con.mod, 0)"
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/hp_roll_advantage__0rcSjPSjHdvGwtOu.json
+++ b/data/packs/talents.db/hp_roll_advantage__0rcSjPSjHdvGwtOu.json
@@ -1,33 +1,33 @@
 {
 	"_id": "0rcSjPSjHdvGwtOu",
 	"_key": "!items.effects!MW43tnJr6lqE1Ty8.0rcSjPSjHdvGwtOu",
-	"changes": [
-		{
-			"key": "system.roll.hp.advantage",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/life/cross-area-circle-green-white.webp",
 	"name": "HP Roll Advantage",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.hp.advantage",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/increased_weapon_damage_die__UGQKMdNcgb1O8qwy.json
+++ b/data/packs/talents.db/increased_weapon_damage_die__UGQKMdNcgb1O8qwy.json
@@ -1,33 +1,33 @@
 {
 	"_id": "UGQKMdNcgb1O8qwy",
 	"_key": "!items.effects!98HEgBRJSED5epGt.UGQKMdNcgb1O8qwy",
-	"changes": [
-		{
-			"key": "system.roll.attack.upgrade-damage-die.REPLACEME",
-			"mode": 2,
-			"priority": null,
-			"value": "5"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/ranged/arrows-flying-salvo-blue-light.webp",
 	"name": "Increased Weapon Damage Die",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.upgrade-damage-die.REPLACEME",
+				"priority": null,
+				"type": "add",
+				"value": 5
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/initiative_advantage__71GTV8nPjnyTdFjT.json
+++ b/data/packs/talents.db/initiative_advantage__71GTV8nPjnyTdFjT.json
@@ -1,33 +1,33 @@
 {
 	"_id": "71GTV8nPjnyTdFjT",
 	"_key": "!items.effects!UVsf7VJCOrBm42Yz.71GTV8nPjnyTdFjT",
-	"changes": [
-		{
-			"key": "system.roll.initiative.advantage",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/movement/feet-winged-boots-glowing-yellow.webp",
 	"name": "Initiative Advantage",
 	"origin": "Compendium.shadowdark.talents.Item.UVsf7VJCOrBm42Yz",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.initiative.advantage",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/knack__spellcasting___OU9XGvWpbh2ADVNy.json
+++ b/data/packs/talents.db/knack__spellcasting___OU9XGvWpbh2ADVNy.json
@@ -1,33 +1,33 @@
 {
 	"_id": "OU9XGvWpbh2ADVNy",
 	"_key": "!items.effects!GVAi0l6mfRillxwZ.OU9XGvWpbh2ADVNy",
-	"changes": [
-		{
-			"key": "system.roll.spell.bonus.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/control/sihouette-hold-beam-green.webp",
 	"name": "Knack (Spellcasting)",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.spell.bonus.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/magical_dabbler_bonus__QBX0EGnKmDfPJ8gQ.json
+++ b/data/packs/talents.db/magical_dabbler_bonus__QBX0EGnKmDfPJ8gQ.json
@@ -1,33 +1,33 @@
 {
 	"_id": "QBX0EGnKmDfPJ8gQ",
 	"_key": "!items.effects!x4xTNUsimUpO3JBt.QBX0EGnKmDfPJ8gQ",
-	"changes": [
-		{
-			"key": "system.roll.spell.bonus.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/symbols/runes-triangle-magenta.webp",
 	"name": "Magical Dabbler Bonus",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.spell.bonus.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/melee_attack_roll_bonus__ZTDD2HwlrjLbEIQp.json
+++ b/data/packs/talents.db/melee_attack_roll_bonus__ZTDD2HwlrjLbEIQp.json
@@ -1,33 +1,33 @@
 {
 	"_id": "ZTDD2HwlrjLbEIQp",
 	"_key": "!items.effects!WSm6JESNoyFBnkW2.ZTDD2HwlrjLbEIQp",
-	"changes": [
-		{
-			"key": "system.roll.melee.bonus.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Melee Attack Roll Bonus",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.melee.bonus.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/melee_attack_roll_bonus__c7CGt0FBJHv5BtpM.json
+++ b/data/packs/talents.db/melee_attack_roll_bonus__c7CGt0FBJHv5BtpM.json
@@ -1,33 +1,33 @@
 {
 	"_id": "c7CGt0FBJHv5BtpM",
 	"_key": "!items.effects!0yk16c9qcJ9vCekD.c7CGt0FBJHv5BtpM",
-	"changes": [
-		{
-			"key": "system.roll.melee.bonus.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Melee Attack Roll Bonus",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.melee.bonus.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/melee_attack_roll_bonus__y00ihJhSPjoGVmKZ.json
+++ b/data/packs/talents.db/melee_attack_roll_bonus__y00ihJhSPjoGVmKZ.json
@@ -1,33 +1,33 @@
 {
 	"_id": "y00ihJhSPjoGVmKZ",
 	"_key": "!items.effects!93QoQQ6cI7xa4TCm.y00ihJhSPjoGVmKZ",
-	"changes": [
-		{
-			"key": "system.roll.melee.bonus.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Melee Attack Roll Bonus",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.melee.bonus.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/melee_damage_bonus__JOP97BP4aJ0kjcgL.json
+++ b/data/packs/talents.db/melee_damage_bonus__JOP97BP4aJ0kjcgL.json
@@ -1,33 +1,33 @@
 {
 	"_id": "JOP97BP4aJ0kjcgL",
 	"_key": "!items.effects!0yk16c9qcJ9vCekD.JOP97BP4aJ0kjcgL",
-	"changes": [
-		{
-			"key": "system.roll.melee.damage.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-axe-blood-red.webp",
 	"name": "Melee Damage Bonus",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.melee.damage.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/melee_damage_bonus__cefeWMKoAqHxuuU1.json
+++ b/data/packs/talents.db/melee_damage_bonus__cefeWMKoAqHxuuU1.json
@@ -1,33 +1,33 @@
 {
 	"_id": "cefeWMKoAqHxuuU1",
 	"_key": "!items.effects!38PGv4JtkfDumLDu.cefeWMKoAqHxuuU1",
-	"changes": [
-		{
-			"key": "system.roll.melee.damage.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-axe-blood-red.webp",
 	"name": "Melee Damage Bonus",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.melee.damage.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/melee_damage_bonus__wryUreqZgIx22crJ.json
+++ b/data/packs/talents.db/melee_damage_bonus__wryUreqZgIx22crJ.json
@@ -1,33 +1,33 @@
 {
 	"_id": "wryUreqZgIx22crJ",
 	"_key": "!items.effects!S4zOvXqPlLLNmGKl.wryUreqZgIx22crJ",
-	"changes": [
-		{
-			"key": "system.roll.melee.damage.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-axe-blood-red.webp",
 	"name": "Melee Damage Bonus",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.melee.damage.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/mighty__A9g8ZeATepsz2xvP.json
+++ b/data/packs/talents.db/mighty__A9g8ZeATepsz2xvP.json
@@ -1,39 +1,39 @@
 {
 	"_id": "A9g8ZeATepsz2xvP",
 	"_key": "!items.effects!LR6h4lXVXwx7AFQ6.A9g8ZeATepsz2xvP",
-	"changes": [
-		{
-			"key": "system.roll.melee.bonus.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		},
-		{
-			"key": "system.roll.melee.damage.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "<p>You have a +1 bonus to attack and damage rolls with melee weapons.</p>",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-axe-blood-red.webp",
 	"name": "Mighty",
 	"origin": "Compendium.shadowdark.talents.Item.LR6h4lXVXwx7AFQ6",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.melee.bonus.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			},
+			{
+				"key": "system.roll.melee.damage.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/ranged_attack_roll_bonus__ODBe0yE8vkVOD2qZ.json
+++ b/data/packs/talents.db/ranged_attack_roll_bonus__ODBe0yE8vkVOD2qZ.json
@@ -1,33 +1,33 @@
 {
 	"_id": "ODBe0yE8vkVOD2qZ",
 	"_key": "!items.effects!Y3Ytsye5zrP43w70.ODBe0yE8vkVOD2qZ",
-	"changes": [
-		{
-			"key": "system.roll.ranged.bonus.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Ranged Attack Roll Bonus",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.ranged.bonus.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/ranged_attack_roll_bonus__OQQ5fxWh3zBw8W5O.json
+++ b/data/packs/talents.db/ranged_attack_roll_bonus__OQQ5fxWh3zBw8W5O.json
@@ -1,33 +1,33 @@
 {
 	"_id": "OQQ5fxWh3zBw8W5O",
 	"_key": "!items.effects!2IfYKGhWxyd3Ldr5.OQQ5fxWh3zBw8W5O",
-	"changes": [
-		{
-			"key": "system.roll.ranged.bonus.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Ranged Attack Roll Bonus",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.ranged.bonus.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/ranged_attack_roll_bonus__njtjaSNJ4WQCV7n5.json
+++ b/data/packs/talents.db/ranged_attack_roll_bonus__njtjaSNJ4WQCV7n5.json
@@ -1,33 +1,33 @@
 {
 	"_id": "njtjaSNJ4WQCV7n5",
 	"_key": "!items.effects!WSm6JESNoyFBnkW2.njtjaSNJ4WQCV7n5",
-	"changes": [
-		{
-			"key": "system.roll.ranged.bonus.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Ranged Attack Roll Bonus",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.ranged.bonus.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/ranged_attack_roll_bonus__p0eEwLNQh9oSEtEj.json
+++ b/data/packs/talents.db/ranged_attack_roll_bonus__p0eEwLNQh9oSEtEj.json
@@ -1,33 +1,33 @@
 {
 	"_id": "p0eEwLNQh9oSEtEj",
 	"_key": "!items.effects!dTEZW21LUNoYL3JU.p0eEwLNQh9oSEtEj",
-	"changes": [
-		{
-			"key": "system.roll.ranged.bonus.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Ranged Attack Roll Bonus",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.ranged.bonus.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/ranged_damage_bonus__V7hLOyXMBijj06wB.json
+++ b/data/packs/talents.db/ranged_damage_bonus__V7hLOyXMBijj06wB.json
@@ -1,33 +1,33 @@
 {
 	"_id": "V7hLOyXMBijj06wB",
 	"_key": "!items.effects!38PGv4JtkfDumLDu.V7hLOyXMBijj06wB",
-	"changes": [
-		{
-			"key": "system.roll.ranged.damage.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-axe-blood-red.webp",
 	"name": "Ranged Damage Bonus",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.ranged.damage.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/ranged_damage_bonus__lodEOfzuI5jDWc4h.json
+++ b/data/packs/talents.db/ranged_damage_bonus__lodEOfzuI5jDWc4h.json
@@ -1,33 +1,33 @@
 {
 	"_id": "lodEOfzuI5jDWc4h",
 	"_key": "!items.effects!2IfYKGhWxyd3Ldr5.lodEOfzuI5jDWc4h",
-	"changes": [
-		{
-			"key": "system.roll.ranged.damage.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-axe-blood-red.webp",
 	"name": "Ranged Damage Bonus",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.ranged.damage.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/spell_class__8BIQChg1O4MQJ9xV.json
+++ b/data/packs/talents.db/spell_class__8BIQChg1O4MQJ9xV.json
@@ -1,33 +1,33 @@
 {
 	"_id": "8BIQChg1O4MQJ9xV",
 	"_key": "!items.effects!Qu0KqU3KzzRS1oer.8BIQChg1O4MQJ9xV",
-	"changes": [
-		{
-			"key": "system.spellcasting.classes",
-			"mode": 2,
-			"priority": null,
-			"value": "seer"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/symbols/runes-star-pentagon-orange-purple.webp",
 	"name": "Spell Class",
 	"origin": "Compendium.shadowdark.talents.Item.Qu0KqU3KzzRS1oer",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.spellcasting.classes",
+				"priority": null,
+				"type": "add",
+				"value": "seer"
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/spell_class__Pd70qHF14hMBGKoj.json
+++ b/data/packs/talents.db/spell_class__Pd70qHF14hMBGKoj.json
@@ -1,33 +1,33 @@
 {
 	"_id": "Pd70qHF14hMBGKoj",
 	"_key": "!items.effects!7XtnCM9VdxVmh6D3.Pd70qHF14hMBGKoj",
-	"changes": [
-		{
-			"key": "system.spellcasting.classes",
-			"mode": 2,
-			"priority": null,
-			"value": "witch"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/symbols/runes-star-pentagon-magenta.webp",
 	"name": "Spell Class",
 	"origin": "Compendium.shadowdark.talents.Item.7XtnCM9VdxVmh6D3",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.spellcasting.classes",
+				"priority": null,
+				"type": "add",
+				"value": "witch"
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/spell_class__dejbAcycqE6ujmcJ.json
+++ b/data/packs/talents.db/spell_class__dejbAcycqE6ujmcJ.json
@@ -1,33 +1,33 @@
 {
 	"_id": "dejbAcycqE6ujmcJ",
 	"_key": "!items.effects!EYRxfb5BUEzH1w3b.dejbAcycqE6ujmcJ",
-	"changes": [
-		{
-			"key": "system.spellcasting.classes",
-			"mode": 2,
-			"priority": null,
-			"value": "priest"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/symbols/runes-star-pentagon-blue.webp",
 	"name": "Spell Class",
 	"origin": "Compendium.shadowdark.talents.Item.EYRxfb5BUEzH1w3b",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.spellcasting.classes",
+				"priority": null,
+				"type": "add",
+				"value": "priest"
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/spell_class__z7bM0dO1y64K6091.json
+++ b/data/packs/talents.db/spell_class__z7bM0dO1y64K6091.json
@@ -1,33 +1,33 @@
 {
 	"_id": "z7bM0dO1y64K6091",
 	"_key": "!items.effects!XRW3jhpTni15hwFc.z7bM0dO1y64K6091",
-	"changes": [
-		{
-			"key": "system.spellcasting.classes",
-			"mode": 2,
-			"priority": null,
-			"value": "witch"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/symbols/runes-star-pentagon-magenta.webp",
 	"name": "Spell Class",
 	"origin": "Compendium.shadowdark.talents.Item.XRW3jhpTni15hwFc",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.spellcasting.classes",
+				"priority": null,
+				"type": "add",
+				"value": "witch"
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/spell_class__zi1nJjmtxnx0lJaZ.json
+++ b/data/packs/talents.db/spell_class__zi1nJjmtxnx0lJaZ.json
@@ -1,33 +1,33 @@
 {
 	"_id": "zi1nJjmtxnx0lJaZ",
 	"_key": "!items.effects!Td6iQW4hVJLZLVLi.zi1nJjmtxnx0lJaZ",
-	"changes": [
-		{
-			"key": "system.spellcasting.classes",
-			"mode": 2,
-			"priority": null,
-			"value": "wizard"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/symbols/runes-star-pentagon-orange.webp",
 	"name": "Spell Class",
 	"origin": "Compendium.shadowdark.talents.Item.Td6iQW4hVJLZLVLi",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.spellcasting.classes",
+				"priority": null,
+				"type": "add",
+				"value": "wizard"
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/spellcasting_advantage_on_spell__ZjpQVS9L1baZZ2PF.json
+++ b/data/packs/talents.db/spellcasting_advantage_on_spell__ZjpQVS9L1baZZ2PF.json
@@ -1,33 +1,33 @@
 {
 	"_id": "ZjpQVS9L1baZZ2PF",
 	"_key": "!items.effects!VRZxd1xswPr1GaKs.ZjpQVS9L1baZZ2PF",
-	"changes": [
-		{
-			"key": "system.roll.spell.advantage.magic-missile",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/air/air-smoke-casting.webp",
 	"name": "Spellcasting Advantage on Spell",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.spell.advantage.magic-missile",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/spellcasting_advantage_on_spell__oEZ9BldTmIl6AS31.json
+++ b/data/packs/talents.db/spellcasting_advantage_on_spell__oEZ9BldTmIl6AS31.json
@@ -1,33 +1,33 @@
 {
 	"_id": "oEZ9BldTmIl6AS31",
 	"_key": "!items.effects!IZZnFjWhZurAIZPP.oEZ9BldTmIl6AS31",
-	"changes": [
-		{
-			"key": "system.roll.spell.advantage.REPLACEME",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/air/air-smoke-casting.webp",
 	"name": "Spellcasting Advantage on Spell",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.spell.advantage.REPLACEME",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/spellcasting_check_bonus__QBX0EGnKmDfPJ8gQ.json
+++ b/data/packs/talents.db/spellcasting_check_bonus__QBX0EGnKmDfPJ8gQ.json
@@ -1,33 +1,33 @@
 {
 	"_id": "QBX0EGnKmDfPJ8gQ",
 	"_key": "!items.effects!0WmG5j0Wv685YTqO.QBX0EGnKmDfPJ8gQ",
-	"changes": [
-		{
-			"key": "system.roll.spell.bonus.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/fire/flame-burning-fist-strike.webp",
 	"name": "Spellcasting Check Bonus",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.spell.bonus.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/spellcasting_check_bonus__etJKhGLqpcKvyloB.json
+++ b/data/packs/talents.db/spellcasting_check_bonus__etJKhGLqpcKvyloB.json
@@ -1,33 +1,33 @@
 {
 	"_id": "etJKhGLqpcKvyloB",
 	"_key": "!items.effects!E3EcGGdGYuEWWj47.etJKhGLqpcKvyloB",
-	"changes": [
-		{
-			"key": "system.roll.spell.bonus.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/fire/flame-burning-fist-strike.webp",
 	"name": "Spellcasting Check Bonus",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.spell.bonus.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/stone_skin_advantage_on_hide__Y9m57iq0VaFQm0yi.json
+++ b/data/packs/talents.db/stone_skin_advantage_on_hide__Y9m57iq0VaFQm0yi.json
@@ -1,36 +1,36 @@
 {
 	"_id": "Y9m57iq0VaFQm0yi",
 	"_key": "!items.effects!RyaDaPST58N9e7aJ.Y9m57iq0VaFQm0yi",
-	"changes": [
-		{
-			"key": "system.roll.dex.advantage",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "<p>You have advantage on checks to hide in natural environments.</p>",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 		"shadowdark": {
 			"situational": true
 		}
 	},
+	"folder": null,
 	"img": "icons/commodities/stone/boulder-grey-blue.webp",
 	"name": "Stone Skin Advantage on Hide",
 	"origin": "Compendium.shadowdark.talents.Item.RyaDaPST58N9e7aJ",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.dex.advantage",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/stone_skin_talent__4CAhqfyLJIkeEoPW.json
+++ b/data/packs/talents.db/stone_skin_talent__4CAhqfyLJIkeEoPW.json
@@ -1,33 +1,33 @@
 {
 	"_id": "4CAhqfyLJIkeEoPW",
 	"_key": "!items.effects!RyaDaPST58N9e7aJ.4CAhqfyLJIkeEoPW",
-	"changes": [
-		{
-			"key": "system.attributes.ac.unarmored",
-			"mode": 2,
-			"priority": null,
-			"value": "2+floor(@level.value/2)"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/magic/earth/strike-fist-stone-gray.webp",
 	"name": "Stone Skin Talent",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.attributes.ac.unarmored",
+				"priority": null,
+				"type": "add",
+				"value": "2+floor(@level.value/2)"
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/thievery__aGa3IciSFPQKDtkc.json
+++ b/data/packs/talents.db/thievery__aGa3IciSFPQKDtkc.json
@@ -1,33 +1,33 @@
 {
 	"_id": "aGa3IciSFPQKDtkc",
 	"_key": "!items.effects!TiaXUSTLoJpjfyxD.aGa3IciSFPQKDtkc",
-	"changes": [
-		{
-			"key": "system.roll.stat.advantage.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "<p>You are trained in the following tasks and have advantage on any associated checks: Climbing, Sneaking and hiding, Applying disguises, Finding and disabling traps and delicate tasks such as picking pockets and opening locks.</p>",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/social/theft-pickpocket-bribery-brown.webp",
 	"name": "Thievery",
 	"origin": "Compendium.shadowdark.talents.Item.TiaXUSTLoJpjfyxD",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.stat.advantage.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/weapon_attack_damage_bonus__euq7Ta3QDNubqAf6.json
+++ b/data/packs/talents.db/weapon_attack_damage_bonus__euq7Ta3QDNubqAf6.json
@@ -1,33 +1,33 @@
 {
 	"_id": "euq7Ta3QDNubqAf6",
 	"_key": "!items.effects!ON5zVUv1xVbHRhbf.euq7Ta3QDNubqAf6",
-	"changes": [
-		{
-			"key": "system.roll.attack.damage.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/weapons/ammunition/arrow-head-war-flight.webp",
 	"name": "Weapon Attack Damage Bonus",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.damage.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/weapon_attack_roll_bonus__1YLz0hdFJKXemMz7.json
+++ b/data/packs/talents.db/weapon_attack_roll_bonus__1YLz0hdFJKXemMz7.json
@@ -1,33 +1,33 @@
 {
 	"_id": "1YLz0hdFJKXemMz7",
 	"_key": "!items.effects!ON5zVUv1xVbHRhbf.1YLz0hdFJKXemMz7",
-	"changes": [
-		{
-			"key": "system.roll.attack.bonus.all",
-			"mode": 2,
-			"priority": null,
-			"value": "1"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/strike-polearm-glowing-white.webp",
 	"name": "Weapon Attack Roll Bonus",
 	"origin": null,
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.attack.bonus.all",
+				"priority": null,
+				"type": "add",
+				"value": 1
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,

--- a/data/packs/talents.db/weapon_mastery__E7SwrOhzSAyMZ1Ec.json
+++ b/data/packs/talents.db/weapon_mastery__E7SwrOhzSAyMZ1Ec.json
@@ -1,39 +1,39 @@
 {
 	"_id": "E7SwrOhzSAyMZ1Ec",
 	"_key": "!items.effects!5bpWuaT0KTNzuzCu.E7SwrOhzSAyMZ1Ec",
-	"changes": [
-		{
-			"key": "system.roll.melee.bonus.REPLACEME",
-			"mode": 2,
-			"priority": null,
-			"value": "1+floor(@level.value/2)"
-		},
-		{
-			"key": "system.roll.melee.damage.REPLACEME",
-			"mode": 2,
-			"priority": null,
-			"value": "1+floor(@level.value/2)"
-		}
-	],
 	"description": "",
 	"disabled": false,
 	"duration": {
-		"combat": null,
-		"rounds": null,
-		"seconds": null,
-		"startRound": null,
-		"startTime": null,
-		"startTurn": null,
-		"turns": null
+		"expired": false,
+		"expiry": null,
+		"units": "seconds",
+		"value": null
 	},
 	"flags": {
 	},
+	"folder": null,
 	"img": "icons/skills/melee/weapons-crossed-swords-white-blue.webp",
 	"name": "Weapon Mastery",
 	"origin": "Compendium.shadowdark.talents.eg8u9L4gcJAxBxVX",
+	"showIcon": 1,
+	"start": null,
 	"statuses": [
 	],
 	"system": {
+		"changes": [
+			{
+				"key": "system.roll.melee.bonus.REPLACEME",
+				"priority": null,
+				"type": "add",
+				"value": "1+floor(@level.value/2)"
+			},
+			{
+				"key": "system.roll.melee.damage.REPLACEME",
+				"priority": null,
+				"type": "add",
+				"value": "1+floor(@level.value/2)"
+			}
+		]
 	},
 	"tint": "#ffffff",
 	"transfer": true,


### PR DESCRIPTION
Implements #1268

I ran `npm run export` initially before I started, there were a _lot_ of automatic changes as part of that, and that's all in the first commit. My actual additions come in later, separate commits. 

- [x] Cursed Scroll 1
  - Cloven Heart
  - Emerald Blade
  - Scroll of Charm Person
  - Wand of Moonbeam
  - Wrath Bolt
  - Ynnith
- [ ] Cursed Scroll 2
- [ ] Cursed Scroll 3