### PR TITLE
fix: Weapon Properties Break with Translation Modules (Babele) (#1390)

### DIFF
--- a/system/src/models/items/_BaseItemSD.mjs
+++ b/system/src/models/items/_BaseItemSD.mjs
@@ -28,9 +28,18 @@ export class BaseItemSD extends foundry.abstract.TypeDataModel {
 		for (const uuid of this.properties ?? []) {
 			propertyItems.push(fromUuidSync(uuid));
 		}
-		const propertyItem = propertyItems.find(
-			p => p.name.slugify() === property.slugify()
-		);
+
+		const propSlug = (property || "").slugify();
+
+		const propertyItem = propertyItems.find(p => {
+			if (!p) return false;
+			const engName = p.originalName || p.flags?.babele?.originalName || p.name || "";
+			return (
+				engName.slugify() === propSlug
+				|| (p.name || "").slugify() === propSlug
+			);
+		});
+
 		return propertyItem ? true : false;
 	}
 


### PR DESCRIPTION
Description:

Overview
This PR addresses issue #1390, where item properties are not recognized when a translation module like Babele is active. The system currently relies on the translated display name to identify properties, which fails because the names are no longer in English.

Closes #1390